### PR TITLE
Correction for encoding int data type. Size is alway 32 bytes.

### DIFF
--- a/HyperLiquid.Net/LightEip712TypedDataEncoder.cs
+++ b/HyperLiquid.Net/LightEip712TypedDataEncoder.cs
@@ -209,7 +209,8 @@ namespace HyperLiquid.Net
             {
                 size = 256;
             }
-            var result = new byte[size / 8];
+//            var result = new byte[size / 8];
+            var result = new byte[32];
             BigInteger v;
             switch (value)
             {


### PR DESCRIPTION
Correction for the uint64 type.