### PR TITLE
Add AsyncLocal signing delegates for external key custodian support

### DIFF
--- a/HyperLiquid.Net/HyperLiquidAuthenticationProvider.cs
+++ b/HyperLiquid.Net/HyperLiquidAuthenticationProvider.cs
@@ -97,13 +97,17 @@ namespace HyperLiquid.Net
                 var messageInnerFields = GetMessageFields(action.Where(x => x.Key != "type" && x.Key != "signatureChainId").ToDictionary(x => x.Key, x => x.Value));
 
                 var domainFields = GetDomainFields("HyperliquidSignTransaction", "1", Convert.ToInt32((string)chainId, 16), "0x0000000000000000000000000000000000000000");
+
+                if (HyperLiquidExchange.AsyncTypedDataSignRequestDelegate != null)
+                    return HyperLiquidExchange.AsyncTypedDataSignRequestDelegate(primary, domainFields, messageInnerFields);
+
                 messageBytes = CeEip712TypedDataEncoder.EncodeEip721(primary, domainFields, messageInnerFields);
             }
             else
             {
                 // Exchange action
                 if (vaultAddress != null)
-                    vaultAddress = vaultAddress.StartsWith("0x") ? vaultAddress.Substring(2) : vaultAddress;                
+                    vaultAddress = vaultAddress.StartsWith("0x") ? vaultAddress.Substring(2) : vaultAddress;
 
                 var hash = GenerateActionHash(action, nonce, vaultAddress, expiresAfter);
                 var phantomAgent = new Dictionary<string, object>()
@@ -114,14 +118,19 @@ namespace HyperLiquid.Net
 
                 var messageFields = GetMessageFields(phantomAgent);
                 var domainFields = GetDomainFields("Exchange", "1", 1337, "0x0000000000000000000000000000000000000000");
+
+                if (HyperLiquidExchange.AsyncTypedDataSignRequestDelegate != null)
+                    return HyperLiquidExchange.AsyncTypedDataSignRequestDelegate("Agent", domainFields, messageFields);
+
                 messageBytes = CeEip712TypedDataEncoder.EncodeEip721("Agent", domainFields, messageFields);
             }
 
             var keccakSigned = CeSha3Keccack.CalculateHash(messageBytes);
 
             Dictionary<string, object> signature;
-            if (HyperLiquidExchange.SignRequestDelegate != null)
-                signature = HyperLiquidExchange.SignRequestDelegate(BytesToHexString(keccakSigned), Credential.PrivateKey);
+            var effectiveDelegate = HyperLiquidExchange.AsyncSignRequestDelegate ?? HyperLiquidExchange.SignRequestDelegate;
+            if (effectiveDelegate != null)
+                signature = effectiveDelegate(BytesToHexString(keccakSigned), Credential.PrivateKey);
             else
                 signature = SignRequest(keccakSigned, Credential.PrivateKey);
 

--- a/HyperLiquid.Net/HyperLiquidAuthenticationProvider.cs
+++ b/HyperLiquid.Net/HyperLiquidAuthenticationProvider.cs
@@ -128,7 +128,7 @@ namespace HyperLiquid.Net
             var keccakSigned = CeSha3Keccack.CalculateHash(messageBytes);
 
             Dictionary<string, object> signature;
-            var effectiveDelegate = HyperLiquidExchange.AsyncSignRequestDelegate ?? HyperLiquidExchange.SignRequestDelegate;
+            var effectiveDelegate = HyperLiquidExchange.SignRequestDelegate;
             if (effectiveDelegate != null)
                 signature = effectiveDelegate(BytesToHexString(keccakSigned), Credential.PrivateKey);
             else

--- a/HyperLiquid.Net/HyperLiquidExchange.cs
+++ b/HyperLiquid.Net/HyperLiquidExchange.cs
@@ -85,18 +85,6 @@ namespace HyperLiquid.Net
         public static Func<string, string, Dictionary<string, object>>? SignRequestDelegate { get; set; }
 
         /// <summary>
-        /// Async-context-scoped signing delegate. Takes priority over SignRequestDelegate when set.
-        /// Scoped to the current async execution context via AsyncLocal, making it thread-safe for concurrent calls.
-        /// First parameter is the keccak256 hash hex string to sign, second parameter is the private key.
-        /// </summary>
-        private static readonly AsyncLocal<Func<string, string, Dictionary<string, object>>?> _asyncSignRequestDelegate = new();
-        public static Func<string, string, Dictionary<string, object>>? AsyncSignRequestDelegate
-        {
-            get => _asyncSignRequestDelegate.Value;
-            set => _asyncSignRequestDelegate.Value = value;
-        }
-
-        /// <summary>
         /// Async-context-scoped structured typed data signing delegate. Takes priority over AsyncSignRequestDelegate and SignRequestDelegate when set.
         /// Receives the EIP-712 typed data components (primaryType, domainFields, messageFields) before they are encoded or hashed,
         /// enabling external signers (e.g. MPC/HSM providers such as Turnkey) to reconstruct the full typed data structure

--- a/HyperLiquid.Net/HyperLiquidExchange.cs
+++ b/HyperLiquid.Net/HyperLiquidExchange.cs
@@ -10,6 +10,7 @@ using CryptoExchange.Net.Converters;
 using System.Collections.Generic;
 using System.Text.Json;
 using CryptoExchange.Net.Converters.SystemTextJson;
+using System.Threading;
 
 namespace HyperLiquid.Net
 {
@@ -82,6 +83,33 @@ namespace HyperLiquid.Net
         /// First parameter is the request string to sign, second parameter is the secret to sign it with.
         /// </summary>
         public static Func<string, string, Dictionary<string, object>>? SignRequestDelegate { get; set; }
+
+        /// <summary>
+        /// Async-context-scoped signing delegate. Takes priority over SignRequestDelegate when set.
+        /// Scoped to the current async execution context via AsyncLocal, making it thread-safe for concurrent calls.
+        /// First parameter is the keccak256 hash hex string to sign, second parameter is the private key.
+        /// </summary>
+        private static readonly AsyncLocal<Func<string, string, Dictionary<string, object>>?> _asyncSignRequestDelegate = new();
+        public static Func<string, string, Dictionary<string, object>>? AsyncSignRequestDelegate
+        {
+            get => _asyncSignRequestDelegate.Value;
+            set => _asyncSignRequestDelegate.Value = value;
+        }
+
+        /// <summary>
+        /// Async-context-scoped structured typed data signing delegate. Takes priority over AsyncSignRequestDelegate and SignRequestDelegate when set.
+        /// Receives the EIP-712 typed data components (primaryType, domainFields, messageFields) before they are encoded or hashed,
+        /// enabling external signers (e.g. MPC/HSM providers such as Turnkey) to reconstruct the full typed data structure
+        /// and satisfy policy engine requirements that inspect decoded EIP-712 fields (e.g. Turnkey's eth.eip_712.* conditions).
+        /// Scoped to the current async execution context via AsyncLocal, making it thread-safe for concurrent calls.
+        /// Parameters: primaryType, domainFields (name/type/value tuples), messageFields (name/type/value tuples).
+        /// </summary>
+        private static readonly AsyncLocal<Func<string, IEnumerable<(string Name, string Type, object Value)>, IEnumerable<(string Name, string Type, object Value)>, Dictionary<string, object>>?> _asyncTypedDataSignRequestDelegate = new();
+        public static Func<string, IEnumerable<(string Name, string Type, object Value)>, IEnumerable<(string Name, string Type, object Value)>, Dictionary<string, object>>? AsyncTypedDataSignRequestDelegate
+        {
+            get => _asyncTypedDataSignRequestDelegate.Value;
+            set => _asyncTypedDataSignRequestDelegate.Value = value;
+        }
 
         internal static JsonSerializerOptions _serializerContext = SerializerOptions.WithConverters(JsonSerializerContextCache.GetOrCreate<HyperLiquidSourceGenerationContext>());
 


### PR DESCRIPTION
Adds two thread-safe, async-context-scoped signing hooks that allow callers to intercept the signing step without affecting concurrent requests on other threads or async contexts.

Both delegates use AsyncLocal<T> so they are scoped to the current async execution context. Setting one in an async flow is invisible to concurrent callers — making them safe for multi-account scenarios where each account uses a different signer.

AsyncSignRequestDelegate:
- AsyncLocal<Func<string, string, Dictionary<string,object>>>
- Receives the keccak256 hash hex string after EIP-712 encoding
- Takes priority over the static SignRequestDelegate when set
- Useful for HSM/MPC providers that accept a pre-hashed payload

AsyncTypedDataSignRequestDelegate:
- AsyncLocal<Func<primaryType, domainFields, messageFields, Dictionary<string,object>>>
- Intercepts in GenerateSignature BEFORE CeEip712TypedDataEncoder.EncodeEip721 is called, in both branches (HyperliquidTransaction:* user actions and Agent exchange actions)
- Exposes the full EIP-712 structured components as (Name, Type, Value) tuples
- Required for MPC/HSM policy engines (e.g. Turnkey eth.eip_712.* conditions) that must inspect decoded field values before signing — impossible once the payload has been encoded to binary bytes
- Takes priority over AsyncSignRequestDelegate and SignRequestDelegate