### PR TITLE
Fix NullReferenceException in GetPricesAsync when request fails

### DIFF
--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiExchangeData.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiExchangeData.cs
@@ -36,7 +36,9 @@ namespace HyperLiquid.Net.Clients.BaseApi
             parameters.AddOptional("dex", dex);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
             var result = await _baseClient.SendAsync<Dictionary<string, decimal>>(request, parameters, ct).ConfigureAwait(false);
-            
+            if (!result)
+                return result.As<Dictionary<string, decimal>>(default);
+
             var resultMapped = new Dictionary<string, decimal>();
             foreach (var item in result.Data)
             {


### PR DESCRIPTION
## Summary

Fixes #77.

`HyperLiquidRestClientApiExchangeData.GetPricesAsync` calls
`_baseClient.SendAsync<Dictionary<string, decimal>>(...)` and then iterates
`result.Data` without checking whether the call succeeded. When the underlying
HTTP request fails the returned `WebCallResult` is unsuccessful and `result.Data`
is `null`, so the `foreach (var item in result.Data)` line throws
`NullReferenceException` before the failed `WebCallResult` can be returned to
the caller.

## Change

Add an early return for the failed-request case so the caller receives the
original failure (status code, error, exception) instead of a generic NRE.

```csharp
var result = await _baseClient.SendAsync<Dictionary<string, decimal>>(request, parameters, ct).ConfigureAwait(false);
if (!result)
    return result.As<Dictionary<string, decimal>>(default);

var resultMapped = new Dictionary<string, decimal>();
foreach (var item in result.Data)
{
    ...
}
```

The successful path is unchanged.

## Stack trace from the linked issue

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at HyperLiquid.Net.Clients.BaseApi.HyperLiquidRestClientApiExchangeData.GetPricesAsync(String dex, CancellationToken ct)
```

## Notes

This patch was drafted by an automated null-guard tool and reviewed by hand
against the issue reporter's suggested fix, which proposes the same shape.
Happy to adjust the early-return form (for example using a different overload of
`WebCallResult.As`) if a different convention is preferred in this repository.
