### PR TITLE
Use HyperLiquidFuturesAccount as Data type in HyperLiquidDexPositionUpdate

### DIFF
--- a/HyperLiquid.Net/Objects/Models/HyperLiquidPositionUpdate.cs
+++ b/HyperLiquid.Net/Objects/Models/HyperLiquidPositionUpdate.cs
@@ -44,7 +44,7 @@ namespace HyperLiquid.Net.Objects.Models
         /// </summary>
         [ArrayProperty(1)]
         [JsonConversion]
-        public HyperLiquidPositionUpdateData Data { get; set; } = default!;
+        public HyperLiquidFuturesAccount Data { get; set; } = default!;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Closes / relates to #87.

The `allDexsClearinghouseState` socket subscription delivers per-DEX clearinghouse state as an array of `[dexName, clearinghouseStateObject]` entries. The `clearinghouseStateObject` has **exactly the same JSON shape** as the object returned by the REST `GetAccountInfo` endpoint — same field names, same nesting. Currently `HyperLiquidDexPositionUpdate.Data` is typed as the separate `HyperLiquidPositionUpdateData` class, forcing callers to maintain two parallel object graphs and write adapter code to bridge them.

This PR changes `HyperLiquidDexPositionUpdate.Data` to use `HyperLiquidFuturesAccount` directly:

```csharp
// before
public HyperLiquidPositionUpdateData Data { get; set; } = default!;

// after
public HyperLiquidFuturesAccount Data { get; set; } = default!;
```

### Why this is safe

- `HyperLiquidFuturesAccount` already carries `[SerializationModel]` and is registered in `HyperLiquidSourceGenerationContext` — no serialization changes required.
- Every JSON field in `HyperLiquidPositionUpdateData` has an exact counterpart in `HyperLiquidFuturesAccount` (mapped to the same JSON property names). The only differences are C# property names (`AssetPositions` → `Positions`, `TotalNtlPos` on `HyperLiquidPositionUpdateAccountValue` → `TotalNotionalPosition` on `HyperLiquidMarginSummary`).
- `HyperLiquidPositionUpdateData` and `HyperLiquidPositionUpdateAccountValue` are still present in the file and remain usable from `HyperLiquidPositionUpdate` (the `userEvents` subscription); they can be removed in a follow-up if desired.

### Benefit

Callers can now initialise their account model from REST and update it in-place from the socket snapshot using the same type, with no adapter layer.