### PR TITLE
CryptoExchange.Net V12

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ description: Use HyperLiquid.Net when generating C#/.NET code that interacts wit
 
 If the user asks for HyperLiquid API access in C#/.NET, use `HyperLiquid.Net`. Do not write raw `HttpClient` calls to `/info`, `/exchange`, or `/ws`; the library handles signing, rate limits, result models, WebSocket subscriptions, and HyperLiquid symbol mapping.
 
-For multi-exchange code, use `CryptoExchange.Net.SharedApis` via `.SharedClient`.
+For multi-exchange code, use `CryptoExchange.Net.SharedApis` via `.SharedClient`. Call `.SharedClient.Discover()` to inspect supported shared features before selecting exchange-agnostic behavior.
 
 ## Installation
 
@@ -39,7 +39,7 @@ var publicClient = new HyperLiquidRestClient();
 
 ## Core Pattern: Result Handling
 
-REST methods return `HttpResult<T>` or `HttpResult`; WebSocket subscriptions and WebSocket request API calls return `WebSocketResult<T>` or `WebSocketResult`. Always check `.Success` before reading `.Data`.
+REST methods return `HttpResult<T>` or `HttpResult`; WebSocket subscriptions return `WebSocketResult<UpdateSubscription>`; WebSocket request API calls return `QueryResult<T>` or `QueryResult`; shared symbol/cache helpers can return `ExchangeCallResult<T>`. Always check `.Success` before reading `.Data`.
 
 ```csharp
 var prices = await restClient.SpotApi.ExchangeData.GetPricesAsync();
@@ -157,7 +157,9 @@ var orders = await authSocket.FuturesApi.Trading.SubscribeToOrderUpdatesAsync(
 using CryptoExchange.Net.SharedApis;
 using HyperLiquid.Net.Clients;
 
-ISpotTickerRestClient tickerClient = new HyperLiquidRestClient().SpotApi.SharedClient;
+var restClient = new HyperLiquidRestClient();
+ISpotTickerRestClient tickerClient = restClient.SpotApi.SharedClient;
+var info = restClient.SpotApi.SharedClient.Discover();
 var symbol = new SharedSymbol(TradingMode.Spot, "HYPE", "USDC");
 
 var ticker = await tickerClient.GetSpotTickerAsync(new GetTickerRequest(symbol));

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ var publicClient = new HyperLiquidRestClient();
 
 ## Core Pattern: Result Handling
 
-REST methods return `WebCallResult<T>` or `WebCallResult`; WebSocket subscriptions and WebSocket request API calls return `CallResult<T>` or `CallResult`. Always check `.Success` before reading `.Data`.
+REST methods return `HttpResult<T>` or `HttpResult`; WebSocket subscriptions and WebSocket request API calls return `WebSocketResult<T>` or `WebSocketResult`. Always check `.Success` before reading `.Data`.
 
 ```csharp
 var prices = await restClient.SpotApi.ExchangeData.GetPricesAsync();

--- a/Examples/ai-friendly/03-websocket.cs
+++ b/Examples/ai-friendly/03-websocket.cs
@@ -10,6 +10,7 @@ using HyperLiquid.Net.Clients;
 
 // ---- 1. PUBLIC SOCKET CLIENT ----
 // Reuse a single socket client instance across subscriptions.
+// Subscription methods return WebSocketResult<UpdateSubscription>.
 var publicSocket = new HyperLiquidSocketClient();
 
 var spotTickerSub = await publicSocket.SpotApi.ExchangeData.SubscribeToSymbolUpdatesAsync(

--- a/Examples/ai-friendly/04-multi-exchange.cs
+++ b/Examples/ai-friendly/04-multi-exchange.cs
@@ -13,8 +13,12 @@ using CryptoExchange.Net.SharedApis;
 using HyperLiquid.Net.Clients;
 
 // ---- REST SHARED CLIENTS ----
-ISpotTickerRestClient hyperLiquidSpot = new HyperLiquidRestClient().SpotApi.SharedClient;
-IFuturesTickerRestClient hyperLiquidFutures = new HyperLiquidRestClient().FuturesApi.SharedClient;
+var restClient = new HyperLiquidRestClient();
+ISpotTickerRestClient hyperLiquidSpot = restClient.SpotApi.SharedClient;
+IFuturesTickerRestClient hyperLiquidFutures = restClient.FuturesApi.SharedClient;
+
+var spotCapabilities = restClient.SpotApi.SharedClient.Discover();
+Console.WriteLine($"Shared spot REST features: {spotCapabilities.Features.Count(x => x.Supported)}");
 
 var hypeUsdc = new SharedSymbol(TradingMode.Spot, "HYPE", "USDC");
 var ethPerp = new SharedSymbol(TradingMode.PerpetualLinear, "ETH", "USDC");

--- a/Examples/ai-friendly/05-error-handling.cs
+++ b/Examples/ai-friendly/05-error-handling.cs
@@ -1,6 +1,6 @@
 // 05-error-handling.cs
 //
-// Demonstrates: WebCallResult patterns, retry logic, symbol formatting,
+// Demonstrates: HttpResult patterns, retry logic, symbol formatting,
 // builder fee checks, and common error categories.
 //
 // Setup: dotnet add package HyperLiquid.Net
@@ -17,8 +17,8 @@ var client = new HyperLiquidRestClient(options =>
 });
 
 // ---- 1. THE BASIC PATTERN ----
-// REST methods return WebCallResult<T> or WebCallResult.
-// WebSocket methods return CallResult<T> or CallResult.
+// REST methods return HttpResult<T> or HttpResult.
+// WebSocket methods return WebSocketResult<T> or WebSocketResult.
 // .Data is only safe to read when .Success is true.
 
 var result = await client.FuturesApi.ExchangeData.GetPricesAsync();
@@ -38,11 +38,11 @@ else
 // ---- 2. SIMPLE RETRY WITH BACKOFF ----
 // Retry only on transient errors. Do not retry validation or credential failures blindly.
 
-async Task<WebCallResult<T>> WithRetry<T>(
-    Func<Task<WebCallResult<T>>> call,
+async Task<HttpResult<T>> WithRetry<T>(
+    Func<Task<HttpResult<T>>> call,
     int maxAttempts = 3)
 {
-    WebCallResult<T> last = default!;
+    HttpResult<T> last = default!;
     for (var attempt = 1; attempt <= maxAttempts; attempt++)
     {
         last = await call();

--- a/Examples/ai-friendly/05-error-handling.cs
+++ b/Examples/ai-friendly/05-error-handling.cs
@@ -1,7 +1,7 @@
 // 05-error-handling.cs
 //
-// Demonstrates: HttpResult patterns, retry logic, symbol formatting,
-// builder fee checks, and common error categories.
+// Demonstrates: HttpResult, QueryResult, WebSocketResult, and ExchangeCallResult
+// patterns, retry logic, symbol formatting, builder fee checks, and common error categories.
 //
 // Setup: dotnet add package HyperLiquid.Net
 
@@ -18,7 +18,9 @@ var client = new HyperLiquidRestClient(options =>
 
 // ---- 1. THE BASIC PATTERN ----
 // REST methods return HttpResult<T> or HttpResult.
-// WebSocket methods return WebSocketResult<T> or WebSocketResult.
+// WebSocket request API methods return QueryResult<T> or QueryResult.
+// WebSocket subscription methods return WebSocketResult<UpdateSubscription>.
+// Some SharedApis symbol helper methods return ExchangeCallResult<T>.
 // .Data is only safe to read when .Success is true.
 
 var result = await client.FuturesApi.ExchangeData.GetPricesAsync();

--- a/Examples/ai-friendly/README.md
+++ b/Examples/ai-friendly/README.md
@@ -9,8 +9,8 @@ These examples are compact single-file console programs for AI assistants, docum
 |`01-spot-quickstart.cs`|Public prices, spot ticker metadata, authenticated balances, spot limit order pattern, order status, cancellation|
 |`02-futures.cs`|Perpetual futures ticker data, leverage, account positions, market order pattern, reduce-only close pattern|
 |`03-websocket.cs`|Spot/futures ticker subscriptions, order book subscription, authenticated order updates, unsubscribe cleanup|
-|`04-multi-exchange.cs`|CryptoExchange.Net SharedApis for exchange-agnostic REST and WebSocket code|
-|`05-error-handling.cs`|`HttpResult<T>` handling, retry decisions, symbol formatting, builder fee checks, validation categories|
+|`04-multi-exchange.cs`|CryptoExchange.Net SharedApis for exchange-agnostic REST/WebSocket code and capability discovery|
+|`05-error-handling.cs`|`HttpResult<T>`, `QueryResult<T>`, `WebSocketResult<UpdateSubscription>`, and `ExchangeCallResult<T>` handling, retry decisions, symbol formatting, builder fee checks, validation categories|
 
 ## Setup
 

--- a/Examples/ai-friendly/README.md
+++ b/Examples/ai-friendly/README.md
@@ -10,7 +10,7 @@ These examples are compact single-file console programs for AI assistants, docum
 |`02-futures.cs`|Perpetual futures ticker data, leverage, account positions, market order pattern, reduce-only close pattern|
 |`03-websocket.cs`|Spot/futures ticker subscriptions, order book subscription, authenticated order updates, unsubscribe cleanup|
 |`04-multi-exchange.cs`|CryptoExchange.Net SharedApis for exchange-agnostic REST and WebSocket code|
-|`05-error-handling.cs`|`WebCallResult<T>` handling, retry decisions, symbol formatting, builder fee checks, validation categories|
+|`05-error-handling.cs`|`HttpResult<T>` handling, retry decisions, symbol formatting, builder fee checks, validation categories|
 
 ## Setup
 

--- a/HyperLiquid.Net.UnitTests/HyperLiquidRestClientTests.cs
+++ b/HyperLiquid.Net.UnitTests/HyperLiquidRestClientTests.cs
@@ -66,9 +66,9 @@ namespace HyperLiquid.Net.UnitTests
                     return "Good";
                 },
                 "Good",
-                new Dictionary<string, object>
+                new Parameters(HyperLiquidExchange._parameterSerializationSettings)
                 {
-                    { "action", new ParameterCollection
+                    { "action", new Parameters(HyperLiquidExchange._parameterSerializationSettings)
                         {
                             { "type", "order" },
                             { "orders", new [] {
@@ -82,7 +82,6 @@ namespace HyperLiquid.Net.UnitTests
                     },
                 },
                 DateTimeConverter.ParseFromDouble(1499827320559),
-                true,
                 false);
         }
 

--- a/HyperLiquid.Net.UnitTests/HyperLiquidRestIntegrationTests.cs
+++ b/HyperLiquid.Net.UnitTests/HyperLiquidRestIntegrationTests.cs
@@ -15,7 +15,7 @@ namespace HyperLiquid.Net.UnitTests
     [NonParallelizable]
     public class HyperLiquidRestIntegrationTests : RestIntegrationTest<HyperLiquidRestClient>
     {
-        public override bool Run { get; set; } = false;
+        public override bool Run { get; set; } = true;
 
         public override HyperLiquidRestClient GetClient(ILoggerFactory loggerFactory)
         {

--- a/HyperLiquid.Net.UnitTests/HyperLiquidSocketIntegrationTests.cs
+++ b/HyperLiquid.Net.UnitTests/HyperLiquidSocketIntegrationTests.cs
@@ -14,7 +14,7 @@ namespace HyperLiquid.Net.UnitTests
     [NonParallelizable]
     internal class HyperLiquidSocketIntegrationTests : SocketIntegrationTest<HyperLiquidSocketClient>
     {
-        public override bool Run { get; set; } = false;
+        public override bool Run { get; set; } = true;
 
         public HyperLiquidSocketIntegrationTests()
         {

--- a/HyperLiquid.Net.UnitTests/RestRequestTests.cs
+++ b/HyperLiquid.Net.UnitTests/RestRequestTests.cs
@@ -115,7 +115,7 @@ namespace HyperLiquid.Net.UnitTests
 
         }
 
-        private bool IsAuthenticated(WebCallResult result)
+        private bool IsAuthenticated(IHttpResult result)
         {
             return result.RequestBody?.Contains("signature") == true;
         }

--- a/HyperLiquid.Net.UnitTests/SocketSubscriptionTests.cs
+++ b/HyperLiquid.Net.UnitTests/SocketSubscriptionTests.cs
@@ -28,7 +28,7 @@ namespace HyperLiquid.Net.UnitTests
                 Environment = HyperLiquidEnvironment.CreateCustom("UnitTest", "https://api.hyperliquid.xyz", "wss://api.hyperliquid.xyz")
             }), logger);
 
-            var tester = new SocketSubscriptionValidator<HyperLiquidSocketClient>(client, "Subscriptions", "wss://api.hyperliquid.xyz", "data");
+            var tester = new SocketSubscriptionValidator<HyperLiquidSocketClient>(client, "Subscriptions", "wss://api.hyperliquid.xyz/ws", "data");
             await tester.ValidateConcurrentAsync<HyperLiquidKline>(
                 (client, handler) => client.SpotApi.ExchangeData.SubscribeToKlineUpdatesAsync("HYPE", Enums.KlineInterval.OneDay, handler),
                 (client, handler) => client.SpotApi.ExchangeData.SubscribeToKlineUpdatesAsync("HYPE", Enums.KlineInterval.OneHour, handler),

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApi.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApi.cs
@@ -51,23 +51,23 @@ namespace HyperLiquid.Net.Clients.BaseApi
         protected override HyperLiquidAuthenticationProvider CreateAuthenticationProvider(HyperLiquidCredentials credentials)
             => new HyperLiquidAuthenticationProvider(credentials);
 
-        internal Task<WebCallResult> SendAsync(RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null)
+        internal Task<WebCallResult> SendAsync(RequestDefinition definition, IParameters? parameters, CancellationToken cancellationToken, int? weight = null)
             => SendToAddressAsync(BaseAddress, definition, parameters, cancellationToken, weight);
 
-        internal async Task<WebCallResult> SendToAddressAsync(string baseAddress, RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null)
+        internal async Task<WebCallResult> SendToAddressAsync(string baseAddress, RequestDefinition definition, IParameters? parameters, CancellationToken cancellationToken, int? weight = null)
         {
             return await base.SendAsync(baseAddress, definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
         }
 
-        internal Task<WebCallResult<T>> SendAsync<T>(RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null)
+        internal Task<WebCallResult<T>> SendAsync<T>(RequestDefinition definition, IParameters? parameters, CancellationToken cancellationToken, int? weight = null)
             => SendToAddressAsync<T>(BaseAddress, definition, parameters, cancellationToken, weight);
 
-        internal async Task<WebCallResult<T>> SendToAddressAsync<T>(string baseAddress, RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null)
+        internal async Task<WebCallResult<T>> SendToAddressAsync<T>(string baseAddress, RequestDefinition definition, IParameters? parameters, CancellationToken cancellationToken, int? weight = null)
         {
             return await base.SendAsync<T>(baseAddress, definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
         }
 
-        internal async Task<WebCallResult<T>> SendAuthAsync<T>(RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null)
+        internal async Task<WebCallResult<T>> SendAuthAsync<T>(RequestDefinition definition, IParameters? parameters, CancellationToken cancellationToken, int? weight = null)
         {
             var result = await SendToAddressAsync<HyperLiquidResponse<T>>(BaseAddress, definition, parameters, cancellationToken, weight).ConfigureAwait(false);
             if (!result)
@@ -79,12 +79,12 @@ namespace HyperLiquid.Net.Clients.BaseApi
             return result.As(result.Data.Data!.Data);
         }
 
-        internal void AddExpiresAfter(ParameterCollection parameters, DateTime? requestExpiresAfter)
+        internal void AddExpiresAfter(IParameters parameters, DateTime? requestExpiresAfter)
         {
             if (requestExpiresAfter != null)
-                parameters.Add("expiresAfter", DateTimeConverter.ConvertToMilliseconds(requestExpiresAfter));
+                parameters.Dictionary.Add("expiresAfter", DateTimeConverter.ConvertToMilliseconds(requestExpiresAfter));
             else if (ClientOptions.ExpiresAfter != null)
-                parameters.Add("expiresAfter", DateTimeConverter.ConvertToMilliseconds(DateTime.UtcNow + ClientOptions.ExpiresAfter));
+                parameters.Dictionary.Add("expiresAfter", DateTimeConverter.ConvertToMilliseconds(DateTime.UtcNow + ClientOptions.ExpiresAfter));
         }
 
         /// <inheritdoc />

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApi.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApi.cs
@@ -29,12 +29,12 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
         #region constructor/destructor
         internal HyperLiquidRestClientApi(
-            ILogger logger, 
+            ILoggerFactory? loggerFactory,
             HyperLiquidRestClient baseClient,
             HttpClient? httpClient,
             HyperLiquidRestOptions options,
             RestApiOptions apiOptions)
-            : base(logger, HyperLiquidExchange.Metadata.Id, httpClient, options.Environment.RestClientAddress, options, apiOptions)
+            : base(loggerFactory, HyperLiquidExchange.Metadata.Id, httpClient, options.Environment.RestClientAddress, options, apiOptions)
         {
             BaseClient = baseClient;
         }

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApi.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApi.cs
@@ -51,23 +51,23 @@ namespace HyperLiquid.Net.Clients.BaseApi
         protected override HyperLiquidAuthenticationProvider CreateAuthenticationProvider(HyperLiquidCredentials credentials)
             => new HyperLiquidAuthenticationProvider(credentials);
 
-        internal Task<WebCallResult> SendAsync(RequestDefinition definition, IParameters? parameters, CancellationToken cancellationToken, int? weight = null)
+        internal Task<WebCallResult> SendAsync(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null)
             => SendToAddressAsync(BaseAddress, definition, parameters, cancellationToken, weight);
 
-        internal async Task<WebCallResult> SendToAddressAsync(string baseAddress, RequestDefinition definition, IParameters? parameters, CancellationToken cancellationToken, int? weight = null)
+        internal async Task<WebCallResult> SendToAddressAsync(string baseAddress, RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null)
         {
             return await base.SendAsync(baseAddress, definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
         }
 
-        internal Task<WebCallResult<T>> SendAsync<T>(RequestDefinition definition, IParameters? parameters, CancellationToken cancellationToken, int? weight = null)
+        internal Task<WebCallResult<T>> SendAsync<T>(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null)
             => SendToAddressAsync<T>(BaseAddress, definition, parameters, cancellationToken, weight);
 
-        internal async Task<WebCallResult<T>> SendToAddressAsync<T>(string baseAddress, RequestDefinition definition, IParameters? parameters, CancellationToken cancellationToken, int? weight = null)
+        internal async Task<WebCallResult<T>> SendToAddressAsync<T>(string baseAddress, RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null)
         {
             return await base.SendAsync<T>(baseAddress, definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
         }
 
-        internal async Task<WebCallResult<T>> SendAuthAsync<T>(RequestDefinition definition, IParameters? parameters, CancellationToken cancellationToken, int? weight = null)
+        internal async Task<WebCallResult<T>> SendAuthAsync<T>(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null)
         {
             var result = await SendToAddressAsync<HyperLiquidResponse<T>>(BaseAddress, definition, parameters, cancellationToken, weight).ConfigureAwait(false);
             if (!result)
@@ -79,12 +79,12 @@ namespace HyperLiquid.Net.Clients.BaseApi
             return result.As(result.Data.Data!.Data);
         }
 
-        internal void AddExpiresAfter(IParameters parameters, DateTime? requestExpiresAfter)
+        internal void AddExpiresAfter(Parameters parameters, DateTime? requestExpiresAfter)
         {
             if (requestExpiresAfter != null)
-                parameters.Dictionary.Add("expiresAfter", DateTimeConverter.ConvertToMilliseconds(requestExpiresAfter));
+                parameters.Add("expiresAfter", DateTimeConverter.ConvertToMilliseconds(requestExpiresAfter));
             else if (ClientOptions.ExpiresAfter != null)
-                parameters.Dictionary.Add("expiresAfter", DateTimeConverter.ConvertToMilliseconds(DateTime.UtcNow + ClientOptions.ExpiresAfter));
+                parameters.Add("expiresAfter", DateTimeConverter.ConvertToMilliseconds(DateTime.UtcNow + ClientOptions.ExpiresAfter));
         }
 
         /// <inheritdoc />

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApi.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApi.cs
@@ -21,9 +21,6 @@ namespace HyperLiquid.Net.Clients.BaseApi
 {
     internal abstract partial class HyperLiquidRestClientApi : RestApiClient<HyperLiquidEnvironment, HyperLiquidAuthenticationProvider, HyperLiquidCredentials>
     {
-        /// <inheritdoc />
-        public string ExchangeName => "HyperLiquid";
-
         public new HyperLiquidRestOptions ClientOptions => (HyperLiquidRestOptions)base.ClientOptions;
         internal HyperLiquidRestClient BaseClient { get; }
 
@@ -37,7 +34,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
             HttpClient? httpClient,
             HyperLiquidRestOptions options,
             RestApiOptions apiOptions)
-            : base(logger, httpClient, options.Environment.RestClientAddress, options, apiOptions)
+            : base(logger, HyperLiquidExchange.Metadata.Id, httpClient, options.Environment.RestClientAddress, options, apiOptions)
         {
             BaseClient = baseClient;
         }
@@ -51,32 +48,26 @@ namespace HyperLiquid.Net.Clients.BaseApi
         protected override HyperLiquidAuthenticationProvider CreateAuthenticationProvider(HyperLiquidCredentials credentials)
             => new HyperLiquidAuthenticationProvider(credentials);
 
-        internal Task<WebCallResult> SendAsync(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null)
-            => SendToAddressAsync(BaseAddress, definition, parameters, cancellationToken, weight);
-
-        internal async Task<WebCallResult> SendToAddressAsync(string baseAddress, RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null)
+        internal async Task<HttpResult> SendAsync(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null)
         {
-            return await base.SendAsync(baseAddress, definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
+            return await base.SendAsync<Unit>(definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
         }
 
-        internal Task<WebCallResult<T>> SendAsync<T>(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null)
-            => SendToAddressAsync<T>(BaseAddress, definition, parameters, cancellationToken, weight);
-
-        internal async Task<WebCallResult<T>> SendToAddressAsync<T>(string baseAddress, RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null)
+        internal async Task<HttpResult<T>> SendAsync<T>(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null)
         {
-            return await base.SendAsync<T>(baseAddress, definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
+            return await base.SendAsync<T>(definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
         }
 
-        internal async Task<WebCallResult<T>> SendAuthAsync<T>(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null)
+        internal async Task<HttpResult<T>> SendAuthAsync<T>(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null)
         {
-            var result = await SendToAddressAsync<HyperLiquidResponse<T>>(BaseAddress, definition, parameters, cancellationToken, weight).ConfigureAwait(false);
-            if (!result)
-                return result.As<T>(default);
+            var result = await SendAsync<HyperLiquidResponse<T>>(definition, parameters, cancellationToken, weight).ConfigureAwait(false);
+            if (!result.Success)
+                return HttpResult.Fail<T>(result);
 
             if (!result.Data.Status.Equals("ok"))
-                return result.AsError<T>(new ServerError(ErrorInfo.Unknown with { Message = result.Data.Status }));
+                return HttpResult.Fail<T>(result, new ServerError(ErrorInfo.Unknown with { Message = result.Data.Status }));
 
-            return result.As(result.Data.Data!.Data);
+            return HttpResult.Ok(result, result.Data.Data!.Data);
         }
 
         internal void AddExpiresAfter(Parameters parameters, DateTime? requestExpiresAfter)
@@ -88,7 +79,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         }
 
         /// <inheritdoc />
-        protected override Task<WebCallResult<DateTime>> GetServerTimestampAsync() => throw new NotImplementedException();
+        protected override Task<HttpResult<DateTime>> GetServerTimestampAsync() => throw new NotImplementedException();
 
         /// <inheritdoc />
         public override string FormatSymbol(string baseAsset, string quoteAsset, TradingMode tradingMode, DateTime? deliverDate = null)

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiAccount.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiAccount.cs
@@ -35,7 +35,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "userFees" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
@@ -61,8 +61,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection();
-            var actionParameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "sendAsset" },
                 { "hyperliquidChain", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? "Testnet" : "Mainnet" },
@@ -73,9 +73,9 @@ namespace HyperLiquid.Net.Clients.BaseApi
             actionParameters.Add("sourceDex", sourceDex);
             actionParameters.Add("destinationDex", destinationDex);
             actionParameters.Add("token", $"{tokenName}:{tokenId}");
-            actionParameters.AddString("amount", quantity);
+            actionParameters.Add("amount", quantity);
             actionParameters.Add("fromSubAccount", fromSubAccount ?? string.Empty);
-            actionParameters.AddMilliseconds("nonce", DateTime.UtcNow);
+            actionParameters.Add("nonce", DateTime.UtcNow);
             parameters.Add("action", actionParameters);
 
             var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
@@ -95,13 +95,13 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "userNonFundingLedgerUpdates" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
             };
-            parameters.AddMilliseconds("startTime", startTime);
-            parameters.AddOptionalMilliseconds("endTime", endTime);
+            parameters.Add("startTime", startTime);
+            parameters.Add("endTime", endTime);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
             return await _baseClient.SendAsync<HyperLiquidAccountLedger>(request, parameters, ct).ConfigureAwait(false);
         }
@@ -118,7 +118,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "userRateLimit" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
@@ -134,7 +134,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         /// <inheritdoc />
         public async Task<WebCallResult<int>> GetApprovedBuilderFeeAsync(string? builderAddress = null, string? address = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "maxBuilderFee" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key },
@@ -153,16 +153,16 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection();
-            var actionParameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "usdSend" },
                 { "hyperliquidChain", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? "Testnet" : "Mainnet" },
                 { "signatureChainId", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? _chainIdTestnet : _chainIdMainnet },
                 { "destination", destinationAddress }
             };
-            actionParameters.AddString("amount", quantity);
-            actionParameters.AddMilliseconds("time", DateTime.UtcNow);
+            actionParameters.Add("amount", quantity);
+            actionParameters.Add("time", DateTime.UtcNow);
             parameters.Add("action", actionParameters);
 
             var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
@@ -182,16 +182,16 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection();
-            var actionParameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "withdraw3" },
                 { "hyperliquidChain", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? "Testnet" : "Mainnet" },
                 { "signatureChainId", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? _chainIdTestnet : _chainIdMainnet },
                 { "destination", destinationAddress },
             };
-            actionParameters.AddString("amount", quantity);
-            actionParameters.AddMilliseconds("time", DateTime.UtcNow);
+            actionParameters.Add("amount", quantity);
+            actionParameters.Add("time", DateTime.UtcNow);
             parameters.Add("action", actionParameters);
 
             var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
@@ -212,8 +212,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection();
-            var actionParameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "usdClassTransfer" },
                 { "hyperliquidChain", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? "Testnet" : "Mainnet" },
@@ -224,7 +224,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 quantityField += " subaccount:" + subAccount;
             actionParameters.Add("amount", quantityField);
             actionParameters.Add("toPerp", direction == TransferDirection.SpotToFutures);
-            actionParameters.AddMilliseconds("nonce", DateTime.UtcNow);
+            actionParameters.Add("nonce", DateTime.UtcNow);
             parameters.Add("action", actionParameters);
 
             var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
@@ -241,14 +241,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "cDeposit" },
                 { "hyperliquidChain", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? "Testnet" : "Mainnet" },
                 { "signatureChainId", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? _chainIdTestnet : _chainIdMainnet },
                 { "wei", wei }
             };
-            parameters.AddMilliseconds("nonce", DateTime.UtcNow);
+            parameters.Add("nonce", DateTime.UtcNow);
 
             var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, false);
             var result = await _baseClient.SendAuthAsync<HyperLiquidDefault>(request, parameters, ct).ConfigureAwait(false);
@@ -264,14 +264,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "cWithdraw" },
                 { "hyperliquidChain", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? "Testnet" : "Mainnet" },
                 { "signatureChainId", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? _chainIdTestnet : _chainIdMainnet },
                 { "wei", wei }
             };
-            parameters.AddMilliseconds("nonce", DateTime.UtcNow);
+            parameters.Add("nonce", DateTime.UtcNow);
 
             var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, false);
             var result = await _baseClient.SendAuthAsync<HyperLiquidDefault>(request, parameters, ct).ConfigureAwait(false);
@@ -287,14 +287,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "tokenDelegate" },
                 { "validator", validator },
                 { "isUndelegate", direction == DelegateDirection.Undelegate },
                 { "wei", wei }
             };
-            parameters.AddMilliseconds("nonce", DateTime.UtcNow);
+            parameters.Add("nonce", DateTime.UtcNow);
 
             var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, false);
             var result = await _baseClient.SendAuthAsync<HyperLiquidDefault>(request, parameters, ct).ConfigureAwait(false);
@@ -315,14 +315,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "vaultTransfer" },
                 { "vaultAddress", vaultAddress },
                 { "isDeposit", direction == DepositWithdrawDirection.Deposit },
                 { "usd", usd }
             };
-            parameters.AddMilliseconds("nonce", DateTime.UtcNow);
+            parameters.Add("nonce", DateTime.UtcNow);
 
             _baseClient.AddExpiresAfter(parameters, expiresAfter);
 
@@ -343,7 +343,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         public async Task<WebCallResult> ApproveBuilderFeeAsync(string builderAddress, decimal maxFeePercentage, CancellationToken ct = default)
         {
             // NOTE; order of the parameters matters
-            var actionParameters = new ParameterCollection()
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "hyperliquidChain", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? "Testnet" : "Mainnet" },
                 { "maxFeeRate", $"{maxFeePercentage.ToString(CultureInfo.InvariantCulture)}%" },
@@ -353,7 +353,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 { "type", "approveBuilderFee" },
             };
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 {
                     "action", actionParameters
@@ -374,7 +374,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "subAccounts" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
@@ -399,7 +399,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "userRole" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
@@ -417,7 +417,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "extraAgents" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
@@ -437,7 +437,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "delegations" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
@@ -457,7 +457,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "delegatorSummary" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
@@ -477,7 +477,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "delegatorHistory" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
@@ -497,7 +497,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "delegatorRewards" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
@@ -517,7 +517,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "userAbstraction" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiAccount.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiAccount.cs
@@ -28,7 +28,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get Trading Fee
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidFeeInfo>> GetFeeInfoAsync(string? address = null, CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidFeeInfo>> GetFeeInfoAsync(string? address = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -40,7 +40,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 { "type", "userFees" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             return await _baseClient.SendAsync<HyperLiquidFeeInfo>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -49,7 +49,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Send Asset
 
         /// <inheritdoc />
-        public async Task<WebCallResult> SendAssetAsync(
+        public async Task<HttpResult> SendAssetAsync(
             string destination,
             string sourceDex,
             string destinationDex,
@@ -78,9 +78,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             actionParameters.Add("nonce", DateTime.UtcNow);
             parameters.Add("action", actionParameters);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
-            var result = await _baseClient.SendAuthAsync<HyperLiquidDefault>(request, parameters, ct).ConfigureAwait(false);
-            return result.AsDataless();
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
+            return await _baseClient.SendAuthAsync<HyperLiquidDefault>(request, parameters, ct).ConfigureAwait(false);
         }
 
         #endregion
@@ -88,7 +87,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get Account Ledger
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidAccountLedger>> GetAccountLedgerAsync(DateTime startTime, DateTime? endTime = null, string? address = null, CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidAccountLedger>> GetAccountLedgerAsync(DateTime startTime, DateTime? endTime = null, string? address = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -102,7 +101,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
             };
             parameters.Add("startTime", startTime);
             parameters.Add("endTime", endTime);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
             return await _baseClient.SendAsync<HyperLiquidAccountLedger>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -111,7 +110,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get Rate Limits
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidRateLimit>> GetRateLimitsAsync(string? address = null, CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidRateLimit>> GetRateLimitsAsync(string? address = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -123,7 +122,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 { "type", "userRateLimit" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             return await _baseClient.SendAsync<HyperLiquidRateLimit>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -132,7 +131,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get Approved Builder Fee
 
         /// <inheritdoc />
-        public async Task<WebCallResult<int>> GetApprovedBuilderFeeAsync(string? builderAddress = null, string? address = null, CancellationToken ct = default)
+        public async Task<HttpResult<int>> GetApprovedBuilderFeeAsync(string? builderAddress = null, string? address = null, CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
@@ -140,7 +139,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key },
                 { "builder", builderAddress ?? _baseClient.ClientOptions.BuilderAddress }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             return await _baseClient.SendAsync<int>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -149,7 +148,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Transfer USD
 
         /// <inheritdoc />
-        public async Task<WebCallResult> TransferUsdAsync(string destinationAddress, decimal quantity, CancellationToken ct = default)
+        public async Task<HttpResult> TransferUsdAsync(string destinationAddress, decimal quantity, CancellationToken ct = default)
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
@@ -165,9 +164,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             actionParameters.Add("time", DateTime.UtcNow);
             parameters.Add("action", actionParameters);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
-            var result = await _baseClient.SendAuthAsync<HyperLiquidDefault>(request, parameters, ct).ConfigureAwait(false);
-            return result.AsDataless();
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
+            return await _baseClient.SendAuthAsync<HyperLiquidDefault>(request, parameters, ct).ConfigureAwait(false);
         }
 
         #endregion
@@ -175,7 +173,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Withdraw
 
         /// <inheritdoc />
-        public async Task<WebCallResult> WithdrawAsync(
+        public async Task<HttpResult> WithdrawAsync(
             string destinationAddress,
             decimal quantity,
             CancellationToken ct = default)
@@ -194,9 +192,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             actionParameters.Add("time", DateTime.UtcNow);
             parameters.Add("action", actionParameters);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
-            var result = await _baseClient.SendAuthAsync<HyperLiquidDefault>(request, parameters, ct).ConfigureAwait(false);
-            return result.AsDataless();
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
+            return await _baseClient.SendAuthAsync<HyperLiquidDefault>(request, parameters, ct).ConfigureAwait(false);
         }
 
         #endregion
@@ -204,7 +201,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Transfer Internal
 
         /// <inheritdoc />
-        public async Task<WebCallResult> TransferInternalAsync(
+        public async Task<HttpResult> TransferInternalAsync(
             TransferDirection direction,
             decimal quantity,
             string? subAccount = null,
@@ -227,9 +224,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             actionParameters.Add("nonce", DateTime.UtcNow);
             parameters.Add("action", actionParameters);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
-            var result = await _baseClient.SendAuthAsync<HyperLiquidDefault>(request, parameters, ct).ConfigureAwait(false);
-            return result.AsDataless();
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
+            return await _baseClient.SendAuthAsync<HyperLiquidDefault>(request, parameters, ct).ConfigureAwait(false);
         }
 
         #endregion
@@ -237,7 +233,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Deposit Into Staking
 
         /// <inheritdoc />
-        public async Task<WebCallResult> DepositIntoStakingAsync(long wei, CancellationToken ct = default)
+        public async Task<HttpResult> DepositIntoStakingAsync(long wei, CancellationToken ct = default)
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
@@ -250,9 +246,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             };
             parameters.Add("nonce", DateTime.UtcNow);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, false);
-            var result = await _baseClient.SendAuthAsync<HyperLiquidDefault>(request, parameters, ct).ConfigureAwait(false);
-            return result.AsDataless();
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, false);
+            return await _baseClient.SendAuthAsync<HyperLiquidDefault>(request, parameters, ct).ConfigureAwait(false);
         }
 
         #endregion
@@ -260,7 +255,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Withdraw From Staking
 
         /// <inheritdoc />
-        public async Task<WebCallResult> WithdrawFromStakingAsync(long wei, CancellationToken ct = default)
+        public async Task<HttpResult> WithdrawFromStakingAsync(long wei, CancellationToken ct = default)
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
@@ -273,9 +268,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             };
             parameters.Add("nonce", DateTime.UtcNow);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, false);
-            var result = await _baseClient.SendAuthAsync<HyperLiquidDefault>(request, parameters, ct).ConfigureAwait(false);
-            return result.AsDataless();
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, false);
+            return await _baseClient.SendAuthAsync<HyperLiquidDefault>(request, parameters, ct).ConfigureAwait(false);
         }
 
         #endregion
@@ -283,7 +277,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Delegate Or Undelegate Stake
 
         /// <inheritdoc />
-        public async Task<WebCallResult> DelegateOrUndelegateStakeFromValidatorAsync(DelegateDirection direction, string validator, long wei, CancellationToken ct = default)
+        public async Task<HttpResult> DelegateOrUndelegateStakeFromValidatorAsync(DelegateDirection direction, string validator, long wei, CancellationToken ct = default)
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
@@ -296,9 +290,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             };
             parameters.Add("nonce", DateTime.UtcNow);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, false);
-            var result = await _baseClient.SendAuthAsync<HyperLiquidDefault>(request, parameters, ct).ConfigureAwait(false);
-            return result.AsDataless();
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, false);
+            return await _baseClient.SendAuthAsync<HyperLiquidDefault>(request, parameters, ct).ConfigureAwait(false);
         }
 
         #endregion
@@ -306,7 +299,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Deposit Or Withdraw From Vault
 
         /// <inheritdoc />
-        public async Task<WebCallResult> DepositOrWithdrawFromVaultAsync(
+        public async Task<HttpResult> DepositOrWithdrawFromVaultAsync(
             DepositWithdrawDirection direction,
             string vaultAddress,
             long usd,
@@ -326,9 +319,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             _baseClient.AddExpiresAfter(parameters, expiresAfter);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, false);
-            var result = await _baseClient.SendAuthAsync<HyperLiquidDefault>(request, parameters, ct).ConfigureAwait(false);
-            return result.AsDataless();
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, false);
+            return await _baseClient.SendAuthAsync<HyperLiquidDefault>(request, parameters, ct).ConfigureAwait(false);
         }
 
         #endregion
@@ -336,11 +328,11 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Approve Builder Fee
 
         /// <inheritdoc />
-        public Task<WebCallResult> ApproveBuilderFeeAsync(CancellationToken ct = default)
+        public Task<HttpResult> ApproveBuilderFeeAsync(CancellationToken ct = default)
             => ApproveBuilderFeeAsync(_baseClient.ClientOptions.BuilderAddress, _baseClient.ClientOptions.BuilderFeePercentage ?? 0.1m);
 
         /// <inheritdoc />
-        public async Task<WebCallResult> ApproveBuilderFeeAsync(string builderAddress, decimal maxFeePercentage, CancellationToken ct = default)
+        public async Task<HttpResult> ApproveBuilderFeeAsync(string builderAddress, decimal maxFeePercentage, CancellationToken ct = default)
         {
             // NOTE; order of the parameters matters
             var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
@@ -360,9 +352,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 }
             };
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
-            var result = await _baseClient.SendAuthAsync<HyperLiquidDefault>(request, parameters, ct).ConfigureAwait(false);
-            return result.AsDataless();
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
+            return await _baseClient.SendAuthAsync<HyperLiquidDefault>(request, parameters, ct).ConfigureAwait(false);
         }
 
         #endregion
@@ -370,7 +361,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get Sub account list
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidSubAccount[]>> GetSubAccountsAsync(string? address = null, CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidSubAccount[]>> GetSubAccountsAsync(string? address = null, CancellationToken ct = default)
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
@@ -379,13 +370,13 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 { "type", "subAccounts" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             var result = await _baseClient.SendAsync<HyperLiquidSubAccount[]>(request, parameters, ct).ConfigureAwait(false);
-            if (!result)
+            if (!result.Success)
                 return result;
 
             if (result.Data == null)
-                return result.As(new HyperLiquidSubAccount[0]);
+                return HttpResult.Ok(result, new HyperLiquidSubAccount[0]);
 
             return result;
         }
@@ -395,7 +386,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get User Role
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidUserRole>> GetUserRoleAsync(string? address = null, CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidUserRole>> GetUserRoleAsync(string? address = null, CancellationToken ct = default)
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
@@ -404,7 +395,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 { "type", "userRole" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 60, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 60, false);
             return await _baseClient.SendAsync<HyperLiquidUserRole>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -413,7 +404,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get Extra Agents
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidUserAgent[]>> GetExtraAgentsAsync(string? address = null, CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidUserAgent[]>> GetExtraAgentsAsync(string? address = null, CancellationToken ct = default)
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
@@ -422,7 +413,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 { "type", "extraAgents" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, false);
             return await _baseClient.SendAsync<HyperLiquidUserAgent[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -430,7 +421,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
         #region Get Staking Delegations
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidStakingDelegation[]>> GetStakingDelegationsAsync(string? address = null, CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidStakingDelegation[]>> GetStakingDelegationsAsync(string? address = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -443,14 +434,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
             };
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
             return await _baseClient.SendAsync<HyperLiquidStakingDelegation[]>(request, parameters, ct).ConfigureAwait(false);
         }
         #endregion
 
         #region Get Staking Summary
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidStakingSummary>> GetStakingSummaryAsync(string? address = null, CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidStakingSummary>> GetStakingSummaryAsync(string? address = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -463,14 +454,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
             };
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
             return await _baseClient.SendAsync<HyperLiquidStakingSummary>(request, parameters, ct).ConfigureAwait(false);
         }
         #endregion
 
         #region Get Staking History
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidStakingHistory[]>> GetStakingHistoryAsync(string? address = null, CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidStakingHistory[]>> GetStakingHistoryAsync(string? address = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -483,14 +474,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
             };
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
             return await _baseClient.SendAsync<HyperLiquidStakingHistory[]>(request, parameters, ct).ConfigureAwait(false);
         }
         #endregion
 
         #region Get Staking Rewards
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidStakingReward[]>> GetStakingRewardsAsync(string? address = null, CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidStakingReward[]>> GetStakingRewardsAsync(string? address = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -503,14 +494,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
             };
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
             return await _baseClient.SendAsync<HyperLiquidStakingReward[]>(request, parameters, ct).ConfigureAwait(false);
         }
         #endregion
 
         #region Get User Abstraction State
         /// <inheritdoc />
-        public async Task<WebCallResult<UserAbstractionState>> GetUserAbstractionStateAsync(string? address = null, CancellationToken ct = default)
+        public async Task<HttpResult<UserAbstractionState>> GetUserAbstractionStateAsync(string? address = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -523,7 +514,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
             };
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
             return await _baseClient.SendAsync<UserAbstractionState>(request, parameters, ct).ConfigureAwait(false);
         }
         #endregion

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiExchangeData.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiExchangeData.cs
@@ -16,6 +16,11 @@ namespace HyperLiquid.Net.Clients.BaseApi
     /// <inheritdoc />
     internal class HyperLiquidRestClientApiExchangeData
     {
+        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
+        {
+            Decimal = DecimalSerialization.String,
+            Sort = false
+        };
         private readonly HyperLiquidRestClientApi _baseClient;
         private static readonly RequestDefinitionCache _definitions = new RequestDefinitionCache();
 
@@ -29,11 +34,11 @@ namespace HyperLiquid.Net.Clients.BaseApi
         /// <inheritdoc />
         public async Task<WebCallResult<Dictionary<string, decimal>>> GetPricesAsync(string? dex = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "allMids" }
             };
-            parameters.AddOptional("dex", dex);
+            parameters.Add("dex", dex);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
             var result = await _baseClient.SendAsync<Dictionary<string, decimal>>(request, parameters, ct).ConfigureAwait(false);
             if (!result)
@@ -70,14 +75,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 coin = spotName.Data;
             }
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "l2Book" },
                 { "coin", coin }
             };
 
-            parameters.AddOptional("nSigFigs", numberSignificantFigures);
-            parameters.AddOptional("mantissa", mantissa);
+            parameters.Add("nSigFigs", numberSignificantFigures);
+            parameters.Add("mantissa", mantissa);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
             var result = await _baseClient.SendAsync<HyperLiquidOrderBook>(request, parameters, ct).ConfigureAwait(false);
             if (result.Data == null)
@@ -104,13 +109,13 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 coin = spotName.Data;
             }
 
-            var innerParameters = new ParameterCollection();
+            var innerParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
             innerParameters.Add("coin", coin);
-            innerParameters.AddEnum("interval", interval);
-            innerParameters.AddOptionalMilliseconds("startTime", startTime);
-            innerParameters.AddOptionalMilliseconds("endTime", endTime);
+            innerParameters.Add("interval", interval);
+            innerParameters.Add("startTime", startTime);
+            innerParameters.Add("endTime", endTime);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "candleSnapshot" },
                 { "req", innerParameters }

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiExchangeData.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiExchangeData.cs
@@ -16,11 +16,6 @@ namespace HyperLiquid.Net.Clients.BaseApi
     /// <inheritdoc />
     internal class HyperLiquidRestClientApiExchangeData
     {
-        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
-        {
-            Decimal = DecimalSerialization.String,
-            Sort = false
-        };
         private readonly HyperLiquidRestClientApi _baseClient;
         private static readonly RequestDefinitionCache _definitions = new RequestDefinitionCache();
 
@@ -70,7 +65,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 // Spot symbol
                 var spotName = await HyperLiquidUtils.GetExchangeNameFromSymbolNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
                 if (!spotName.Success)
-                    return HttpResult.Fail<HyperLiquidOrderBook>(_baseClient.ExchangeName, spotName.Error);
+                    return HttpResult.Fail<HyperLiquidOrderBook>(_baseClient.Exchange, spotName.Error);
 
                 coin = spotName.Data;
             }
@@ -104,7 +99,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 // Spot symbol
                 var spotName = await HyperLiquidUtils.GetExchangeNameFromSymbolNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
                 if (!spotName.Success)
-                    return HttpResult.Fail<HyperLiquidKline[]>(_baseClient.ExchangeName, spotName.Error);
+                    return HttpResult.Fail<HyperLiquidKline[]>(_baseClient.Exchange, spotName.Error);
 
                 coin = spotName.Data;
             }

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiExchangeData.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiExchangeData.cs
@@ -32,20 +32,20 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get Prices
 
         /// <inheritdoc />
-        public async Task<WebCallResult<Dictionary<string, decimal>>> GetPricesAsync(string? dex = null, CancellationToken ct = default)
+        public async Task<HttpResult<Dictionary<string, decimal>>> GetPricesAsync(string? dex = null, CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "allMids" }
             };
             parameters.Add("dex", dex);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
             var result = await _baseClient.SendAsync<Dictionary<string, decimal>>(request, parameters, ct).ConfigureAwait(false);
-            if (!result)
+            if (!result.Success)
                 return result;
 
             if (result.Data == null)
-                return result.AsError<Dictionary<string, decimal>>(new ServerError(new ErrorInfo(ErrorType.InvalidParameter, "DEX not found")));
+                return HttpResult.Fail<Dictionary<string, decimal>>(result, new ServerError(new ErrorInfo(ErrorType.InvalidParameter, "DEX not found")));
 
             var resultMapped = new Dictionary<string, decimal>();
             foreach (var item in result.Data)
@@ -54,7 +54,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 resultMapped.Add(nameRes.Data ?? item.Key, item.Value);
             }
 
-            return result.As(resultMapped);
+            return HttpResult.Ok(result, resultMapped);
         }
 
         #endregion
@@ -62,15 +62,15 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get Order Book
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidOrderBook>> GetOrderBookAsync(string symbol, int? numberSignificantFigures = null, int? mantissa = null, CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidOrderBook>> GetOrderBookAsync(string symbol, int? numberSignificantFigures = null, int? mantissa = null, CancellationToken ct = default)
         {
             var coin = symbol;
             if (HyperLiquidUtils.SymbolIsExchangeSpotSymbol(coin))
             {
                 // Spot symbol
                 var spotName = await HyperLiquidUtils.GetExchangeNameFromSymbolNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
-                if (!spotName)
-                    return new WebCallResult<HyperLiquidOrderBook>(spotName.Error);
+                if (!spotName.Success)
+                    return HttpResult.Fail<HyperLiquidOrderBook>(_baseClient.ExchangeName, spotName.Error);
 
                 coin = spotName.Data;
             }
@@ -83,10 +83,10 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             parameters.Add("nSigFigs", numberSignificantFigures);
             parameters.Add("mantissa", mantissa);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
             var result = await _baseClient.SendAsync<HyperLiquidOrderBook>(request, parameters, ct).ConfigureAwait(false);
             if (result.Data == null)
-                return result.AsError<HyperLiquidOrderBook>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
+                return HttpResult.Fail<HyperLiquidOrderBook>(result, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
             
             return result;
         }
@@ -96,15 +96,15 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get Klines
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidKline[]>> GetKlinesAsync(string symbol, KlineInterval interval, DateTime startTime, DateTime endTime, CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidKline[]>> GetKlinesAsync(string symbol, KlineInterval interval, DateTime startTime, DateTime endTime, CancellationToken ct = default)
         {
             var coin = symbol;
             if (HyperLiquidUtils.SymbolIsExchangeSpotSymbol(coin))
             {
                 // Spot symbol
                 var spotName = await HyperLiquidUtils.GetExchangeNameFromSymbolNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
-                if (!spotName)
-                    return new WebCallResult<HyperLiquidKline[]>(spotName.Error);
+                if (!spotName.Success)
+                    return HttpResult.Fail<HyperLiquidKline[]>(_baseClient.ExchangeName, spotName.Error);
 
                 coin = spotName.Data;
             }
@@ -121,10 +121,10 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 { "req", innerParameters }
             };
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             var result = await _baseClient.SendAsync<HyperLiquidKline[]>(request, parameters, ct).ConfigureAwait(false);
             if (result.ResponseStatusCode == (HttpStatusCode)500 && result.Error?.ErrorType == ErrorType.Unknown)
-                return result.AsError<HyperLiquidKline[]>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
+                return HttpResult.Fail<HyperLiquidKline[]>(result, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
             return result;
         }

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiTrading.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiTrading.cs
@@ -18,6 +18,11 @@ namespace HyperLiquid.Net.Clients.BaseApi
     /// <inheritdoc />
     internal class HyperLiquidRestClientApiTrading : IHyperLiquidRestClientTrading
     {
+        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
+        {
+            Decimal = DecimalSerialization.String,
+            Sort = false
+        };
         private static readonly RequestDefinitionCache _definitions = new RequestDefinitionCache();
         private readonly HyperLiquidRestClientApi _baseClient;
         private readonly ILogger _logger;
@@ -319,11 +324,12 @@ namespace HyperLiquid.Net.Clients.BaseApi
             TpSlGrouping? tpSlGrouping = null, 
 			string? vaultAddress = null,
             DateTime? expiresAfter = null,
+            IDictionary<string, object>? rawParameters = null,
             CancellationToken ct = default)
         {
             var result = await PlaceMultipleOrdersAsync([
                 new HyperLiquidOrderRequest(symbol, side, orderType, quantity, price, timeInForce, reduceOnly, triggerPrice: triggerPrice, tpSlType: tpSlType, clientOrderId: clientOrderId)
-                ], tpSlGrouping, vaultAddress, expiresAfter, ct).ConfigureAwait(false);
+                ], tpSlGrouping, vaultAddress, expiresAfter, rawParameters, ct).ConfigureAwait(false);
 
             if (!result)
                 return result.As<HyperLiquidOrderResult>(default);
@@ -345,6 +351,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
             TpSlGrouping? tpSlGrouping = null,
 			string? vaultAddress = null,
             DateTime? expireAfter = null,
+            IDictionary<string, object>? rawParameters = null,
             CancellationToken ct = default)
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
@@ -441,15 +448,15 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 );
             }
 
-            var parameters = new ParameterCollection()
-            {
-                { "action", actionParameters }
-            };
-            
+            var parameters = new Parameters(_parameterSerializationSettings);
+            parameters.AddRaw("action", actionParameters);
+
             if (vaultAddress != null)
                 parameters.Add("vaultAddress", vaultAddress);
 
             _baseClient.AddExpiresAfter(parameters, expireAfter);
+
+            parameters.ApplyRawParameters(rawParameters);
 
             var weight = 1 + (int)Math.Floor(orderRequests.Count / 40m);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiTrading.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiTrading.cs
@@ -19,11 +19,6 @@ namespace HyperLiquid.Net.Clients.BaseApi
     /// <inheritdoc />
     internal class HyperLiquidRestClientApiTrading : IHyperLiquidRestClientTrading
     {
-        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
-        {
-            Decimal = DecimalSerialization.String,
-            Sort = false
-        };
         private static readonly RequestDefinitionCache _definitions = new RequestDefinitionCache();
         private readonly HyperLiquidRestClientApi _baseClient;
         private readonly ILogger _logger;
@@ -37,7 +32,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get Open Orders
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidOpenOrder[]>> GetOpenOrdersAsync(string? address = null, string? dex = null, CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidOpenOrder[]>> GetOpenOrdersAsync(string? address = null, string? dex = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -50,9 +45,9 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key  }
             };
             parameters.Add("dex", dex);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             var result = await _baseClient.SendAsync<HyperLiquidOpenOrder[]>(request, parameters, ct).ConfigureAwait(false);
-            if (!result)
+            if (!result.Success)
                 return result;
 
             foreach (var order in result.Data)
@@ -81,7 +76,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get Open Orders Extended
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidOrder[]>> GetOpenOrdersExtendedAsync(string? address = null, string? dex = null, CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidOrder[]>> GetOpenOrdersExtendedAsync(string? address = null, string? dex = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -94,9 +89,9 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
             };
             parameters.Add("dex", dex);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             var result = await _baseClient.SendAsync<HyperLiquidOrder[]>(request, parameters, ct).ConfigureAwait(false);
-            if (!result)
+            if (!result.Success)
                 return result;
 
             foreach (var order in result.Data)
@@ -125,7 +120,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get User Trades
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidUserTrade[]>> GetUserTradesAsync(string? address = null, CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidUserTrade[]>> GetUserTradesAsync(string? address = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -137,9 +132,9 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 { "type", "userFills" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             var result = await _baseClient.SendAsync<HyperLiquidUserTrade[]>(request, parameters, ct).ConfigureAwait(false);
-            if (!result)
+            if (!result.Success)
                 return result;
 
             foreach (var order in result.Data)
@@ -168,7 +163,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get User Trades By Time
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidUserTrade[]>> GetUserTradesByTimeAsync(
+        public async Task<HttpResult<HyperLiquidUserTrade[]>> GetUserTradesByTimeAsync(
             DateTime startTime,
             DateTime? endTime = null,
             bool? aggregateByTime = null,
@@ -189,9 +184,9 @@ namespace HyperLiquid.Net.Clients.BaseApi
             parameters.Add("endTime", endTime);
             parameters.Add("aggregateByTime", aggregateByTime);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             var result = await _baseClient.SendAsync<HyperLiquidUserTrade[]>(request, parameters, ct).ConfigureAwait(false);
-            if (!result)
+            if (!result.Success)
                 return result;
 
             foreach (var order in result.Data)
@@ -220,7 +215,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get Order
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidOrderStatus>> GetOrderAsync(long? orderId = null, string? clientOrderId = null, string? address = null, CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidOrderStatus>> GetOrderAsync(long? orderId = null, string? clientOrderId = null, string? address = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -236,13 +231,13 @@ namespace HyperLiquid.Net.Clients.BaseApi
             parameters.Add("oid", orderId);
             parameters.Add("oid", clientOrderId);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
             var result = await _baseClient.SendAsync<HyperLiquidOrderStatusResult>(request, parameters, ct).ConfigureAwait(false);
-            if (!result)
-                return result.As<HyperLiquidOrderStatus>(default);
+            if (!result.Success)
+                return HttpResult.Fail<HyperLiquidOrderStatus>(result);
 
             if (result.Data.Status != "order")
-                return result.AsError<HyperLiquidOrderStatus>(new ServerError(new ErrorInfo(ErrorType.Unknown, result.Data.Status)));
+                return HttpResult.Fail<HyperLiquidOrderStatus>(result, new ServerError(new ErrorInfo(ErrorType.Unknown, result.Data.Status)));
 
             if (HyperLiquidUtils.ExchangeSymbolIsSpotSymbol(result.Data.Order!.Order.ExchangeSymbol))
             {
@@ -259,7 +254,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 result.Data.Order!.Order.SymbolType = SymbolType.Futures;
             }
 
-            return result.As(result.Data.Order);
+            return HttpResult.Ok(result, result.Data.Order);
         }
 
         #endregion
@@ -267,7 +262,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get Order History
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidOrderStatus[]>> GetOrderHistoryAsync(string? address = null, CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidOrderStatus[]>> GetOrderHistoryAsync(string? address = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -280,10 +275,10 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 { "user",  address ?? _baseClient.AuthenticationProvider!.Key }
             };
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             var result = await _baseClient.SendAsync<HyperLiquidOrderStatus[]>(request, parameters, ct).ConfigureAwait(false);
 
-            if (!result)
+            if (!result.Success)
                 return result;
 
             foreach (var order in result.Data)
@@ -311,7 +306,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
         #region Place Order
 
-        public async Task<WebCallResult<HyperLiquidOrderResult>> PlaceOrderAsync(
+        public async Task<HttpResult<HyperLiquidOrderResult>> PlaceOrderAsync(
             string symbol,
             OrderSide side,
             OrderType orderType,
@@ -325,21 +320,20 @@ namespace HyperLiquid.Net.Clients.BaseApi
             TpSlGrouping? tpSlGrouping = null, 
 			string? vaultAddress = null,
             DateTime? expiresAfter = null,
-            IDictionary<string, object>? rawParameters = null,
             CancellationToken ct = default)
         {
             var result = await PlaceMultipleOrdersAsync([
                 new HyperLiquidOrderRequest(symbol, side, orderType, quantity, price, timeInForce, reduceOnly, triggerPrice: triggerPrice, tpSlType: tpSlType, clientOrderId: clientOrderId)
-                ], tpSlGrouping, vaultAddress, expiresAfter, rawParameters, ct).ConfigureAwait(false);
+                ], tpSlGrouping, vaultAddress, expiresAfter, ct).ConfigureAwait(false);
 
-            if (!result)
-                return result.As<HyperLiquidOrderResult>(default);
+            if (!result.Success)
+                return HttpResult.Fail<HyperLiquidOrderResult>(result);
 
             var orderResult = result.Data.Single();
-            if (!orderResult)
-                return result.AsError<HyperLiquidOrderResult>(orderResult.Error!);
+            if (!orderResult.Success)
+                return HttpResult.Fail<HyperLiquidOrderResult>(result, orderResult.Error);
 
-            return result.As(result.Data.Single().Data);
+            return HttpResult.Ok(result, result.Data.Single().Data!);
         }
 
         #endregion
@@ -347,12 +341,11 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Place Multiple Orders
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CallResult<HyperLiquidOrderResult>[]>> PlaceMultipleOrdersAsync(
+        public async Task<HttpResult<CallResult<HyperLiquidOrderResult>[]>> PlaceMultipleOrdersAsync(
             IEnumerable<HyperLiquidOrderRequest> orders,
             TpSlGrouping? tpSlGrouping = null,
 			string? vaultAddress = null,
             DateTime? expireAfter = null,
-            IDictionary<string, object>? rawParameters = null,
             CancellationToken ct = default)
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
@@ -361,8 +354,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             foreach (var order in orders)
             {
                 var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, order.Symbol).ConfigureAwait(false);
-                if (!symbolId)
-                    return new WebCallResult<CallResult<HyperLiquidOrderResult>[]>(symbolId.Error);
+                if (!symbolId.Success)
+                    return HttpResult.Fail<CallResult<HyperLiquidOrderResult>[]>(_baseClient.Exchange, symbolId.Error);
 
                 var orderParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
                 orderParameters.Add("a", symbolId.Data);
@@ -383,8 +376,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
                     var maxSlippage = order.MaxSlippage ?? 5;
                     var price = (order.Side == OrderSide.Buy ? order.Price * (1 + maxSlippage / 100m) : order.Price * (1 - maxSlippage / 100m)) ?? 0;
                     var quantityDecimals = await HyperLiquidUtils.GetQuantityDecimalPlacesForSymbolAsync(_baseClient.BaseClient, order.Symbol).ConfigureAwait(false);
-                    if (!quantityDecimals)
-                        return new WebCallResult<CallResult<HyperLiquidOrderResult>[]>(quantityDecimals.Error);
+                    if (!quantityDecimals.Success)
+                        return HttpResult.Fail<CallResult<HyperLiquidOrderResult>[]>(_baseClient.Exchange, quantityDecimals.Error);
 
                     // Price can be a max of 5 significant figures
                     // but no more than (Spot:8, Futures:6) - quantityDecimals decimal places for the symbol
@@ -455,40 +448,38 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             _baseClient.AddExpiresAfter(parameters, expireAfter);
 
-            parameters.ApplyRawParameters(rawParameters);
-
             var weight = 1 + (int)Math.Floor(orderRequests.Count / 40m);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
             var intResult = await _baseClient.SendAuthAsync<HyperLiquidOrderResultIntWrapper>(request, parameters, ct, weight).ConfigureAwait(false);
-            if (!intResult)
-                return intResult.As<CallResult<HyperLiquidOrderResult>[]>(default);
+            if (!intResult.Success)
+                return HttpResult.Fail<CallResult<HyperLiquidOrderResult>[]>(intResult);
 
             var result = new List<CallResult<HyperLiquidOrderResult>>();
             foreach (var order in intResult.Data.Statuses)
             {
                 if (order.Error != null)
-                    result.Add(new CallResult<HyperLiquidOrderResult>(new ServerError(_baseClient.GetErrorInfo("Order", order.Error))));
+                    result.Add(CallResult<HyperLiquidOrderResult>.Fail(new ServerError(_baseClient.GetErrorInfo("Order", order.Error))));
                 else if (order.ResultResting != null)
-                    result.Add(new CallResult<HyperLiquidOrderResult>(order.ResultResting with { Status = OrderStatus.Open }));
+                    result.Add(CallResult<HyperLiquidOrderResult>.Ok(order.ResultResting with { Status = OrderStatus.Open }));
                 else if (order.ResultFilled != null)
-                    result.Add(new CallResult<HyperLiquidOrderResult>(order.ResultFilled! with { Status = OrderStatus.Filled }));
+                    result.Add(CallResult<HyperLiquidOrderResult>.Ok(order.ResultFilled! with { Status = OrderStatus.Filled }));
                 else if (order.WaitingForFill != null)
-                    result.Add(new CallResult<HyperLiquidOrderResult>(order.WaitingForFill! with { Status = OrderStatus.WaitingTrigger }));
+                    result.Add(CallResult<HyperLiquidOrderResult>.Ok(order.WaitingForFill! with { Status = OrderStatus.WaitingTrigger }));
                 else
-                    result.Add(new CallResult<HyperLiquidOrderResult>(order.WaitingForTrigger! with { Status = OrderStatus.WaitingTrigger }));
+                    result.Add(CallResult<HyperLiquidOrderResult>.Ok(order.WaitingForTrigger! with { Status = OrderStatus.WaitingTrigger }));
             }
 
             if (result.Count > 1 && result.All(x => !x.Success))
-                return intResult.AsErrorWithData<CallResult<HyperLiquidOrderResult>[]>(new ServerError(new ErrorInfo(ErrorType.AllOrdersFailed, "All orders failed")), result.ToArray());
+                return HttpResult.Fail<CallResult<HyperLiquidOrderResult>[]>(intResult, new ServerError(new ErrorInfo(ErrorType.AllOrdersFailed, "All orders failed")), result.ToArray());
 
-            return intResult.As<CallResult<HyperLiquidOrderResult>[]>(result.ToArray());
+            return HttpResult.Ok(intResult, result.ToArray());
         }
 
         #endregion
 
         #region Cancel Order
 
-        public async Task<WebCallResult> CancelOrderAsync(
+        public async Task<HttpResult> CancelOrderAsync(
             string symbol,
             long orderId,
             string? vaultAddress = null,
@@ -496,14 +487,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
             CancellationToken ct = default)
         {
             var result = await CancelOrdersAsync([new HyperLiquidCancelRequest(symbol, orderId)], vaultAddress, expiresAfter, ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsDataless();
+            if (!result.Success)
+                return result;
 
             var cancelResult = result.Data.Single();
-            if (!cancelResult)
-                return result.AsDatalessError(cancelResult.Error!);
+            if (!cancelResult.Success)
+                return HttpResult.Fail(_baseClient.Exchange, cancelResult.Error!);
 
-            return result.AsDataless();
+            return result;
         }
 
         #endregion
@@ -511,7 +502,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Cancel Orders
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CallResult[]>> CancelOrdersAsync(
+        public async Task<HttpResult<CallResult[]>> CancelOrdersAsync(
             IEnumerable<HyperLiquidCancelRequest> requests, 
             string? vaultAddress = null,
             DateTime? expiresAfter = null,
@@ -523,8 +514,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             foreach (var order in requests)
             {
                 var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, order.Symbol).ConfigureAwait(false);
-                if (!symbolId)
-                    return new WebCallResult<CallResult[]>(symbolId.Error);
+                if (!symbolId.Success)
+                    return HttpResult.Fail<CallResult[]>(_baseClient.Exchange, symbolId.Error);
 
                 orderRequests.Add(new Parameters(HyperLiquidExchange._parameterSerializationSettings)
                     {
@@ -552,28 +543,28 @@ namespace HyperLiquid.Net.Clients.BaseApi
             _baseClient.AddExpiresAfter(parameters, expiresAfter);
 
             var weight = 1 + (int)Math.Floor(orderRequests.Count / 40m);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
             var resultInt = await _baseClient.SendAuthAsync<HyperLiquidCancelResult>(request, parameters, ct, weight).ConfigureAwait(false);
-            if (!resultInt)
-                return resultInt.AsError<CallResult[]>(resultInt.Error!);
+            if (!resultInt.Success)
+                return HttpResult.Fail<CallResult[]>(resultInt);
 
             var result = new List<CallResult>();
             foreach (var order in resultInt.Data.Statuses)
             {
                 if (order.Equals("success"))
-                    result.Add(CallResult.SuccessResult);
+                    result.Add(CallResult.Ok());
                 else
-                    result.Add(new CallResult(new ServerError(_baseClient.GetErrorInfo("Order", order))));
+                    result.Add(CallResult.Fail(new ServerError(_baseClient.GetErrorInfo("Order", order))));
             }
 
-            return resultInt.As<CallResult[]>(result.ToArray());
+            return HttpResult.Ok(resultInt, result.ToArray());
         }
 
         #endregion
 
         #region Cancel Order By Client Order Id
 
-        public async Task<WebCallResult> CancelOrderByClientOrderIdAsync(
+        public async Task<HttpResult> CancelOrderByClientOrderIdAsync(
             string symbol,
             string clientOrderId,
             string? vaultAddress,
@@ -581,14 +572,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
             CancellationToken ct = default)
         {
             var result = await CancelOrdersByClientOrderIdAsync([new HyperLiquidCancelByClientOrderIdRequest(symbol, clientOrderId)], vaultAddress, expiresAfter, ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsDataless();
+            if (!result.Success)
+                return result;
 
             var cancelResult = result.Data.Single();
-            if (!cancelResult)
-                return result.AsDatalessError(cancelResult.Error!);
+            if (!cancelResult.Success)
+                return HttpResult.Fail(_baseClient.Exchange, cancelResult.Error);
 
-            return result.AsDataless();
+            return result;
         }
 
         #endregion
@@ -596,7 +587,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Cancel Orders By Client Order Id
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CallResult[]>> CancelOrdersByClientOrderIdAsync(
+        public async Task<HttpResult<CallResult[]>> CancelOrdersByClientOrderIdAsync(
             IEnumerable<HyperLiquidCancelByClientOrderIdRequest> requests, 
             string? vaultAddress = null,
             DateTime? expiresAfter = null,
@@ -608,8 +599,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             foreach (var order in requests)
             {
                 var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, order.Symbol).ConfigureAwait(false);
-                if (!symbolId)
-                    return new WebCallResult<CallResult[]>(symbolId.Error);
+                if (!symbolId.Success)
+                    return HttpResult.Fail<CallResult[]>(_baseClient.Exchange, symbolId.Error);
 
                 orderRequests.Add(new Parameters(HyperLiquidExchange._parameterSerializationSettings)
                     {
@@ -637,21 +628,21 @@ namespace HyperLiquid.Net.Clients.BaseApi
             _baseClient.AddExpiresAfter(parameters, expiresAfter);
 
             var weight = 1 + (int)Math.Floor(orderRequests.Count / 40m);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
             var resultInt = await _baseClient.SendAuthAsync<HyperLiquidCancelResult>(request, parameters, ct, weight).ConfigureAwait(false);
-            if (!resultInt)
-                return resultInt.AsError<CallResult[]>(resultInt.Error!);
+            if (!resultInt.Success)
+                return HttpResult.Fail<CallResult[]>(resultInt);
 
             var result = new List<CallResult>();
             foreach (var order in resultInt.Data.Statuses)
             {
                 if (order.Equals("success"))
-                    result.Add(CallResult.SuccessResult);
+                    result.Add(CallResult.Ok());
                 else
-                    result.Add(new CallResult(new ServerError(_baseClient.GetErrorInfo("Order", order))));
+                    result.Add(CallResult.Fail(new ServerError(_baseClient.GetErrorInfo("Order", order))));
             }
 
-            return resultInt.As<CallResult[]>(result.ToArray());
+            return HttpResult.Ok<CallResult[]>(resultInt, result.ToArray());
         }
 
         #endregion
@@ -659,7 +650,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Cancel after
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidOrderStatus[]>> CancelAfterAsync(
+        public async Task<HttpResult<HyperLiquidOrderStatus[]>> CancelAfterAsync(
             TimeSpan? timeout,
             string? vaultAddress = null,
             DateTime? expiresAfter = null,
@@ -680,10 +671,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             _baseClient.AddExpiresAfter(parameters, expiresAfter);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
             var result = await _baseClient.SendAsync<HyperLiquidOrderStatus[]>(request, parameters, ct).ConfigureAwait(false);
-
-
             return result;
         }
 
@@ -692,7 +681,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Edit Order
 
         /// <inheritdoc />
-        public async Task<WebCallResult> EditOrderAsync(
+        public async Task<HttpResult> EditOrderAsync(
             string symbol,
             long? orderId,
             string? clientOrderId,
@@ -719,8 +708,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
             var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
-            if (!symbolId)
-                return new WebCallResult(symbolId.Error!);
+            if (!symbolId.Success)
+                return HttpResult.Fail(_baseClient.Exchange, symbolId.Error!);
 
             var orderParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
             orderParameters.Add("a", symbolId.Data);
@@ -769,9 +758,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             _baseClient.AddExpiresAfter(parameters, expiresAfter);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
-            var result = await _baseClient.SendAsync<HyperLiquidResponse>(request, parameters, ct).ConfigureAwait(false);
-            return result.AsDataless();
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
+            return await _baseClient.SendAsync<HyperLiquidResponse>(request, parameters, ct).ConfigureAwait(false);
         }
 
         #endregion
@@ -779,7 +767,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Edit Orders
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CallResult<HyperLiquidOrderResult>[]>> EditOrdersAsync(
+        public async Task<HttpResult<CallResult<HyperLiquidOrderResult>[]>> EditOrdersAsync(
             IEnumerable<HyperLiquidEditOrderRequest> requests,
             string? vaultAddress = null,
             DateTime? expiresAfter = null,
@@ -797,8 +785,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
                     throw new ArgumentException("Order type can't be market");
 
                 var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, order.Symbol).ConfigureAwait(false);
-                if (!symbolId)
-                    return new WebCallResult<CallResult<HyperLiquidOrderResult>[]>(symbolId.Error!);
+                if (!symbolId.Success)
+                    return HttpResult.Fail<CallResult<HyperLiquidOrderResult>[]>(_baseClient.Exchange, symbolId.Error!);
 
                 var modifyParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
                 modifyParameters.Add("oid", order.OrderId);
@@ -856,23 +844,23 @@ namespace HyperLiquid.Net.Clients.BaseApi
             _baseClient.AddExpiresAfter(parameters, expiresAfter);
 
             var weight = 1 + (int)Math.Floor(orderRequests.Count / 40m);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
             var intResult = await _baseClient.SendAuthAsync<HyperLiquidOrderResultIntWrapper>(request, parameters, ct, weight).ConfigureAwait(false);
-            if (!intResult)
-                return intResult.As<CallResult<HyperLiquidOrderResult>[]>(default);
+            if (!intResult.Success)
+                return HttpResult.Fail<CallResult<HyperLiquidOrderResult>[]>(intResult);
 
             var result = new List<CallResult<HyperLiquidOrderResult>>();
             foreach (var order in intResult.Data.Statuses)
             {
                 if (order.Error != null)
-                    result.Add(new CallResult<HyperLiquidOrderResult>(new ServerError(_baseClient.GetErrorInfo("Order", order.Error))));
+                    result.Add(CallResult.Fail<HyperLiquidOrderResult>(new ServerError(_baseClient.GetErrorInfo("Order", order.Error))));
                 else if (order.ResultResting != null)
-                    result.Add(new CallResult<HyperLiquidOrderResult>(order.ResultResting with { Status = OrderStatus.Open }));
+                    result.Add(CallResult.Ok<HyperLiquidOrderResult>(order.ResultResting with { Status = OrderStatus.Open }));
                 else
-                    result.Add(new CallResult<HyperLiquidOrderResult>(order.ResultFilled! with { Status = OrderStatus.Filled }));
+                    result.Add(CallResult.Ok<HyperLiquidOrderResult>(order.ResultFilled! with { Status = OrderStatus.Filled }));
             }
 
-            return intResult.As<CallResult<HyperLiquidOrderResult>[]>(result.ToArray());
+            return HttpResult.Ok<CallResult<HyperLiquidOrderResult>[]>(intResult, result.ToArray());
         }
 
         #endregion
@@ -880,7 +868,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Place TWAP order
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidTwapOrderResult>> PlaceTwapOrderAsync(
+        public async Task<HttpResult<HyperLiquidTwapOrderResult>> PlaceTwapOrderAsync(
             string symbol, 
             OrderSide orderSide, 
             decimal quantity, 
@@ -894,8 +882,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
             var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
-            if (!symbolId)
-                return new WebCallResult<HyperLiquidTwapOrderResult>(symbolId.Error);
+            if (!symbolId.Success)
+                return HttpResult.Fail<HyperLiquidTwapOrderResult>(_baseClient.Exchange, symbolId.Error);
 
             var orderParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
             orderParameters.Add("a", symbolId.Data);
@@ -920,15 +908,15 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             _baseClient.AddExpiresAfter(parameters, expiresAfter);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
             var result = await _baseClient.SendAuthAsync<HyperLiquidTwapOrderResultIntWrapper>(request, parameters, ct).ConfigureAwait(false);
-            if (!result)
-                return result.As<HyperLiquidTwapOrderResult>(default);
+            if (!result.Success)
+                return HttpResult.Fail<HyperLiquidTwapOrderResult>(result);
 
             if (result.Data.Status.Error != null)
-                return result.AsError<HyperLiquidTwapOrderResult>(new ServerError(_baseClient.GetErrorInfo("Order", result.Data.Status.Error)));
+                return HttpResult.Fail<HyperLiquidTwapOrderResult>(result, new ServerError(_baseClient.GetErrorInfo("Order", result.Data.Status.Error)));
 
-            return result.As(result.Data.Status.ResultRunning!);
+            return HttpResult.Ok(result, result.Data.Status.ResultRunning!);
         }
 
         #endregion
@@ -936,7 +924,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Cancel Twap Order
 
         /// <inheritdoc />
-        public async Task<WebCallResult> CancelTwapOrderAsync(
+        public async Task<HttpResult> CancelTwapOrderAsync(
             string symbol, 
             long twapId,
             string? vaultAddress = null,
@@ -946,8 +934,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
             var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
-            if (!symbolId)
-                return new WebCallResult(symbolId.Error!);
+            if (!symbolId.Success)
+                return HttpResult.Fail(_baseClient.Exchange, symbolId.Error!);
 
             var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
@@ -966,15 +954,15 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             _baseClient.AddExpiresAfter(parameters, expiresAfter);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
             var result = await _baseClient.SendAuthAsync<HyperLiquidTwapCancelResult>(request, parameters, ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsDataless();
+            if (!result.Success)
+                return result;
 
             if (result.Data.Status != "success")
-                return result.AsDatalessError(new ServerError(_baseClient.GetErrorInfo("Order", result.Data.Status)));
+                return HttpResult.Fail(result, new ServerError(_baseClient.GetErrorInfo("Order", result.Data.Status)));
 
-            return result.AsDataless();
+            return result;
         }
 
         #endregion

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiTrading.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiTrading.cs
@@ -697,6 +697,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
             TpSlGrouping? tpSlGrouping = null,
             string? vaultAddress = null,
             DateTime? expiresAfter = null,
+            bool? alwaysPlace = null,
             CancellationToken ct = default)
         {
             if ((orderId == null) == (clientOrderId == null))
@@ -751,6 +752,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             actionParameters.Add("oid", orderId);
             actionParameters.Add("oid", clientOrderId);
             actionParameters.Add("order", orderParameters);
+            if (alwaysPlace == true)
+                actionParameters.Add("a", alwaysPlace.Value);
             parameters.Add("action", actionParameters);
             
             if (vaultAddress != null)
@@ -771,6 +774,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
             IEnumerable<HyperLiquidEditOrderRequest> requests,
             string? vaultAddress = null,
             DateTime? expiresAfter = null,
+            bool? alwaysPlace = null,
             CancellationToken ct = default)
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
@@ -827,17 +831,18 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 orderRequests.Add(modifyParameters);
             }
 
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
+            {
+                { "type", "batchModify" },
+                { "modifies", orderRequests }
+            };
+            if (alwaysPlace == true)
+                actionParameters.Add("a", alwaysPlace.Value);
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
-                {
-                    "action", new Parameters(HyperLiquidExchange._parameterSerializationSettings)
-                    {
-                        { "type", "batchModify" },
-                        { "modifies", orderRequests }
-                    }
-                }
+                { "action", actionParameters }
             };
-            
+
             if (vaultAddress != null)
                 parameters.Add("vaultAddress", vaultAddress);
 

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiTrading.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiTrading.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using HyperLiquid.Net.Interfaces.Clients.BaseApi;
 using CryptoExchange.Net;
 using CryptoExchange.Net.Objects.Errors;
+using CryptoExchange.Net.Interfaces;
 
 namespace HyperLiquid.Net.Clients.BaseApi
 {
@@ -43,12 +44,12 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "openOrders" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key  }
             };
-            parameters.AddOptional("dex", dex);
+            parameters.Add("dex", dex);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             var result = await _baseClient.SendAsync<HyperLiquidOpenOrder[]>(request, parameters, ct).ConfigureAwait(false);
             if (!result)
@@ -87,12 +88,12 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "frontendOpenOrders" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
             };
-            parameters.AddOptional("dex", dex);
+            parameters.Add("dex", dex);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             var result = await _baseClient.SendAsync<HyperLiquidOrder[]>(request, parameters, ct).ConfigureAwait(false);
             if (!result)
@@ -131,7 +132,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "userFills" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
@@ -179,14 +180,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "userFillsByTime" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
             };
-            parameters.AddMilliseconds("startTime", startTime);
-            parameters.AddOptionalMilliseconds("endTime", endTime);
-            parameters.AddOptional("aggregateByTime", aggregateByTime);
+            parameters.Add("startTime", startTime);
+            parameters.Add("endTime", endTime);
+            parameters.Add("aggregateByTime", aggregateByTime);
 
             var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             var result = await _baseClient.SendAsync<HyperLiquidUserTrade[]>(request, parameters, ct).ConfigureAwait(false);
@@ -226,14 +227,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "orderStatus" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
             };
 
-            parameters.AddOptional("oid", orderId);
-            parameters.AddOptional("oid", clientOrderId);
+            parameters.Add("oid", orderId);
+            parameters.Add("oid", clientOrderId);
 
             var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
             var result = await _baseClient.SendAsync<HyperLiquidOrderStatusResult>(request, parameters, ct).ConfigureAwait(false);
@@ -273,7 +274,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "historicalOrders" },
                 { "user",  address ?? _baseClient.AuthenticationProvider!.Key }
@@ -356,26 +357,26 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var orderRequests = new List<ParameterCollection>();
+            var orderRequests = new List<Parameters>();
             foreach (var order in orders)
             {
                 var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, order.Symbol).ConfigureAwait(false);
                 if (!symbolId)
                     return new WebCallResult<CallResult<HyperLiquidOrderResult>[]>(symbolId.Error);
 
-                var orderParameters = new ParameterCollection();
+                var orderParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
                 orderParameters.Add("a", symbolId.Data);
                 orderParameters.Add("b", order.Side == OrderSide.Buy);
 
-                var orderTypeParameters = new ParameterCollection();                
+                var orderTypeParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);                
                 if (order.OrderType == OrderType.Limit)
                 {
-                    orderParameters.AddString("p", order.Price?.Normalize() ?? 0);
-                    orderParameters.AddString("s", order.Quantity.Normalize());
+                    orderParameters.Add("p", order.Price?.Normalize() ?? 0);
+                    orderParameters.Add("s", order.Quantity.Normalize());
                     orderParameters.Add("r", order.ReduceOnly ?? false);
-                    var limitParameters = new ParameterCollection();
-                    limitParameters.AddEnum("tif", order.TimeInForce ?? TimeInForce.GoodTillCanceled);
-                    orderTypeParameters.Add("limit", limitParameters);
+                    var limitParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+                    limitParameters.Add("tif", order.TimeInForce ?? TimeInForce.GoodTillCanceled);
+                    orderTypeParameters.AddRaw("limit", limitParameters);
                 }
                 else if (order.OrderType == OrderType.Market)
                 {
@@ -391,12 +392,12 @@ namespace HyperLiquid.Net.Clients.BaseApi
                     price = ExchangeHelpers.RoundToSignificantDigits(price, 5, RoundingType.Closest);
                     price = ExchangeHelpers.RoundDown(price, decimalMax - quantityDecimals.Data);
 
-                    orderParameters.AddString("p", price.Normalize());
-                    orderParameters.AddString("s", order.Quantity.Normalize());
+                    orderParameters.Add("p", price.Normalize());
+                    orderParameters.Add("s", order.Quantity.Normalize());
                     orderParameters.Add("r", order.ReduceOnly ?? false);
-                    var limitParameters = new ParameterCollection();
-                    limitParameters.AddEnum("tif", order.TimeInForce ?? TimeInForce.ImmediateOrCancel);
-                    orderTypeParameters.Add("limit", limitParameters);
+                    var limitParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+                    limitParameters.Add("tif", order.TimeInForce ?? TimeInForce.ImmediateOrCancel);
+                    orderTypeParameters.AddRaw("limit", limitParameters);
                 }
                 else
                 {
@@ -406,30 +407,28 @@ namespace HyperLiquid.Net.Clients.BaseApi
                     if (order.TpSlType == null)
                         throw new ArgumentNullException(nameof(order.TpSlType), "Stop order should have a TpSlType");
 
-                    orderParameters.AddString("p", order.Price?.Normalize() ?? 0);
-                    orderParameters.AddString("s", order.Quantity.Normalize());
+                    orderParameters.Add("p", order.Price?.Normalize() ?? 0);
+                    orderParameters.Add("s", order.Quantity.Normalize());
                     orderParameters.Add("r", order.ReduceOnly ?? false);
-                    var triggerParameters = new ParameterCollection();
+                    var triggerParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
                     triggerParameters.Add("isMarket", order.OrderType == OrderType.StopMarket);
-                    triggerParameters.AddString("triggerPx", order.TriggerPrice.Value.Normalize());
-                    triggerParameters.AddEnum("tpsl", order.TpSlType.Value);
-                    orderTypeParameters.Add("trigger", triggerParameters);
+                    triggerParameters.Add("triggerPx", order.TriggerPrice.Value.Normalize());
+                    triggerParameters.Add("tpsl", order.TpSlType.Value);
+                    orderTypeParameters.AddRaw("trigger", triggerParameters);
                 }
 
-                orderParameters.Add("t", orderTypeParameters);
-                orderParameters.AddOptional("c", order.ClientOrderId);
+                orderParameters.AddRaw("t", orderTypeParameters);
+                orderParameters.Add("c", order.ClientOrderId);
 
                 orderRequests.Add(orderParameters);
             }
 
-            var actionParameters = new ParameterCollection
-            {
-                { "type", "order" },
-                { "orders", orderRequests },
-            };
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+            actionParameters.Add("type", "order");
+            actionParameters.AddRaw("orders", orderRequests);
 
             if (tpSlGrouping != null)
-                actionParameters.AddEnum("grouping", tpSlGrouping.Value);
+                actionParameters.Add("grouping", tpSlGrouping.Value);
             else
                 actionParameters.Add("grouping", "na");
 
@@ -439,8 +438,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             {
                 // Convert from percentage to 1/10 basis point
                 var tenthPoints = (int)(_baseClient.ClientOptions.BuilderFeePercentage * 1000);
-                actionParameters.Add("builder",
-                    new ParameterCollection
+                actionParameters.AddRaw("builder",
+                    new Parameters(HyperLiquidExchange._parameterSerializationSettings)
                     {
                         { "b", _baseClient.ClientOptions.BuilderAddress.ToLower() },
                         { "f", tenthPoints }
@@ -448,7 +447,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 );
             }
 
-            var parameters = new Parameters(_parameterSerializationSettings);
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
             parameters.AddRaw("action", actionParameters);
 
             if (vaultAddress != null)
@@ -520,14 +519,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var orderRequests = new List<ParameterCollection>();
+            var orderRequests = new List<Parameters>();
             foreach (var order in requests)
             {
                 var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, order.Symbol).ConfigureAwait(false);
                 if (!symbolId)
                     return new WebCallResult<CallResult[]>(symbolId.Error);
 
-                orderRequests.Add(new ParameterCollection
+                orderRequests.Add(new Parameters(HyperLiquidExchange._parameterSerializationSettings)
                     {
                         { "a", symbolId.Data },
                         { "o", order.OrderId }
@@ -535,10 +534,10 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 );
             }
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 {
-                    "action", new ParameterCollection
+                    "action", new Parameters(HyperLiquidExchange._parameterSerializationSettings)
                     {
                         { "type", "cancel" },
                         { "cancels", orderRequests
@@ -605,14 +604,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var orderRequests = new List<ParameterCollection>();
+            var orderRequests = new List<Parameters>();
             foreach (var order in requests)
             {
                 var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, order.Symbol).ConfigureAwait(false);
                 if (!symbolId)
                     return new WebCallResult<CallResult[]>(symbolId.Error);
 
-                orderRequests.Add(new ParameterCollection
+                orderRequests.Add(new Parameters(HyperLiquidExchange._parameterSerializationSettings)
                     {
                         { "asset", symbolId.Data },
                         { "cloid", order.OrderId }
@@ -620,10 +619,10 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 );
             }
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 {
-                    "action", new ParameterCollection
+                    "action", new Parameters(HyperLiquidExchange._parameterSerializationSettings)
                     {
                         { "type", "cancelByCloid" },
                         { "cancels", orderRequests
@@ -668,12 +667,12 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection();
-            var actionParameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "scheduleCancel" }
             };
-            actionParameters.AddOptionalMilliseconds("time", timeout == null ? null : DateTime.UtcNow + timeout);
+            actionParameters.Add("time", timeout == null ? null : DateTime.UtcNow + timeout);
             parameters.Add("action", actionParameters);
             
             if (vaultAddress != null)
@@ -723,18 +722,18 @@ namespace HyperLiquid.Net.Clients.BaseApi
             if (!symbolId)
                 return new WebCallResult(symbolId.Error!);
 
-            var orderParameters = new ParameterCollection();
+            var orderParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
             orderParameters.Add("a", symbolId.Data);
             orderParameters.Add("b", side == OrderSide.Buy);
-            orderParameters.AddString("p", price.Normalize());
-            orderParameters.AddString("s", quantity.Normalize());
+            orderParameters.Add("p", price.Normalize());
+            orderParameters.Add("s", quantity.Normalize());
             orderParameters.Add("r", reduceOnly ?? false);
 
-            var orderTypeParameters = new ParameterCollection();            
+            var orderTypeParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);            
             if (orderType == OrderType.Limit)
             {
-                var limitParameters = new ParameterCollection();
-                limitParameters.AddEnum("tif", timeInForce ?? TimeInForce.GoodTillCanceled);
+                var limitParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+                limitParameters.Add("tif", timeInForce ?? TimeInForce.GoodTillCanceled);
                 orderTypeParameters.Add("limit", limitParameters);
             }
             else
@@ -745,23 +744,23 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 if (tpSlType == null)
                     throw new ArgumentNullException(nameof(tpSlType), "Stop order should have a TpSlType");
 
-                var triggerParameters = new ParameterCollection();
+                var triggerParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
                 triggerParameters.Add("isMarket", orderType == OrderType.StopMarket);
-                triggerParameters.AddString("triggerPx", triggerPrice.Value.Normalize());
-                triggerParameters.AddEnum("tpsl", tpSlType.Value);
+                triggerParameters.Add("triggerPx", triggerPrice.Value.Normalize());
+                triggerParameters.Add("tpsl", tpSlType.Value);
                 orderTypeParameters.Add("trigger", triggerParameters);
             }
 
             orderParameters.Add("t", orderTypeParameters);
-            orderParameters.AddOptional("c", newClientOrderId);
+            orderParameters.Add("c", newClientOrderId);
 
-            var parameters = new ParameterCollection();
-            var actionParameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "modify" }
             };
-            actionParameters.AddOptional("oid", orderId);
-            actionParameters.AddOptional("oid", clientOrderId);
+            actionParameters.Add("oid", orderId);
+            actionParameters.Add("oid", clientOrderId);
             actionParameters.Add("order", orderParameters);
             parameters.Add("action", actionParameters);
             
@@ -788,7 +787,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var orderRequests = new List<ParameterCollection>();
+            var orderRequests = new List<Parameters>();
             foreach (var order in requests)
             {
                 if ((order.OrderId == null) == (order.ClientOrderId == null))
@@ -801,21 +800,21 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 if (!symbolId)
                     return new WebCallResult<CallResult<HyperLiquidOrderResult>[]>(symbolId.Error!);
 
-                var modifyParameters = new ParameterCollection();
-                modifyParameters.AddOptional("oid", order.OrderId);
-                modifyParameters.AddOptional("oid", order.ClientOrderId);
-                var orderParameters = new ParameterCollection();
+                var modifyParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+                modifyParameters.Add("oid", order.OrderId);
+                modifyParameters.Add("oid", order.ClientOrderId);
+                var orderParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
                 orderParameters.Add("a", symbolId.Data);
                 orderParameters.Add("b", order.Side == OrderSide.Buy);
-                orderParameters.AddString("p", order.Price.Normalize());
-                orderParameters.AddString("s", order.Quantity.Normalize());
+                orderParameters.Add("p", order.Price.Normalize());
+                orderParameters.Add("s", order.Quantity.Normalize());
                 orderParameters.Add("r", order.ReduceOnly ?? false);
 
-                var orderTypeParameters = new ParameterCollection();
+                var orderTypeParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
                 if (order.OrderType is OrderType.Limit or OrderType.Market)
                 {
-                    var limitParameters = new ParameterCollection();
-                    limitParameters.AddEnum("tif", order.OrderType == OrderType.Market ? TimeInForce.ImmediateOrCancel : order.TimeInForce ?? TimeInForce.GoodTillCanceled);
+                    var limitParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+                    limitParameters.Add("tif", order.OrderType == OrderType.Market ? TimeInForce.ImmediateOrCancel : order.TimeInForce ?? TimeInForce.GoodTillCanceled);
                     orderTypeParameters.Add("limit", limitParameters);
                 }
                 else
@@ -826,25 +825,24 @@ namespace HyperLiquid.Net.Clients.BaseApi
                     if (order.TpSlType == null)
                         throw new ArgumentNullException(nameof(order.TpSlType), "Stop order should have a TpSlType");
 
-                    var triggerParameters = new ParameterCollection();
+                    var triggerParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
                     triggerParameters.Add("isMarket", order.OrderType == OrderType.StopMarket);
-                    triggerParameters.AddString("triggerPx", order.TriggerPrice.Value.Normalize());
-                    triggerParameters.AddEnum("tpsl", order.TpSlType.Value);
+                    triggerParameters.Add("triggerPx", order.TriggerPrice.Value.Normalize());
+                    triggerParameters.Add("tpsl", order.TpSlType.Value);
                     orderTypeParameters.Add("trigger", triggerParameters);
                 }
 
                 orderParameters.Add("t", orderTypeParameters);
-
-                orderParameters.AddOptional("c", order.ClientOrderId);
+                orderParameters.Add("c", order.ClientOrderId);
 
                 modifyParameters.Add("order", orderParameters);
                 orderRequests.Add(modifyParameters);
             }
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 {
-                    "action", new ParameterCollection
+                    "action", new Parameters(HyperLiquidExchange._parameterSerializationSettings)
                     {
                         { "type", "batchModify" },
                         { "modifies", orderRequests }
@@ -899,20 +897,20 @@ namespace HyperLiquid.Net.Clients.BaseApi
             if (!symbolId)
                 return new WebCallResult<HyperLiquidTwapOrderResult>(symbolId.Error);
 
-            var orderParameters = new ParameterCollection();
+            var orderParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
             orderParameters.Add("a", symbolId.Data);
             orderParameters.Add("b", orderSide == OrderSide.Buy);
-            orderParameters.AddString("s", quantity.Normalize());
+            orderParameters.Add("s", quantity.Normalize());
             orderParameters.Add("r", reduceOnly);
             orderParameters.Add("m", minutes);
             orderParameters.Add("t", randomize);
 
-            var actionParameters = new ParameterCollection()
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "twapOrder" },
                 { "twap", orderParameters }
             };
-            var parameters = new ParameterCollection
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "action", actionParameters }
             };
@@ -951,14 +949,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
             if (!symbolId)
                 return new WebCallResult(symbolId.Error!);
 
-            var actionParameters = new ParameterCollection()
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "twapCancel" },
                 { "a", symbolId.Data },
                 { "t", twapId }
             };
 
-            var parameters = new ParameterCollection
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "action", actionParameters }
             };

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiTrading.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiTrading.cs
@@ -142,7 +142,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 if (HyperLiquidUtils.ExchangeSymbolIsSpotSymbol(order.ExchangeSymbol))
                 {
                     var symbolName = await HyperLiquidUtils.GetSymbolNameFromExchangeNameAsync(_baseClient.BaseClient, order.ExchangeSymbol).ConfigureAwait(false);
-                    if (symbolName == null)
+                    if (!symbolName.Success)
                         continue;
 
                     order.Symbol = symbolName.Data;
@@ -194,7 +194,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 if (HyperLiquidUtils.ExchangeSymbolIsSpotSymbol(order.ExchangeSymbol))
                 {
                     var symbolName = await HyperLiquidUtils.GetSymbolNameFromExchangeNameAsync(_baseClient.BaseClient, order.ExchangeSymbol).ConfigureAwait(false);
-                    if (symbolName == null)
+                    if (!symbolName.Success)
                         continue;
 
                     order.Symbol = symbolName.Data;

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApi.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApi.cs
@@ -41,11 +41,11 @@ namespace HyperLiquid.Net.Clients.BaseApi
         /// ctor
         /// </summary>
         internal HyperLiquidSocketClientApi(
-            ILogger logger,
+            ILoggerFactory? loggerFactory,
             HyperLiquidSocketClient baseClient,
             HyperLiquidSocketOptions options,
             SocketApiOptions apiOptions) :
-            base(logger, HyperLiquidExchange.Metadata.Id, options.Environment.SocketClientAddress!, options, apiOptions)
+            base(loggerFactory, HyperLiquidExchange.Metadata.Id, options.Environment.SocketClientAddress!, options, apiOptions)
         {
             BaseClient = baseClient;
 

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApi.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApi.cs
@@ -45,7 +45,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
             HyperLiquidSocketClient baseClient,
             HyperLiquidSocketOptions options,
             SocketApiOptions apiOptions) :
-            base(logger, options.Environment.SocketClientAddress!, options, apiOptions)
+            base(logger, HyperLiquidExchange.Metadata.Id, options.Environment.SocketClientAddress!, options, apiOptions)
         {
             BaseClient = baseClient;
 
@@ -76,10 +76,10 @@ namespace HyperLiquid.Net.Clients.BaseApi
         protected override HyperLiquidAuthenticationProvider CreateAuthenticationProvider(HyperLiquidCredentials credentials)
             => new HyperLiquidAuthenticationProvider(credentials);
 
-        internal Task<CallResult<UpdateSubscription>> SubscribeInternalAsync(Subscription subscription, CancellationToken ct)
+        internal Task<WebSocketResult<UpdateSubscription>> SubscribeInternalAsync(Subscription subscription, CancellationToken ct)
             => base.SubscribeAsync(BaseAddress.AppendPath("ws"), subscription, ct);
 
-        internal Task<CallResult<T>> QueryInternalAsync<T>(Query<T> query, CancellationToken ct)
+        internal Task<QueryResult<T>> QueryInternalAsync<T>(Query<T> query, CancellationToken ct)
             => base.QueryAsync<T>(BaseAddress.AppendPath("ws"), query, ct);
 
         internal void AddExpiresAfter(Parameters parameters, DateTime? requestExpiresAfter)

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApi.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApi.cs
@@ -82,7 +82,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         internal Task<CallResult<T>> QueryInternalAsync<T>(Query<T> query, CancellationToken ct)
             => base.QueryAsync<T>(BaseAddress.AppendPath("ws"), query, ct);
 
-        internal void AddExpiresAfter(ParameterCollection parameters, DateTime? requestExpiresAfter)
+        internal void AddExpiresAfter(Parameters parameters, DateTime? requestExpiresAfter)
         {
             if (requestExpiresAfter != null)
                 parameters.Add("expiresAfter", DateTimeConverter.ConvertToMilliseconds(requestExpiresAfter));

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiAccount.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiAccount.cs
@@ -20,12 +20,6 @@ namespace HyperLiquid.Net.Clients.BaseApi
 {
     internal partial class HyperLiquidSocketClientApiAccount : IHyperLiquidSocketClientApiAccount
     {
-        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
-        {
-            Decimal = DecimalSerialization.String,
-            Sort = false
-        };
-
         protected internal readonly HyperLiquidSocketClientApi _baseClient;
         protected readonly ILogger _logger;
 
@@ -99,9 +93,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             actionParameters.Add("nonce", DateTime.UtcNow);
             parameters.Add("action", actionParameters);
 
-            var result = await _baseClient.QueryInternalAsync(
+            return await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidDefault>(_baseClient, "post", "action", parameters, true), ct).ConfigureAwait(false);
-            return result.AsDataless();
         }
 
         #endregion
@@ -192,9 +185,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             actionParameters.Add("time", DateTime.UtcNow);
             parameters.Add("action", actionParameters);
 
-            var result = await _baseClient.QueryInternalAsync(
+            return await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidDefault>(_baseClient, "post", "action", parameters, true), ct).ConfigureAwait(false);
-            return result.AsDataless();
         }
 
         #endregion
@@ -219,9 +211,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             actionParameters.Add("time", DateTime.UtcNow);
             parameters.Add("action", actionParameters);
 
-            var result = await _baseClient.QueryInternalAsync(
+            return await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidDefault>(_baseClient, "post", "action", parameters, true), ct).ConfigureAwait(false);
-            return result.AsDataless();
         }
 
         #endregion
@@ -252,9 +243,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             actionParameters.Add("nonce", DateTime.UtcNow);
             parameters.Add("action", actionParameters);
 
-            var result = await _baseClient.QueryInternalAsync(
+           return await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidDefault>(_baseClient, "post", "action", parameters, true), ct).ConfigureAwait(false);
-            return result.AsDataless();
         }
 
         #endregion
@@ -275,9 +265,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             };
             parameters.Add("nonce", DateTime.UtcNow);
 
-            var result = await _baseClient.QueryInternalAsync(
+            return await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidDefault>(_baseClient, "post", "action", parameters, true), ct).ConfigureAwait(false);
-            return result.AsDataless();
         }
 
         #endregion
@@ -298,9 +287,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             };
             parameters.Add("nonce", DateTime.UtcNow);
 
-            var result = await _baseClient.QueryInternalAsync(
+            return await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidDefault>(_baseClient, "post", "action", parameters, true), ct).ConfigureAwait(false);
-            return result.AsDataless();
         }
 
         #endregion
@@ -321,9 +309,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             };
             parameters.Add("nonce", DateTime.UtcNow);
 
-            var result = await _baseClient.QueryInternalAsync(
+            return await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidDefault>(_baseClient, "post", "action", parameters, true), ct).ConfigureAwait(false);
-            return result.AsDataless();
         }
 
         #endregion
@@ -351,9 +338,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             _baseClient.AddExpiresAfter(parameters, expiresAfter);
 
-            var result = await _baseClient.QueryInternalAsync(
+            return await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidDefault>(_baseClient, "post", "action", parameters, true), ct).ConfigureAwait(false);
-            return result.AsDataless();
         }
 
         #endregion
@@ -385,9 +371,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 }
             };
 
-            var result = await _baseClient.QueryInternalAsync(
+            return await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidDefault>(_baseClient, "post", "action", parameters, true), ct).ConfigureAwait(false);
-            return result.AsDataless();
         }
 
         #endregion
@@ -406,11 +391,11 @@ namespace HyperLiquid.Net.Clients.BaseApi
             };
             var result = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidSubAccount[]>(_baseClient, "post", "info", parameters, false), ct).ConfigureAwait(false);
-            if (!result)
+            if (!result.Success)
                 return result;
 
             if (result.Data == null)
-                return result.As(new HyperLiquidSubAccount[0]);
+                return QueryResult.Ok(result, new HyperLiquidSubAccount[0]);
 
             return result;
         }

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiAccount.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiAccount.cs
@@ -20,6 +20,12 @@ namespace HyperLiquid.Net.Clients.BaseApi
 {
     internal partial class HyperLiquidSocketClientApiAccount : IHyperLiquidSocketClientApiAccount
     {
+        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
+        {
+            Decimal = DecimalSerialization.String,
+            Sort = false
+        };
+
         protected internal readonly HyperLiquidSocketClientApi _baseClient;
         protected readonly ILogger _logger;
 
@@ -48,7 +54,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "userFees" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
@@ -76,8 +82,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection();
-            var actionParameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "sendAsset" },
                 { "hyperliquidChain", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? "Testnet" : "Mainnet" },
@@ -88,9 +94,9 @@ namespace HyperLiquid.Net.Clients.BaseApi
             actionParameters.Add("sourceDex", sourceDex);
             actionParameters.Add("destinationDex", destinationDex);
             actionParameters.Add("token", $"{tokenName}:{tokenId}");
-            actionParameters.AddString("amount", quantity);
+            actionParameters.Add("amount", quantity);
             actionParameters.Add("fromSubAccount", fromSubAccount ?? string.Empty);
-            actionParameters.AddMilliseconds("nonce", DateTime.UtcNow);
+            actionParameters.Add("nonce", DateTime.UtcNow);
             parameters.Add("action", actionParameters);
 
             var result = await _baseClient.QueryInternalAsync(
@@ -110,13 +116,13 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "userNonFundingLedgerUpdates" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
             };
-            parameters.AddMilliseconds("startTime", startTime);
-            parameters.AddOptionalMilliseconds("endTime", endTime);
+            parameters.Add("startTime", startTime);
+            parameters.Add("endTime", endTime);
 
             var result = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidAccountLedger>(_baseClient, "post", "info", parameters, false), ct).ConfigureAwait(false);
@@ -135,7 +141,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "userRateLimit" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
@@ -153,7 +159,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         /// <inheritdoc />
         public async Task<CallResult<int>> GetApprovedBuilderFeeAsync(string? builderAddress = null, string? address = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "maxBuilderFee" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key },
@@ -174,16 +180,16 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection();
-            var actionParameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "usdSend" },
                 { "hyperliquidChain", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? "Testnet" : "Mainnet" },
                 { "signatureChainId", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? _chainIdTestnet : _chainIdMainnet },
                 { "destination", destinationAddress }
             };
-            actionParameters.AddString("amount", quantity);
-            actionParameters.AddMilliseconds("time", DateTime.UtcNow);
+            actionParameters.Add("amount", quantity);
+            actionParameters.Add("time", DateTime.UtcNow);
             parameters.Add("action", actionParameters);
 
             var result = await _baseClient.QueryInternalAsync(
@@ -201,16 +207,16 @@ namespace HyperLiquid.Net.Clients.BaseApi
             decimal quantity,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            var actionParameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "withdraw3" },
                 { "hyperliquidChain", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? "Testnet" : "Mainnet" },
                 { "signatureChainId", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? _chainIdTestnet : _chainIdMainnet },
                 { "destination", destinationAddress },
             };
-            actionParameters.AddString("amount", quantity);
-            actionParameters.AddMilliseconds("time", DateTime.UtcNow);
+            actionParameters.Add("amount", quantity);
+            actionParameters.Add("time", DateTime.UtcNow);
             parameters.Add("action", actionParameters);
 
             var result = await _baseClient.QueryInternalAsync(
@@ -231,8 +237,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection();
-            var actionParameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "usdClassTransfer" },
                 { "hyperliquidChain", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? "Testnet" : "Mainnet" },
@@ -243,7 +249,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 quantityField += " subaccount:" + subAccount;
             actionParameters.Add("amount", quantityField);
             actionParameters.Add("toPerp", direction == TransferDirection.SpotToFutures);
-            actionParameters.AddMilliseconds("nonce", DateTime.UtcNow);
+            actionParameters.Add("nonce", DateTime.UtcNow);
             parameters.Add("action", actionParameters);
 
             var result = await _baseClient.QueryInternalAsync(
@@ -260,14 +266,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "cDeposit" },
                 { "hyperliquidChain", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? "Testnet" : "Mainnet" },
                 { "signatureChainId", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? _chainIdTestnet : _chainIdMainnet },
                 { "wei", wei }
             };
-            parameters.AddMilliseconds("nonce", DateTime.UtcNow);
+            parameters.Add("nonce", DateTime.UtcNow);
 
             var result = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidDefault>(_baseClient, "post", "action", parameters, true), ct).ConfigureAwait(false);
@@ -283,14 +289,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "cWithdraw" },
                 { "hyperliquidChain", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? "Testnet" : "Mainnet" },
                 { "signatureChainId", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? _chainIdTestnet : _chainIdMainnet },
                 { "wei", wei }
             };
-            parameters.AddMilliseconds("nonce", DateTime.UtcNow);
+            parameters.Add("nonce", DateTime.UtcNow);
 
             var result = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidDefault>(_baseClient, "post", "action", parameters, true), ct).ConfigureAwait(false);
@@ -306,14 +312,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "tokenDelegate" },
                 { "validator", validator },
                 { "isUndelegate", direction == DelegateDirection.Undelegate },
                 { "wei", wei }
             };
-            parameters.AddMilliseconds("nonce", DateTime.UtcNow);
+            parameters.Add("nonce", DateTime.UtcNow);
 
             var result = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidDefault>(_baseClient, "post", "action", parameters, true), ct).ConfigureAwait(false);
@@ -334,14 +340,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "vaultTransfer" },
                 { "vaultAddress", vaultAddress },
                 { "isDeposit", direction == DepositWithdrawDirection.Deposit },
                 { "usd", usd }
             };
-            parameters.AddMilliseconds("nonce", DateTime.UtcNow);
+            parameters.Add("nonce", DateTime.UtcNow);
 
             _baseClient.AddExpiresAfter(parameters, expiresAfter);
 
@@ -362,7 +368,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         public async Task<CallResult> ApproveBuilderFeeAsync(string builderAddress, decimal maxFeePercentage, CancellationToken ct = default)
         {
             // NOTE; order of the parameters matters
-            var actionParameters = new ParameterCollection()
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "hyperliquidChain", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? "Testnet" : "Mainnet" },
                 { "maxFeeRate", $"{maxFeePercentage.ToString(CultureInfo.InvariantCulture)}%" },
@@ -372,7 +378,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 { "type", "approveBuilderFee" },
             };
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 {
                     "action", actionParameters
@@ -393,7 +399,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "subAccounts" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
@@ -418,7 +424,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "userRole" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
@@ -437,7 +443,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "extraAgents" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
@@ -458,7 +464,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "delegations" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
@@ -479,7 +485,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "delegatorSummary" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
@@ -500,7 +506,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "delegatorHistory" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
@@ -521,7 +527,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
             
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "delegatorRewards" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiAccount.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiAccount.cs
@@ -47,7 +47,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get Trading Fee
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidFeeInfo>> GetFeeInfoAsync(string? address = null, CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidFeeInfo>> GetFeeInfoAsync(string? address = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -70,7 +70,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Send Asset
 
         /// <inheritdoc />
-        public async Task<CallResult> SendAssetAsync(
+        public async Task<QueryResult> SendAssetAsync(
             string destination,
             string sourceDex,
             string destinationDex,
@@ -109,7 +109,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get Account Ledger
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidAccountLedger>> GetAccountLedgerAsync(DateTime startTime, DateTime? endTime = null, string? address = null, CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidAccountLedger>> GetAccountLedgerAsync(DateTime startTime, DateTime? endTime = null, string? address = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -134,7 +134,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get Rate Limits
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidRateLimit>> GetRateLimitsAsync(string? address = null, CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidRateLimit>> GetRateLimitsAsync(string? address = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -157,7 +157,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get Approved Builder Fee
 
         /// <inheritdoc />
-        public async Task<CallResult<int>> GetApprovedBuilderFeeAsync(string? builderAddress = null, string? address = null, CancellationToken ct = default)
+        public async Task<QueryResult<int>> GetApprovedBuilderFeeAsync(string? builderAddress = null, string? address = null, CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
@@ -176,7 +176,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Transfer USD
 
         /// <inheritdoc />
-        public async Task<CallResult> TransferUsdAsync(string destinationAddress, decimal quantity, CancellationToken ct = default)
+        public async Task<QueryResult> TransferUsdAsync(string destinationAddress, decimal quantity, CancellationToken ct = default)
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
@@ -202,7 +202,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Withdraw
 
         /// <inheritdoc />
-        public async Task<CallResult> WithdrawAsync(
+        public async Task<QueryResult> WithdrawAsync(
             string destinationAddress,
             decimal quantity,
             CancellationToken ct = default)
@@ -229,7 +229,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Transfer Internal
 
         /// <inheritdoc />
-        public async Task<CallResult> TransferInternalAsync(
+        public async Task<QueryResult> TransferInternalAsync(
             TransferDirection direction,
             decimal quantity,
             string? subAccount = null,
@@ -262,7 +262,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Deposit Into Staking
 
         /// <inheritdoc />
-        public async Task<CallResult> DepositIntoStakingAsync(long wei, CancellationToken ct = default)
+        public async Task<QueryResult> DepositIntoStakingAsync(long wei, CancellationToken ct = default)
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
@@ -285,7 +285,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Withdraw From Staking
 
         /// <inheritdoc />
-        public async Task<CallResult> WithdrawFromStakingAsync(long wei, CancellationToken ct = default)
+        public async Task<QueryResult> WithdrawFromStakingAsync(long wei, CancellationToken ct = default)
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
@@ -308,7 +308,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Delegate Or Undelegate Stake
 
         /// <inheritdoc />
-        public async Task<CallResult> DelegateOrUndelegateStakeFromValidatorAsync(DelegateDirection direction, string validator, long wei, CancellationToken ct = default)
+        public async Task<QueryResult> DelegateOrUndelegateStakeFromValidatorAsync(DelegateDirection direction, string validator, long wei, CancellationToken ct = default)
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
@@ -331,7 +331,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Deposit Or Withdraw From Vault
 
         /// <inheritdoc />
-        public async Task<CallResult> DepositOrWithdrawFromVaultAsync(
+        public async Task<QueryResult> DepositOrWithdrawFromVaultAsync(
             DepositWithdrawDirection direction,
             string vaultAddress,
             long usd,
@@ -361,11 +361,11 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Approve Builder Fee
 
         /// <inheritdoc />
-        public Task<CallResult> ApproveBuilderFeeAsync(CancellationToken ct = default)
+        public Task<QueryResult> ApproveBuilderFeeAsync(CancellationToken ct = default)
             => ApproveBuilderFeeAsync(_baseClient.ClientOptions.BuilderAddress, _baseClient.ClientOptions.BuilderFeePercentage ?? 0.1m);
 
         /// <inheritdoc />
-        public async Task<CallResult> ApproveBuilderFeeAsync(string builderAddress, decimal maxFeePercentage, CancellationToken ct = default)
+        public async Task<QueryResult> ApproveBuilderFeeAsync(string builderAddress, decimal maxFeePercentage, CancellationToken ct = default)
         {
             // NOTE; order of the parameters matters
             var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
@@ -395,7 +395,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get Sub account list
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidSubAccount[]>> GetSubAccountsAsync(string? address = null, CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidSubAccount[]>> GetSubAccountsAsync(string? address = null, CancellationToken ct = default)
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
@@ -420,7 +420,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get User Role
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidUserRole>> GetUserRoleAsync(string? address = null, CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidUserRole>> GetUserRoleAsync(string? address = null, CancellationToken ct = default)
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
@@ -439,7 +439,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get Extra Agents
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidUserAgent[]>> GetExtraAgentsAsync(string? address = null, CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidUserAgent[]>> GetExtraAgentsAsync(string? address = null, CancellationToken ct = default)
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
@@ -457,7 +457,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
         #region Get Staking Delegations
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidStakingDelegation[]>> GetStakingDelegationsAsync(string? address = null, CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidStakingDelegation[]>> GetStakingDelegationsAsync(string? address = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -478,7 +478,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
         #region Get Staking Summary
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidStakingSummary>> GetStakingSummaryAsync(string? address = null, CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidStakingSummary>> GetStakingSummaryAsync(string? address = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -499,7 +499,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
         #region Get Staking History
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidStakingHistory[]>> GetStakingHistoryAsync(string? address = null, CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidStakingHistory[]>> GetStakingHistoryAsync(string? address = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -520,7 +520,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
         #region Get Staking Rewards
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidStakingReward[]>> GetStakingRewardsAsync(string? address = null, CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidStakingReward[]>> GetStakingRewardsAsync(string? address = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -540,7 +540,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #endregion
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToUserLedgerUpdatesAsync(string? address, Action<DataEvent<HyperLiquidAccountLedger>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToUserLedgerUpdatesAsync(string? address, Action<DataEvent<HyperLiquidAccountLedger>> onMessage, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -566,7 +566,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToUserUpdatesAsync(string? address, Action<DataEvent<HyperLiquidUserUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToUserUpdatesAsync(string? address, Action<DataEvent<HyperLiquidUserUpdate>> onMessage, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -595,7 +595,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToWebData3UpdatesAsync(string? address, Action<DataEvent<HyperLiquidWebDataV3Update>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToWebData3UpdatesAsync(string? address, Action<DataEvent<HyperLiquidWebDataV3Update>> onMessage, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -624,7 +624,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToUserEventUpdatesAsync(
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToUserEventUpdatesAsync(
             string? address,
             Action<DataEvent<HyperLiquidUserTrade[]>>? onTradeUpdate = null,
             Action<DataEvent<HyperLiquidUserFunding>>? onFundingUpdate = null,

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiExchangeData.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiExchangeData.cs
@@ -20,12 +20,6 @@ namespace HyperLiquid.Net.Clients.BaseApi
 {
     internal partial class HyperLiquidSocketClientApiExchangeData : IHyperLiquidSocketClientApiExchangeData
     {
-        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
-        {
-            Decimal = DecimalSerialization.String,
-            Sort = false
-        };
-
         protected readonly HyperLiquidSocketClientApi _baseClient;
         protected readonly ILogger _logger;
 
@@ -52,6 +46,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             };
             parameters.Add("dex", dex);
             var result = await _baseClient.QueryInternalAsync(new HyperLiquidRequestQuery<Dictionary<string, decimal>>(_baseClient, "post", "info", parameters, false), ct).ConfigureAwait(false);
+            if (!result.Success)
+                return QueryResult.Fail<Dictionary<string, decimal>>(result);
 
             var resultMapped = new Dictionary<string, decimal>();
             foreach (var item in result.Data)
@@ -60,7 +56,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 resultMapped.Add(nameRes.Data ?? item.Key, item.Value);
             }
 
-            return result.As(resultMapped);
+            return QueryResult.Ok(result, resultMapped);
         }
 
         #endregion
@@ -75,8 +71,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             {
                 // Spot symbol
                 var spotName = await HyperLiquidUtils.GetExchangeNameFromSymbolNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
-                if (!spotName)
-                    return new HttpResult<HyperLiquidOrderBook>(spotName.Error);
+                if (!spotName.Success)
+                    return QueryResult.Fail<HyperLiquidOrderBook>(_baseClient.Exchange, spotName.Error);
 
                 coin = spotName.Data;
             }
@@ -106,8 +102,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             {
                 // Spot symbol
                 var spotName = await HyperLiquidUtils.GetExchangeNameFromSymbolNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
-                if (!spotName)
-                    return new HttpResult<HyperLiquidKline[]>(spotName.Error);
+                if (!spotName.Success)
+                    return QueryResult.Fail<HyperLiquidKline[]>(_baseClient.Exchange, spotName.Error);
 
                 coin = spotName.Data;
             }
@@ -141,8 +137,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
         public async Task<WebSocketResult<UpdateSubscription>> SubscribeToPriceUpdatesAsync(string? dex, Action<DataEvent<Dictionary<string, decimal>>> onMessage, CancellationToken ct = default)
         {
             var result = await HyperLiquidUtils.UpdateSpotSymbolInfoAsync(_baseClient.BaseClient).ConfigureAwait(false);
-            if (!result)
-                return new CallResult<UpdateSubscription>(result.Error!);
+            if (!result.Success)
+                return WebSocketResult.Fail<UpdateSubscription>(_baseClient.Exchange, result.Error!);
 
             var internalHandler = new Action<DateTime, string?, int, HyperLiquidSocketUpdate<HyperLiquidMidsUpdate>>((receiveTime, originalData, invocations, data) =>
             {
@@ -178,8 +174,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             {
                 // Spot symbol
                 var spotName = await HyperLiquidUtils.GetExchangeNameFromSymbolNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
-                if (!spotName)
-                    return new HttpResult<UpdateSubscription>(spotName.Error);
+                if (!spotName.Success)
+                    return WebSocketResult.Fail<UpdateSubscription>(_baseClient.Exchange, spotName.Error);
 
                 coin = spotName.Data;
             }
@@ -213,8 +209,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             {
                 // Spot symbol
                 var spotName = await HyperLiquidUtils.GetExchangeNameFromSymbolNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
-                if (!spotName)
-                    return new HttpResult<UpdateSubscription>(spotName.Error);
+                if (!spotName.Success)
+                    return WebSocketResult.Fail<UpdateSubscription>(_baseClient.Exchange, spotName.Error);
 
                 coin = spotName.Data;
             }
@@ -253,8 +249,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             {
                 // Spot symbol
                 var spotName = await HyperLiquidUtils.GetExchangeNameFromSymbolNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
-                if (!spotName)
-                    return new HttpResult<UpdateSubscription>(spotName.Error);
+                if (!spotName.Success)
+                    return WebSocketResult.Fail<UpdateSubscription>(_baseClient.Exchange, spotName.Error);
 
                 coin = spotName.Data;
             }
@@ -293,8 +289,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             {
                 // Spot symbol
                 var spotName = await HyperLiquidUtils.GetExchangeNameFromSymbolNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
-                if (!spotName)
-                    return new HttpResult<UpdateSubscription>(spotName.Error);
+                if (!spotName.Success)
+                    return WebSocketResult.Fail<UpdateSubscription>(_baseClient.Exchange, spotName.Error);
 
                 coin = spotName.Data;
             }

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiExchangeData.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiExchangeData.cs
@@ -44,7 +44,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get Prices
 
         /// <inheritdoc />
-        public async Task<CallResult<Dictionary<string, decimal>>> GetPricesAsync(string? dex = null, CancellationToken ct = default)
+        public async Task<QueryResult<Dictionary<string, decimal>>> GetPricesAsync(string? dex = null, CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
@@ -68,7 +68,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get Order Book
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidOrderBook>> GetOrderBookAsync(string symbol, int? numberSignificantFigures = null, int? mantissa = null, CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidOrderBook>> GetOrderBookAsync(string symbol, int? numberSignificantFigures = null, int? mantissa = null, CancellationToken ct = default)
         {
             var coin = symbol;
             if (HyperLiquidUtils.SymbolIsExchangeSpotSymbol(coin))
@@ -76,7 +76,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 // Spot symbol
                 var spotName = await HyperLiquidUtils.GetExchangeNameFromSymbolNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
                 if (!spotName)
-                    return new WebCallResult<HyperLiquidOrderBook>(spotName.Error);
+                    return new HttpResult<HyperLiquidOrderBook>(spotName.Error);
 
                 coin = spotName.Data;
             }
@@ -99,7 +99,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get Klines
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidKline[]>> GetKlinesAsync(string symbol, KlineInterval interval, DateTime startTime, DateTime endTime, CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidKline[]>> GetKlinesAsync(string symbol, KlineInterval interval, DateTime startTime, DateTime endTime, CancellationToken ct = default)
         {
             var coin = symbol;
             if (HyperLiquidUtils.SymbolIsExchangeSpotSymbol(coin))
@@ -107,7 +107,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 // Spot symbol
                 var spotName = await HyperLiquidUtils.GetExchangeNameFromSymbolNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
                 if (!spotName)
-                    return new WebCallResult<HyperLiquidKline[]>(spotName.Error);
+                    return new HttpResult<HyperLiquidKline[]>(spotName.Error);
 
                 coin = spotName.Data;
             }
@@ -134,11 +134,11 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #endregion
 
         /// <inheritdoc />
-        public Task<CallResult<UpdateSubscription>> SubscribeToPriceUpdatesAsync(Action<DataEvent<Dictionary<string, decimal>>> onMessage, CancellationToken ct = default)
+        public Task<WebSocketResult<UpdateSubscription>> SubscribeToPriceUpdatesAsync(Action<DataEvent<Dictionary<string, decimal>>> onMessage, CancellationToken ct = default)
             => SubscribeToPriceUpdatesAsync(null, onMessage, ct);
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToPriceUpdatesAsync(string? dex, Action<DataEvent<Dictionary<string, decimal>>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToPriceUpdatesAsync(string? dex, Action<DataEvent<Dictionary<string, decimal>>> onMessage, CancellationToken ct = default)
         {
             var result = await HyperLiquidUtils.UpdateSpotSymbolInfoAsync(_baseClient.BaseClient).ConfigureAwait(false);
             if (!result)
@@ -171,7 +171,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, KlineInterval interval, Action<DataEvent<HyperLiquidKline>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, KlineInterval interval, Action<DataEvent<HyperLiquidKline>> onMessage, CancellationToken ct = default)
         {
             var coin = symbol;
             if (HyperLiquidUtils.SymbolIsExchangeSpotSymbol(coin))
@@ -179,7 +179,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 // Spot symbol
                 var spotName = await HyperLiquidUtils.GetExchangeNameFromSymbolNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
                 if (!spotName)
-                    return new WebCallResult<UpdateSubscription>(spotName.Error);
+                    return new HttpResult<UpdateSubscription>(spotName.Error);
 
                 coin = spotName.Data;
             }
@@ -206,7 +206,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, Action<DataEvent<HyperLiquidOrderBook>> onMessage, int? nSigFigs = null, int? mantissa = null, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, Action<DataEvent<HyperLiquidOrderBook>> onMessage, int? nSigFigs = null, int? mantissa = null, CancellationToken ct = default)
         {
             var coin = symbol;
             if (HyperLiquidUtils.SymbolIsExchangeSpotSymbol(coin))
@@ -214,7 +214,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 // Spot symbol
                 var spotName = await HyperLiquidUtils.GetExchangeNameFromSymbolNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
                 if (!spotName)
-                    return new WebCallResult<UpdateSubscription>(spotName.Error);
+                    return new HttpResult<UpdateSubscription>(spotName.Error);
 
                 coin = spotName.Data;
             }
@@ -246,7 +246,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<HyperLiquidTrade[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<HyperLiquidTrade[]>> onMessage, CancellationToken ct = default)
         {
             var coin = symbol;
             if (HyperLiquidUtils.SymbolIsExchangeSpotSymbol(coin))
@@ -254,7 +254,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 // Spot symbol
                 var spotName = await HyperLiquidUtils.GetExchangeNameFromSymbolNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
                 if (!spotName)
-                    return new WebCallResult<UpdateSubscription>(spotName.Error);
+                    return new HttpResult<UpdateSubscription>(spotName.Error);
 
                 coin = spotName.Data;
             }
@@ -286,7 +286,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToBookTickerUpdatesAsync(string symbol, Action<DataEvent<HyperLiquidBookTicker>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToBookTickerUpdatesAsync(string symbol, Action<DataEvent<HyperLiquidBookTicker>> onMessage, CancellationToken ct = default)
         {
             var coin = symbol;
             if (HyperLiquidUtils.SymbolIsExchangeSpotSymbol(coin))
@@ -294,7 +294,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 // Spot symbol
                 var spotName = await HyperLiquidUtils.GetExchangeNameFromSymbolNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
                 if (!spotName)
-                    return new WebCallResult<UpdateSubscription>(spotName.Error);
+                    return new HttpResult<UpdateSubscription>(spotName.Error);
 
                 coin = spotName.Data;
             }

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiExchangeData.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiExchangeData.cs
@@ -20,6 +20,12 @@ namespace HyperLiquid.Net.Clients.BaseApi
 {
     internal partial class HyperLiquidSocketClientApiExchangeData : IHyperLiquidSocketClientApiExchangeData
     {
+        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
+        {
+            Decimal = DecimalSerialization.String,
+            Sort = false
+        };
+
         protected readonly HyperLiquidSocketClientApi _baseClient;
         protected readonly ILogger _logger;
 
@@ -40,11 +46,11 @@ namespace HyperLiquid.Net.Clients.BaseApi
         /// <inheritdoc />
         public async Task<CallResult<Dictionary<string, decimal>>> GetPricesAsync(string? dex = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "allMids" }
             };
-            parameters.AddOptional("dex", dex);
+            parameters.Add("dex", dex);
             var result = await _baseClient.QueryInternalAsync(new HyperLiquidRequestQuery<Dictionary<string, decimal>>(_baseClient, "post", "info", parameters, false), ct).ConfigureAwait(false);
 
             var resultMapped = new Dictionary<string, decimal>();
@@ -75,14 +81,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 coin = spotName.Data;
             }
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "l2Book" },
                 { "coin", coin }
             };
 
-            parameters.AddOptional("nSigFigs", numberSignificantFigures);
-            parameters.AddOptional("mantissa", mantissa);
+            parameters.Add("nSigFigs", numberSignificantFigures);
+            parameters.Add("mantissa", mantissa);
 
             var result = await _baseClient.QueryInternalAsync(new HyperLiquidRequestQuery<HyperLiquidOrderBook>(_baseClient, "post", "info", parameters, false), ct).ConfigureAwait(false);
             return result;
@@ -106,13 +112,13 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 coin = spotName.Data;
             }
 
-            var innerParameters = new ParameterCollection();
+            var innerParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
             innerParameters.Add("coin", coin);
-            innerParameters.AddEnum("interval", interval);
-            innerParameters.AddOptionalMilliseconds("startTime", startTime);
-            innerParameters.AddOptionalMilliseconds("endTime", endTime);
+            innerParameters.Add("interval", interval);
+            innerParameters.Add("startTime", startTime);
+            innerParameters.Add("endTime", endTime);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "candleSnapshot" },
                 { "req", innerParameters }

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiTrading.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiTrading.cs
@@ -45,7 +45,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get Open Orders
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidOpenOrder[]>> GetOpenOrdersAsync(string? address = null, string? dex = null, CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidOpenOrder[]>> GetOpenOrdersAsync(string? address = null, string? dex = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -89,7 +89,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get Open Orders Extended
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidOrder[]>> GetOpenOrdersExtendedAsync(string? address = null, string? dex = null, CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidOrder[]>> GetOpenOrdersExtendedAsync(string? address = null, string? dex = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -133,7 +133,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get User Trades
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidUserTrade[]>> GetUserTradesAsync(string? address = null, CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidUserTrade[]>> GetUserTradesAsync(string? address = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -177,7 +177,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get User Trades By Time
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidUserTrade[]>> GetUserTradesByTimeAsync(
+        public async Task<QueryResult<HyperLiquidUserTrade[]>> GetUserTradesByTimeAsync(
             DateTime startTime,
             DateTime? endTime = null,
             bool? aggregateByTime = null,
@@ -229,7 +229,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get Order
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidOrderStatus>> GetOrderAsync(long? orderId = null, string? clientOrderId = null, string? address = null, CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidOrderStatus>> GetOrderAsync(long? orderId = null, string? clientOrderId = null, string? address = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -276,7 +276,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Get Order History
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidOrderStatus[]>> GetOrderHistoryAsync(string? address = null, CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidOrderStatus[]>> GetOrderHistoryAsync(string? address = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -319,7 +319,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
         #region Place Order
 
-        public async Task<CallResult<HyperLiquidOrderResult>> PlaceOrderAsync(
+        public async Task<QueryResult<HyperLiquidOrderResult>> PlaceOrderAsync(
             string symbol,
             OrderSide side,
             OrderType orderType,
@@ -354,7 +354,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Place Multiple Orders
 
         /// <inheritdoc />
-        public async Task<CallResult<CallResult<HyperLiquidOrderResult>[]>> PlaceMultipleOrdersAsync(
+        public async Task<QueryResult<CallResult<HyperLiquidOrderResult>[]>> PlaceMultipleOrdersAsync(
             IEnumerable<HyperLiquidOrderRequest> orders,
             TpSlGrouping? tpSlGrouping = null,
             string? vaultAddress = null,
@@ -368,7 +368,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
             {
                 var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, order.Symbol).ConfigureAwait(false);
                 if (!symbolId)
-                    return new WebCallResult<CallResult<HyperLiquidOrderResult>[]>(symbolId.Error);
+                    return new HttpResult<CallResult<HyperLiquidOrderResult>[]>(symbolId.Error);
 
                 var orderParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
                 orderParameters.Add("a", symbolId.Data);
@@ -390,7 +390,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                     var price = (order.Side == OrderSide.Buy ? order.Price * (1 + maxSlippage / 100m) : order.Price * (1 - maxSlippage / 100m)) ?? 0;
                     var quantityDecimals = await HyperLiquidUtils.GetQuantityDecimalPlacesForSymbolAsync(_baseClient.BaseClient, order.Symbol).ConfigureAwait(false);
                     if (!quantityDecimals)
-                        return new WebCallResult<CallResult<HyperLiquidOrderResult>[]>(quantityDecimals.Error);
+                        return new HttpResult<CallResult<HyperLiquidOrderResult>[]>(quantityDecimals.Error);
 
                     // Price can be a max of 5 significant figures
                     // but no more than (Spot:8, Futures:6) - quantityDecimals decimal places for the symbol
@@ -495,7 +495,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
         #region Cancel Order
 
-        public async Task<CallResult> CancelOrderAsync(
+        public async Task<QueryResult> CancelOrderAsync(
             string symbol,
             long orderId,
             string? vaultAddress = null,
@@ -518,7 +518,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Cancel Orders
 
         /// <inheritdoc />
-        public async Task<CallResult<CallResult[]>> CancelOrdersAsync(
+        public async Task<QueryResult<CallResult[]>> CancelOrdersAsync(
             IEnumerable<HyperLiquidCancelRequest> requests,
             string? vaultAddress = null,
             DateTime? expiresAfter = null,
@@ -531,7 +531,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
             {
                 var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, order.Symbol).ConfigureAwait(false);
                 if (!symbolId)
-                    return new WebCallResult<CallResult[]>(symbolId.Error);
+                    return new HttpResult<CallResult[]>(symbolId.Error);
 
                 orderRequests.Add(new Parameters(HyperLiquidExchange._parameterSerializationSettings)
                     {
@@ -568,7 +568,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
             foreach (var order in resultInt.Data.Statuses)
             {
                 if (order.Equals("success"))
-                    result.Add(CallResult.SuccessResult);
+                    result.Add(CallResult.Ok());
                 else
                     result.Add(new CallResult(new ServerError(_baseClient.GetErrorInfo("Order", order))));
             }
@@ -580,7 +580,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
         #region Cancel Order By Client Order Id
 
-        public async Task<CallResult> CancelOrderByClientOrderIdAsync(
+        public async Task<QueryResult> CancelOrderByClientOrderIdAsync(
             string symbol,
             string clientOrderId,
             string? vaultAddress,
@@ -603,7 +603,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Cancel Orders By Client Order Id
 
         /// <inheritdoc />
-        public async Task<CallResult<CallResult[]>> CancelOrdersByClientOrderIdAsync(
+        public async Task<QueryResult<CallResult[]>> CancelOrdersByClientOrderIdAsync(
             IEnumerable<HyperLiquidCancelByClientOrderIdRequest> requests,
             string? vaultAddress = null,
             DateTime? expiresAfter = null,
@@ -616,7 +616,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
             {
                 var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, order.Symbol).ConfigureAwait(false);
                 if (!symbolId)
-                    return new WebCallResult<CallResult[]>(symbolId.Error);
+                    return new HttpResult<CallResult[]>(symbolId.Error);
 
                 orderRequests.Add(new Parameters(HyperLiquidExchange._parameterSerializationSettings)
                     {
@@ -653,7 +653,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
             foreach (var order in resultInt.Data.Statuses)
             {
                 if (order.Equals("success"))
-                    result.Add(CallResult.SuccessResult);
+                    result.Add(CallResult.Ok());
                 else
                     result.Add(new CallResult(new ServerError(_baseClient.GetErrorInfo("Order", order))));
             }
@@ -666,7 +666,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Cancel after
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidOrderStatus[]>> CancelAfterAsync(
+        public async Task<QueryResult<HyperLiquidOrderStatus[]>> CancelAfterAsync(
             TimeSpan? timeout,
             string? vaultAddress = null,
             DateTime? expiresAfter = null,
@@ -697,7 +697,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Edit Order
 
         /// <inheritdoc />
-        public async Task<CallResult> EditOrderAsync(
+        public async Task<QueryResult> EditOrderAsync(
             string symbol,
             long? orderId,
             string? clientOrderId,
@@ -725,7 +725,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
             if (!symbolId)
-                return new WebCallResult(symbolId.Error!);
+                return new HttpResult(symbolId.Error!);
 
             var orderParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
             orderParameters.Add("a", symbolId.Data);
@@ -784,7 +784,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Edit Orders
 
         /// <inheritdoc />
-        public async Task<CallResult<CallResult<HyperLiquidOrderResult>[]>> EditOrdersAsync(
+        public async Task<QueryResult<CallResult<HyperLiquidOrderResult>[]>> EditOrdersAsync(
             IEnumerable<HyperLiquidEditOrderRequest> requests,
             string? vaultAddress = null,
             DateTime? expiresAfter = null,
@@ -803,7 +803,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
                 var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, order.Symbol).ConfigureAwait(false);
                 if (!symbolId)
-                    return new WebCallResult<CallResult<HyperLiquidOrderResult>[]>(symbolId.Error!);
+                    return new HttpResult<CallResult<HyperLiquidOrderResult>[]>(symbolId.Error!);
 
                 var modifyParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
                 modifyParameters.Add("oid", order.OrderId);
@@ -886,7 +886,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Place TWAP order
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidTwapOrderResult>> PlaceTwapOrderAsync(
+        public async Task<QueryResult<HyperLiquidTwapOrderResult>> PlaceTwapOrderAsync(
             string symbol,
             OrderSide orderSide,
             decimal quantity,
@@ -901,7 +901,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
             if (!symbolId)
-                return new WebCallResult<HyperLiquidTwapOrderResult>(symbolId.Error);
+                return new HttpResult<HyperLiquidTwapOrderResult>(symbolId.Error);
 
             var orderParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
             orderParameters.Add("a", symbolId.Data);
@@ -942,7 +942,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #region Cancel Twap Order
 
         /// <inheritdoc />
-        public async Task<CallResult> CancelTwapOrderAsync(
+        public async Task<QueryResult> CancelTwapOrderAsync(
             string symbol,
             long twapId,
             string? vaultAddress = null,
@@ -953,7 +953,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
             if (!symbolId)
-                return new WebCallResult(symbolId.Error!);
+                return new HttpResult(symbolId.Error!);
 
             var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
@@ -986,7 +986,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         #endregion
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(string? address, Action<DataEvent<HyperLiquidOrderStatus[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(string? address, Action<DataEvent<HyperLiquidOrderStatus[]>> onMessage, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -1039,7 +1039,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToOpenOrderUpdatesAsync(string? address, string? dex, Action<DataEvent<HyperLiquidOpenOrderUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToOpenOrderUpdatesAsync(string? address, string? dex, Action<DataEvent<HyperLiquidOpenOrderUpdate>> onMessage, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -1097,7 +1097,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(string? address, Action<DataEvent<HyperLiquidUserTrade[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(string? address, Action<DataEvent<HyperLiquidUserTrade[]>> onMessage, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -1150,7 +1150,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToTwapTradeUpdatesAsync(string? address, Action<DataEvent<HyperLiquidTwapStatus[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToTwapTradeUpdatesAsync(string? address, Action<DataEvent<HyperLiquidTwapStatus[]>> onMessage, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -1203,7 +1203,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToTwapOrderUpdatesAsync(string? address, Action<DataEvent<HyperLiquidTwapOrderStatus[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToTwapOrderUpdatesAsync(string? address, Action<DataEvent<HyperLiquidTwapOrderStatus[]>> onMessage, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiTrading.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiTrading.cs
@@ -1024,6 +1024,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
             });
 
             var addressSub = address ?? _baseClient.AuthenticationProvider!.Key;
+            // The update doesn't contain the address, so we can't specify the address as filter..
             var subscription = new HyperLiquidSubscription<HyperLiquidOrderStatus[]>(_logger, _baseClient, "orderUpdates", null, new Dictionary<string, object>
             {
                 { "user", addressSub.ToLowerInvariant() },
@@ -1081,7 +1082,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
             });
 
             var addressSub = address ?? _baseClient.AuthenticationProvider!.Key;
-            var subscription = new HyperLiquidSubscription<HyperLiquidOpenOrderUpdate>(_logger, _baseClient, "openOrders", null, new Dictionary<string, object>
+            var subscription = new HyperLiquidSubscription<HyperLiquidOpenOrderUpdate>(_logger, _baseClient, "openOrders", addressSub.ToLowerInvariant(), new Dictionary<string, object>
             {
                 { "user", addressSub.ToLowerInvariant() },
                 { "dex", dex ?? "" },
@@ -1135,7 +1136,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
             });
 
             var addressSub = address ?? _baseClient.AuthenticationProvider!.Key;
-            var subscription = new HyperLiquidSubscription<HyperLiquidUserTradeUpdate>(_logger, _baseClient, "userFills", null, new Dictionary<string, object>
+            var subscription = new HyperLiquidSubscription<HyperLiquidUserTradeUpdate>(_logger, _baseClient, "userFills", addressSub.ToLowerInvariant(), new Dictionary<string, object>
             {
                 { "user", addressSub.ToLowerInvariant() },
             },
@@ -1188,7 +1189,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
             });
 
             var addressSub = address ?? _baseClient.AuthenticationProvider!.Key;
-            var subscription = new HyperLiquidSubscription<HyperLiquidTwapTradeUpdate>(_logger, _baseClient, "userTwapSliceFills", null, new Dictionary<string, object>
+            var subscription = new HyperLiquidSubscription<HyperLiquidTwapTradeUpdate>(_logger, _baseClient, "userTwapSliceFills", addressSub.ToLowerInvariant(), new Dictionary<string, object>
             {
                 { "user", addressSub.ToLowerInvariant() },
             },
@@ -1241,7 +1242,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
             });
 
             var addressSub = address ?? _baseClient.AuthenticationProvider!.Key;
-            var subscription = new HyperLiquidSubscription<HyperLiquidTwapOrderUpdate>(_logger, _baseClient, "userTwapHistory", null, new Dictionary<string, object>
+            var subscription = new HyperLiquidSubscription<HyperLiquidTwapOrderUpdate>(_logger, _baseClient, "userTwapHistory", addressSub.ToLowerInvariant(), new Dictionary<string, object>
             {
                 { "user", addressSub.ToLowerInvariant() },
             },

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiTrading.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiTrading.cs
@@ -707,6 +707,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
             TpSlGrouping? tpSlGrouping = null,
             string? vaultAddress = null,
             DateTime? expiresAfter = null,
+            bool? alwaysPlace = null,
             CancellationToken ct = default)
         {
             if ((orderId == null) == (clientOrderId == null))
@@ -761,6 +762,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             actionParameters.Add("oid", orderId);
             actionParameters.Add("oid", clientOrderId);
             actionParameters.Add("order", orderParameters);
+            if (alwaysPlace == true)
+                actionParameters.Add("a", alwaysPlace.Value);
             parameters.Add("action", actionParameters);
 
             if (vaultAddress != null)
@@ -782,6 +785,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
             IEnumerable<HyperLiquidEditOrderRequest> requests,
             string? vaultAddress = null,
             DateTime? expiresAfter = null,
+            bool? alwaysPlace = null,
             CancellationToken ct = default)
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
@@ -839,15 +843,16 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 orderRequests.Add(modifyParameters);
             }
 
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
+            {
+                { "type", "batchModify" },
+                { "modifies", orderRequests }
+            };
+            if (alwaysPlace == true)
+                actionParameters.Add("a", alwaysPlace.Value);
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
-                {
-                    "action", new Parameters(HyperLiquidExchange._parameterSerializationSettings)
-                    {
-                        { "type", "batchModify" },
-                        { "modifies", orderRequests }
-                    }
-                }
+                { "action", actionParameters }
             };
 
             if (vaultAddress != null)

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiTrading.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiTrading.cs
@@ -20,12 +20,6 @@ namespace HyperLiquid.Net.Clients.BaseApi
 {
     internal partial class HyperLiquidSocketClientApiTrading : IHyperLiquidSocketClientApiTrading
     {
-        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
-        {
-            Decimal = DecimalSerialization.String,
-            Sort = false
-        };
-
         protected readonly HyperLiquidSocketClientApi _baseClient;
         protected readonly ILogger _logger;
 
@@ -60,7 +54,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
             parameters.Add("dex", dex);
             var result = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidOpenOrder[]>(_baseClient, "post", "info", parameters, false), ct).ConfigureAwait(false);
-            if (!result)
+            if (!result.Success)
                 return result;
 
             foreach (var order in result.Data)
@@ -104,7 +98,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
             parameters.Add("dex", dex);
             var result = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidOrder[]>(_baseClient, "post", "info", parameters, false), ct).ConfigureAwait(false);
-            if (!result)
+            if (!result.Success)
                 return result;
 
             foreach (var order in result.Data)
@@ -148,7 +142,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             var result = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidUserTrade[]>(_baseClient, "post", "info", parameters, false), ct).ConfigureAwait(false);
-            if (!result)
+            if (!result.Success)
                 return result;
 
             foreach (var order in result.Data)
@@ -156,7 +150,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 if (HyperLiquidUtils.ExchangeSymbolIsSpotSymbol(order.ExchangeSymbol))
                 {
                     var symbolName = await HyperLiquidUtils.GetSymbolNameFromExchangeNameAsync(_baseClient.BaseClient, order.ExchangeSymbol).ConfigureAwait(false);
-                    if (symbolName == null)
+                    if (!symbolName.Success)
                         continue;
 
                     order.Symbol = symbolName.Data;
@@ -200,7 +194,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             var result = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidUserTrade[]>(_baseClient, "post", "info", parameters, false), ct).ConfigureAwait(false);
-            if (!result)
+            if (!result.Success)
                 return result;
 
             foreach (var order in result.Data)
@@ -208,7 +202,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 if (HyperLiquidUtils.ExchangeSymbolIsSpotSymbol(order.ExchangeSymbol))
                 {
                     var symbolName = await HyperLiquidUtils.GetSymbolNameFromExchangeNameAsync(_baseClient.BaseClient, order.ExchangeSymbol).ConfigureAwait(false);
-                    if (symbolName == null)
+                    if (!symbolName.Success)
                         continue;
 
                     order.Symbol = symbolName.Data;
@@ -247,11 +241,11 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             var result = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidOrderStatusResult>(_baseClient, "post", "info", parameters, false), ct).ConfigureAwait(false);
-            if (!result)
-                return result.As<HyperLiquidOrderStatus>(default);
+            if (!result.Success)
+                return QueryResult.Fail<HyperLiquidOrderStatus>(result);
 
             if (result.Data.Status != "order")
-                return result.AsError<HyperLiquidOrderStatus>(new ServerError(new ErrorInfo(ErrorType.Unknown, result.Data.Status)));
+                return QueryResult.Fail<HyperLiquidOrderStatus>(result, new ServerError(new ErrorInfo(ErrorType.Unknown, result.Data.Status)));
 
             if (HyperLiquidUtils.ExchangeSymbolIsSpotSymbol(result.Data.Order!.Order.ExchangeSymbol))
             {
@@ -268,7 +262,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 result.Data.Order!.Order.SymbolType = SymbolType.Futures;
             }
 
-            return result.As(result.Data.Order);
+            return QueryResult.Ok(result, result.Data.Order);
         }
 
         #endregion
@@ -291,7 +285,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             var result = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidOrderStatus[]>(_baseClient, "post", "info", parameters, false), ct).ConfigureAwait(false);
-            if (!result)
+            if (!result.Success)
                 return result;
 
             foreach (var order in result.Data)
@@ -339,14 +333,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 new HyperLiquidOrderRequest(symbol, side, orderType, quantity, price, timeInForce, reduceOnly, triggerPrice: triggerPrice, tpSlType: tpSlType, clientOrderId: clientOrderId)
                 ], tpSlGrouping, vaultAddress, expiresAfter, ct).ConfigureAwait(false);
 
-            if (!result)
-                return result.As<HyperLiquidOrderResult>(default);
+            if (!result.Success)
+                return QueryResult.Fail<HyperLiquidOrderResult>(result);
 
             var orderResult = result.Data.Single();
-            if (!orderResult)
-                return result.AsError<HyperLiquidOrderResult>(orderResult.Error!);
+            if (!orderResult.Success)
+                return QueryResult.Fail<HyperLiquidOrderResult>(result, orderResult.Error!);
 
-            return result.As(result.Data.Single().Data);
+            return QueryResult.Ok(result, result.Data.Single().Data!);
         }
 
         #endregion
@@ -367,8 +361,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             foreach (var order in orders)
             {
                 var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, order.Symbol).ConfigureAwait(false);
-                if (!symbolId)
-                    return new HttpResult<CallResult<HyperLiquidOrderResult>[]>(symbolId.Error);
+                if (!symbolId.Success)
+                    return QueryResult.Fail<CallResult<HyperLiquidOrderResult>[]>(_baseClient.Exchange, symbolId.Error);
 
                 var orderParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
                 orderParameters.Add("a", symbolId.Data);
@@ -389,8 +383,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
                     var maxSlippage = order.MaxSlippage ?? 5;
                     var price = (order.Side == OrderSide.Buy ? order.Price * (1 + maxSlippage / 100m) : order.Price * (1 - maxSlippage / 100m)) ?? 0;
                     var quantityDecimals = await HyperLiquidUtils.GetQuantityDecimalPlacesForSymbolAsync(_baseClient.BaseClient, order.Symbol).ConfigureAwait(false);
-                    if (!quantityDecimals)
-                        return new HttpResult<CallResult<HyperLiquidOrderResult>[]>(quantityDecimals.Error);
+                    if (!quantityDecimals.Success)
+                        return QueryResult.Fail<CallResult<HyperLiquidOrderResult>[]>(_baseClient.Exchange, quantityDecimals.Error);
 
                     // Price can be a max of 5 significant figures
                     // but no more than (Spot:8, Futures:6) - quantityDecimals decimal places for the symbol
@@ -467,28 +461,28 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             var intResult = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidOrderResultIntWrapper>(_baseClient, "post", "action", parameters, true), ct).ConfigureAwait(false);
-            if (!intResult)
-                return intResult.As<CallResult<HyperLiquidOrderResult>[]>(default);
+            if (!intResult.Success)
+                return QueryResult.Fail<CallResult<HyperLiquidOrderResult>[]>(intResult);
 
             var result = new List<CallResult<HyperLiquidOrderResult>>();
             foreach (var order in intResult.Data.Statuses)
             {
                 if (order.Error != null)
-                    result.Add(new CallResult<HyperLiquidOrderResult>(new ServerError(_baseClient.GetErrorInfo("Order", order.Error))));
+                    result.Add(CallResult.Fail<HyperLiquidOrderResult>(new ServerError(_baseClient.GetErrorInfo("Order", order.Error))));
                 else if (order.ResultResting != null)
-                    result.Add(new CallResult<HyperLiquidOrderResult>(order.ResultResting with { Status = OrderStatus.Open }));
+                    result.Add(CallResult.Ok<HyperLiquidOrderResult>(order.ResultResting with { Status = OrderStatus.Open }));
                 else if (order.ResultFilled != null)
-                    result.Add(new CallResult<HyperLiquidOrderResult>(order.ResultFilled! with { Status = OrderStatus.Filled }));
+                    result.Add(CallResult.Ok<HyperLiquidOrderResult>(order.ResultFilled! with { Status = OrderStatus.Filled }));
                 else if (order.WaitingForFill != null)
-                    result.Add(new CallResult<HyperLiquidOrderResult>(order.WaitingForFill! with { Status = OrderStatus.WaitingTrigger }));
+                    result.Add(CallResult.Ok<HyperLiquidOrderResult>(order.WaitingForFill! with { Status = OrderStatus.WaitingTrigger }));
                 else
-                    result.Add(new CallResult<HyperLiquidOrderResult>(order.WaitingForTrigger! with { Status = OrderStatus.WaitingTrigger }));
+                    result.Add(CallResult.Ok<HyperLiquidOrderResult>(order.WaitingForTrigger! with { Status = OrderStatus.WaitingTrigger }));
             }
 
             if (result.Count > 1 && result.All(x => !x.Success))
-                return intResult.AsErrorWithData<CallResult<HyperLiquidOrderResult>[]>(new ServerError(new ErrorInfo(ErrorType.AllOrdersFailed, "All orders failed")), result.ToArray());
+                return QueryResult.Fail<CallResult<HyperLiquidOrderResult>[]>(intResult, new ServerError(new ErrorInfo(ErrorType.AllOrdersFailed, "All orders failed")), result.ToArray());
 
-            return intResult.As<CallResult<HyperLiquidOrderResult>[]>(result.ToArray());
+            return QueryResult.Ok(intResult, result.ToArray());
         }
 
         #endregion
@@ -503,14 +497,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
             CancellationToken ct = default)
         {
             var result = await CancelOrdersAsync([new HyperLiquidCancelRequest(symbol, orderId)], vaultAddress, expiresAfter, ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsDataless();
+            if (!result.Success)
+                return result;
 
             var cancelResult = result.Data.Single();
-            if (!cancelResult)
-                return result.AsDatalessError(cancelResult.Error!);
+            if (!cancelResult.Success)
+                return QueryResult.Fail(result, cancelResult.Error!);
 
-            return result.AsDataless();
+            return result;
         }
 
         #endregion
@@ -530,8 +524,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             foreach (var order in requests)
             {
                 var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, order.Symbol).ConfigureAwait(false);
-                if (!symbolId)
-                    return new HttpResult<CallResult[]>(symbolId.Error);
+                if (!symbolId.Success)
+                    return QueryResult.Fail<CallResult[]>(_baseClient.Exchange, symbolId.Error);
 
                 orderRequests.Add(new Parameters(HyperLiquidExchange._parameterSerializationSettings)
                     {
@@ -561,8 +555,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             var weight = 1 + (int)Math.Floor(orderRequests.Count / 40m);
             var resultInt = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidCancelResult>(_baseClient, "post", "action", parameters, true), ct).ConfigureAwait(false);
-            if (!resultInt)
-                return resultInt.AsError<CallResult[]>(resultInt.Error!);
+            if (!resultInt.Success)
+                return QueryResult.Fail<CallResult[]>(resultInt);
 
             var result = new List<CallResult>();
             foreach (var order in resultInt.Data.Statuses)
@@ -570,10 +564,10 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 if (order.Equals("success"))
                     result.Add(CallResult.Ok());
                 else
-                    result.Add(new CallResult(new ServerError(_baseClient.GetErrorInfo("Order", order))));
+                    result.Add(CallResult.Fail(new ServerError(_baseClient.GetErrorInfo("Order", order))));
             }
 
-            return resultInt.As<CallResult[]>(result.ToArray());
+            return QueryResult.Ok(resultInt, result.ToArray());
         }
 
         #endregion
@@ -588,14 +582,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
             CancellationToken ct = default)
         {
             var result = await CancelOrdersByClientOrderIdAsync([new HyperLiquidCancelByClientOrderIdRequest(symbol, clientOrderId)], vaultAddress, expiresAfter, ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsDataless();
+            if (!result.Success)
+                return result;
 
             var cancelResult = result.Data.Single();
-            if (!cancelResult)
-                return result.AsDatalessError(cancelResult.Error!);
+            if (!cancelResult.Success)
+                return QueryResult.Fail(result, cancelResult.Error!);
 
-            return result.AsDataless();
+            return result;
         }
 
         #endregion
@@ -615,8 +609,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             foreach (var order in requests)
             {
                 var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, order.Symbol).ConfigureAwait(false);
-                if (!symbolId)
-                    return new HttpResult<CallResult[]>(symbolId.Error);
+                if (!symbolId.Success)
+                    return QueryResult.Fail<CallResult[]>(_baseClient.Exchange, symbolId.Error);
 
                 orderRequests.Add(new Parameters(HyperLiquidExchange._parameterSerializationSettings)
                     {
@@ -646,8 +640,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             var weight = 1 + (int)Math.Floor(orderRequests.Count / 40m);
             var resultInt = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidCancelResult>(_baseClient, "post", "action", parameters, true), ct).ConfigureAwait(false);
-            if (!resultInt)
-                return resultInt.AsError<CallResult[]>(resultInt.Error!);
+            if (!resultInt.Success)
+                return QueryResult.Fail<CallResult[]>(_baseClient.Exchange, resultInt.Error!);
 
             var result = new List<CallResult>();
             foreach (var order in resultInt.Data.Statuses)
@@ -655,10 +649,10 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 if (order.Equals("success"))
                     result.Add(CallResult.Ok());
                 else
-                    result.Add(new CallResult(new ServerError(_baseClient.GetErrorInfo("Order", order))));
+                    result.Add(CallResult.Fail(new ServerError(_baseClient.GetErrorInfo("Order", order))));
             }
 
-            return resultInt.As<CallResult[]>(result.ToArray());
+            return QueryResult.Ok(resultInt, result.ToArray());
         }
 
         #endregion
@@ -724,8 +718,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
             var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
-            if (!symbolId)
-                return new HttpResult(symbolId.Error!);
+            if (!symbolId.Success)
+                return QueryResult.Fail(_baseClient.Exchange, symbolId.Error!);
 
             var orderParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
             orderParameters.Add("a", symbolId.Data);
@@ -776,7 +770,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             var result = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<object>(_baseClient, "post", "action", parameters, true), ct).ConfigureAwait(false);
-            return result.AsDataless();
+            return result;
         }
 
         #endregion
@@ -802,8 +796,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
                     throw new ArgumentException("Order type can't be market");
 
                 var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, order.Symbol).ConfigureAwait(false);
-                if (!symbolId)
-                    return new HttpResult<CallResult<HyperLiquidOrderResult>[]>(symbolId.Error!);
+                if (!symbolId.Success)
+                    return QueryResult.Fail<CallResult<HyperLiquidOrderResult>[]>(_baseClient.Exchange, symbolId.Error!);
 
                 var modifyParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
                 modifyParameters.Add("oid", order.OrderId);
@@ -864,21 +858,21 @@ namespace HyperLiquid.Net.Clients.BaseApi
             var weight = 1 + (int)Math.Floor(orderRequests.Count / 40m);
             var intResult = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidOrderResultIntWrapper>(_baseClient, "post", "action", parameters, true), ct).ConfigureAwait(false);
-            if (!intResult)
-                return intResult.As<CallResult<HyperLiquidOrderResult>[]>(default);
+            if (!intResult.Success)
+                return QueryResult.Fail<CallResult<HyperLiquidOrderResult>[]>(intResult);
 
             var result = new List<CallResult<HyperLiquidOrderResult>>();
             foreach (var order in intResult.Data.Statuses)
             {
                 if (order.Error != null)
-                    result.Add(new CallResult<HyperLiquidOrderResult>(new ServerError(_baseClient.GetErrorInfo("Order", order.Error))));
+                    result.Add(CallResult.Fail<HyperLiquidOrderResult>(new ServerError(_baseClient.GetErrorInfo("Order", order.Error))));
                 else if (order.ResultResting != null)
-                    result.Add(new CallResult<HyperLiquidOrderResult>(order.ResultResting with { Status = OrderStatus.Open }));
+                    result.Add(CallResult.Ok(order.ResultResting with { Status = OrderStatus.Open }));
                 else
-                    result.Add(new CallResult<HyperLiquidOrderResult>(order.ResultFilled! with { Status = OrderStatus.Filled }));
+                    result.Add(CallResult.Ok(order.ResultFilled! with { Status = OrderStatus.Filled }));
             }
 
-            return intResult.As<CallResult<HyperLiquidOrderResult>[]>(result.ToArray());
+            return QueryResult.Ok(intResult, result.ToArray());
         }
 
         #endregion
@@ -900,8 +894,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
             var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
-            if (!symbolId)
-                return new HttpResult<HyperLiquidTwapOrderResult>(symbolId.Error);
+            if (!symbolId.Success)
+                return QueryResult.Fail<HyperLiquidTwapOrderResult>(_baseClient.Exchange, symbolId.Error);
 
             var orderParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
             orderParameters.Add("a", symbolId.Data);
@@ -928,13 +922,13 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             var result = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidTwapOrderResultIntWrapper>(_baseClient, "post", "action", parameters, true), ct).ConfigureAwait(false);
-            if (!result)
-                return result.As<HyperLiquidTwapOrderResult>(default);
+            if (!result.Success)
+                return QueryResult.Fail<HyperLiquidTwapOrderResult>(result);
 
             if (result.Data.Status.Error != null)
-                return result.AsError<HyperLiquidTwapOrderResult>(new ServerError(_baseClient.GetErrorInfo("Order", result.Data.Status.Error)));
+                return QueryResult.Fail<HyperLiquidTwapOrderResult>(result, new ServerError(_baseClient.GetErrorInfo("Order", result.Data.Status.Error)));
 
-            return result.As(result.Data.Status.ResultRunning!);
+            return QueryResult.Ok(result, result.Data.Status.ResultRunning!);
         }
 
         #endregion
@@ -952,8 +946,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
             var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
-            if (!symbolId)
-                return new HttpResult(symbolId.Error!);
+            if (!symbolId.Success)
+                return QueryResult.Fail(_baseClient.Exchange, symbolId.Error!);
 
             var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
@@ -974,13 +968,13 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             var result = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidTwapCancelResult>(_baseClient, "post", "action", parameters, true), ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsDataless();
+            if (!result.Success)
+                return result;
 
             if (result.Data.Status != "success")
-                return result.AsDatalessError(new ServerError(_baseClient.GetErrorInfo("Order", result.Data.Status)));
+                return QueryResult.Fail(result, new ServerError(_baseClient.GetErrorInfo("Order", result.Data.Status)));
 
-            return result.AsDataless();
+            return result;
         }
 
         #endregion
@@ -994,8 +988,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             _baseClient.ValidateAddress(address);
 
             var result = await HyperLiquidUtils.UpdateSpotSymbolInfoAsync(_baseClient.BaseClient).ConfigureAwait(false);
-            if (!result)
-                return new CallResult<UpdateSubscription>(result.Error!);
+            if (!result.Success)
+                return WebSocketResult.Fail<UpdateSubscription>(_baseClient.Exchange, result.Error!);
 
             var internalHandler = new Action<DateTime, string?, int, HyperLiquidSocketUpdate<HyperLiquidOrderStatus[]>>((receiveTime, originalData, invocation, data) =>
             {
@@ -1047,8 +1041,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             _baseClient.ValidateAddress(address);
 
             var result = await HyperLiquidUtils.UpdateSpotSymbolInfoAsync(_baseClient.BaseClient).ConfigureAwait(false);
-            if (!result)
-                return new CallResult<UpdateSubscription>(result.Error!);
+            if (!result.Success)
+                return WebSocketResult.Fail<UpdateSubscription>(_baseClient.Exchange, result.Error!);
 
             var internalHandler = new Action<DateTime, string?, int, HyperLiquidSocketUpdate<HyperLiquidOpenOrderUpdate>>((receiveTime, originalData, invocation, data) =>
             {
@@ -1105,8 +1099,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             _baseClient.ValidateAddress(address);
 
             var result = await HyperLiquidUtils.UpdateSpotSymbolInfoAsync(_baseClient.BaseClient).ConfigureAwait(false);
-            if (!result)
-                return new CallResult<UpdateSubscription>(result.Error!);
+            if (!result.Success)
+                return WebSocketResult.Fail<UpdateSubscription>(_baseClient.Exchange, result.Error!);
 
             var internalHandler = new Action<DateTime, string?, int, HyperLiquidSocketUpdate<HyperLiquidUserTradeUpdate>>((receiveTime, originalData, invocation, data) =>
             {
@@ -1119,7 +1113,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                     if (HyperLiquidUtils.ExchangeSymbolIsSpotSymbol(order.ExchangeSymbol))
                     {
                         var symbolName = HyperLiquidUtils.GetSymbolNameFromExchangeName(_baseClient.ClientOptions.Environment.Name, order.ExchangeSymbol);
-                        if (symbolName == null)
+                        if (!symbolName.Success)
                             continue;
 
                         order.Symbol = symbolName.Data;
@@ -1158,8 +1152,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             _baseClient.ValidateAddress(address);
 
             var result = await HyperLiquidUtils.UpdateSpotSymbolInfoAsync(_baseClient.BaseClient).ConfigureAwait(false);
-            if (!result)
-                return new CallResult<UpdateSubscription>(result.Error!);
+            if (!result.Success)
+                return WebSocketResult.Fail<UpdateSubscription>(_baseClient.Exchange, result.Error!);
 
             var internalHandler = new Action<DateTime, string?, int, HyperLiquidSocketUpdate<HyperLiquidTwapTradeUpdate>>((receiveTime, originalData, invocation, data) =>
             {
@@ -1168,7 +1162,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                     if (HyperLiquidUtils.ExchangeSymbolIsSpotSymbol(order.ExchangeSymbol))
                     {
                         var symbolName = HyperLiquidUtils.GetSymbolNameFromExchangeName(_baseClient.ClientOptions.Environment.Name, order.ExchangeSymbol);
-                        if (symbolName == null)
+                        if (!symbolName.Success)
                             continue;
 
                         order.Symbol = symbolName.Data;
@@ -1211,8 +1205,8 @@ namespace HyperLiquid.Net.Clients.BaseApi
             _baseClient.ValidateAddress(address);
 
             var result = await HyperLiquidUtils.UpdateSpotSymbolInfoAsync(_baseClient.BaseClient).ConfigureAwait(false);
-            if (!result)
-                return new CallResult<UpdateSubscription>(result.Error!);
+            if (!result.Success)
+                return WebSocketResult.Fail<UpdateSubscription>(_baseClient.Exchange, result.Error!);
 
             var internalHandler = new Action<DateTime, string?, int, HyperLiquidSocketUpdate<HyperLiquidTwapOrderUpdate>>((receiveTime, originalData, invocation, data) =>
             {
@@ -1225,7 +1219,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                     if (HyperLiquidUtils.ExchangeSymbolIsSpotSymbol(order.TwapInfo.ExchangeSymbol))
                     {
                         var symbolName = HyperLiquidUtils.GetSymbolNameFromExchangeName(_baseClient.ClientOptions.Environment.Name, order.TwapInfo.ExchangeSymbol);
-                        if (symbolName == null)
+                        if (!symbolName.Success)
                             continue;
 
                         order.TwapInfo.Symbol = symbolName.Data;

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiTrading.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiTrading.cs
@@ -35,7 +35,6 @@ namespace HyperLiquid.Net.Clients.BaseApi
         }
         #endregion
 
-
         #region Get Open Orders
 
         /// <inheritdoc />

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiTrading.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiTrading.cs
@@ -20,6 +20,12 @@ namespace HyperLiquid.Net.Clients.BaseApi
 {
     internal partial class HyperLiquidSocketClientApiTrading : IHyperLiquidSocketClientApiTrading
     {
+        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
+        {
+            Decimal = DecimalSerialization.String,
+            Sort = false
+        };
+
         protected readonly HyperLiquidSocketClientApi _baseClient;
         protected readonly ILogger _logger;
 
@@ -46,12 +52,12 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "openOrders" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key  }
             };
-            parameters.AddOptional("dex", dex);
+            parameters.Add("dex", dex);
             var result = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidOpenOrder[]>(_baseClient, "post", "info", parameters, false), ct).ConfigureAwait(false);
             if (!result)
@@ -90,12 +96,12 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "frontendOpenOrders" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
             };
-            parameters.AddOptional("dex", dex);
+            parameters.Add("dex", dex);
             var result = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidOrder[]>(_baseClient, "post", "info", parameters, false), ct).ConfigureAwait(false);
             if (!result)
@@ -134,7 +140,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "userFills" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
@@ -183,14 +189,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "userFillsByTime" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
             };
-            parameters.AddMilliseconds("startTime", startTime);
-            parameters.AddOptionalMilliseconds("endTime", endTime);
-            parameters.AddOptional("aggregateByTime", aggregateByTime);
+            parameters.Add("startTime", startTime);
+            parameters.Add("endTime", endTime);
+            parameters.Add("aggregateByTime", aggregateByTime);
 
             var result = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidUserTrade[]>(_baseClient, "post", "info", parameters, false), ct).ConfigureAwait(false);
@@ -230,14 +236,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "orderStatus" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
             };
 
-            parameters.AddOptional("oid", orderId);
-            parameters.AddOptional("oid", clientOrderId);
+            parameters.Add("oid", orderId);
+            parameters.Add("oid", clientOrderId);
 
             var result = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidOrderStatusResult>(_baseClient, "post", "info", parameters, false), ct).ConfigureAwait(false);
@@ -277,7 +283,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "historicalOrders" },
                 { "user",  address ?? _baseClient.AuthenticationProvider!.Key }
@@ -357,25 +363,25 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var orderRequests = new List<ParameterCollection>();
+            var orderRequests = new List<Parameters>();
             foreach (var order in orders)
             {
                 var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, order.Symbol).ConfigureAwait(false);
                 if (!symbolId)
                     return new WebCallResult<CallResult<HyperLiquidOrderResult>[]>(symbolId.Error);
 
-                var orderParameters = new ParameterCollection();
+                var orderParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
                 orderParameters.Add("a", symbolId.Data);
                 orderParameters.Add("b", order.Side == OrderSide.Buy);
 
-                var orderTypeParameters = new ParameterCollection();
+                var orderTypeParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
                 if (order.OrderType == OrderType.Limit)
                 {
-                    orderParameters.AddString("p", order.Price?.Normalize() ?? 0);
-                    orderParameters.AddString("s", order.Quantity.Normalize());
+                    orderParameters.Add("p", order.Price?.Normalize() ?? 0);
+                    orderParameters.Add("s", order.Quantity.Normalize());
                     orderParameters.Add("r", order.ReduceOnly ?? false);
-                    var limitParameters = new ParameterCollection();
-                    limitParameters.AddEnum("tif", order.TimeInForce ?? TimeInForce.GoodTillCanceled);
+                    var limitParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+                    limitParameters.Add("tif", order.TimeInForce ?? TimeInForce.GoodTillCanceled);
                     orderTypeParameters.Add("limit", limitParameters);
                 }
                 else if (order.OrderType == OrderType.Market)
@@ -392,11 +398,11 @@ namespace HyperLiquid.Net.Clients.BaseApi
                     price = ExchangeHelpers.RoundToSignificantDigits(price, 5, RoundingType.Closest);
                     price = ExchangeHelpers.RoundDown(price, decimalMax - quantityDecimals.Data);
 
-                    orderParameters.AddString("p", price.Normalize());
-                    orderParameters.AddString("s", order.Quantity.Normalize());
+                    orderParameters.Add("p", price.Normalize());
+                    orderParameters.Add("s", order.Quantity.Normalize());
                     orderParameters.Add("r", order.ReduceOnly ?? false);
-                    var limitParameters = new ParameterCollection();
-                    limitParameters.AddEnum("tif", order.TimeInForce ?? TimeInForce.ImmediateOrCancel);
+                    var limitParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+                    limitParameters.Add("tif", order.TimeInForce ?? TimeInForce.ImmediateOrCancel);
                     orderTypeParameters.Add("limit", limitParameters);
                 }
                 else
@@ -407,30 +413,30 @@ namespace HyperLiquid.Net.Clients.BaseApi
                     if (order.TpSlType == null)
                         throw new ArgumentNullException(nameof(order.TpSlType), "Stop order should have a TpSlType");
 
-                    orderParameters.AddString("p", order.Price?.Normalize() ?? 0);
-                    orderParameters.AddString("s", order.Quantity.Normalize());
+                    orderParameters.Add("p", order.Price?.Normalize() ?? 0);
+                    orderParameters.Add("s", order.Quantity.Normalize());
                     orderParameters.Add("r", order.ReduceOnly ?? false);
-                    var triggerParameters = new ParameterCollection();
+                    var triggerParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
                     triggerParameters.Add("isMarket", order.OrderType == OrderType.StopMarket);
-                    triggerParameters.AddString("triggerPx", order.TriggerPrice.Value.Normalize());
-                    triggerParameters.AddEnum("tpsl", order.TpSlType.Value);
+                    triggerParameters.Add("triggerPx", order.TriggerPrice.Value.Normalize());
+                    triggerParameters.Add("tpsl", order.TpSlType.Value);
                     orderTypeParameters.Add("trigger", triggerParameters);
                 }
 
                 orderParameters.Add("t", orderTypeParameters);
-                orderParameters.AddOptional("c", order.ClientOrderId);
+                orderParameters.Add("c", order.ClientOrderId);
 
                 orderRequests.Add(orderParameters);
             }
 
-            var actionParameters = new ParameterCollection
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "order" },
                 { "orders", orderRequests },
             };
 
             if (tpSlGrouping != null)
-                actionParameters.AddEnum("grouping", tpSlGrouping.Value);
+                actionParameters.Add("grouping", tpSlGrouping.Value);
             else
                 actionParameters.Add("grouping", "na");
 
@@ -439,7 +445,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 // Convert from percentage to 1/10 basis point
                 var tenthPoints = (int)(_baseClient.ClientOptions.BuilderFeePercentage * 1000);
                 actionParameters.Add("builder",
-                    new ParameterCollection
+                    new Parameters(HyperLiquidExchange._parameterSerializationSettings)
                     {
                         { "b", _baseClient.ClientOptions.BuilderAddress.ToLower() },
                         { "f", tenthPoints }
@@ -447,7 +453,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 );
             }
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "action", actionParameters }
             };
@@ -520,14 +526,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var orderRequests = new List<ParameterCollection>();
+            var orderRequests = new List<Parameters>();
             foreach (var order in requests)
             {
                 var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, order.Symbol).ConfigureAwait(false);
                 if (!symbolId)
                     return new WebCallResult<CallResult[]>(symbolId.Error);
 
-                orderRequests.Add(new ParameterCollection
+                orderRequests.Add(new Parameters(HyperLiquidExchange._parameterSerializationSettings)
                     {
                         { "a", symbolId.Data },
                         { "o", order.OrderId }
@@ -535,10 +541,10 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 );
             }
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 {
-                    "action", new ParameterCollection
+                    "action", new Parameters(HyperLiquidExchange._parameterSerializationSettings)
                     {
                         { "type", "cancel" },
                         { "cancels", orderRequests
@@ -605,14 +611,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var orderRequests = new List<ParameterCollection>();
+            var orderRequests = new List<Parameters>();
             foreach (var order in requests)
             {
                 var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, order.Symbol).ConfigureAwait(false);
                 if (!symbolId)
                     return new WebCallResult<CallResult[]>(symbolId.Error);
 
-                orderRequests.Add(new ParameterCollection
+                orderRequests.Add(new Parameters(HyperLiquidExchange._parameterSerializationSettings)
                     {
                         { "asset", symbolId.Data },
                         { "cloid", order.OrderId }
@@ -620,10 +626,10 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 );
             }
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 {
-                    "action", new ParameterCollection
+                    "action", new Parameters(HyperLiquidExchange._parameterSerializationSettings)
                     {
                         { "type", "cancelByCloid" },
                         { "cancels", orderRequests
@@ -668,12 +674,12 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection();
-            var actionParameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "scheduleCancel" }
             };
-            actionParameters.AddOptionalMilliseconds("time", timeout == null ? null : DateTime.UtcNow + timeout);
+            actionParameters.Add("time", timeout == null ? null : DateTime.UtcNow + timeout);
             parameters.Add("action", actionParameters);
 
             if (vaultAddress != null)
@@ -721,18 +727,18 @@ namespace HyperLiquid.Net.Clients.BaseApi
             if (!symbolId)
                 return new WebCallResult(symbolId.Error!);
 
-            var orderParameters = new ParameterCollection();
+            var orderParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
             orderParameters.Add("a", symbolId.Data);
             orderParameters.Add("b", side == OrderSide.Buy);
-            orderParameters.AddString("p", price.Normalize());
-            orderParameters.AddString("s", quantity.Normalize());
+            orderParameters.Add("p", price.Normalize());
+            orderParameters.Add("s", quantity.Normalize());
             orderParameters.Add("r", reduceOnly ?? false);
 
-            var orderTypeParameters = new ParameterCollection();
+            var orderTypeParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
             if (orderType == OrderType.Limit)
             {
-                var limitParameters = new ParameterCollection();
-                limitParameters.AddEnum("tif", timeInForce ?? TimeInForce.GoodTillCanceled);
+                var limitParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+                limitParameters.Add("tif", timeInForce ?? TimeInForce.GoodTillCanceled);
                 orderTypeParameters.Add("limit", limitParameters);
             }
             else
@@ -743,23 +749,23 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 if (tpSlType == null)
                     throw new ArgumentNullException(nameof(tpSlType), "Stop order should have a TpSlType");
 
-                var triggerParameters = new ParameterCollection();
+                var triggerParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
                 triggerParameters.Add("isMarket", orderType == OrderType.StopMarket);
-                triggerParameters.AddString("triggerPx", triggerPrice.Value.Normalize());
-                triggerParameters.AddEnum("tpsl", tpSlType.Value);
+                triggerParameters.Add("triggerPx", triggerPrice.Value.Normalize());
+                triggerParameters.Add("tpsl", tpSlType.Value);
                 orderTypeParameters.Add("trigger", triggerParameters);
             }
 
             orderParameters.Add("t", orderTypeParameters);
-            orderParameters.AddOptional("c", newClientOrderId);
+            orderParameters.Add("c", newClientOrderId);
 
-            var parameters = new ParameterCollection();
-            var actionParameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "modify" }
             };
-            actionParameters.AddOptional("oid", orderId);
-            actionParameters.AddOptional("oid", clientOrderId);
+            actionParameters.Add("oid", orderId);
+            actionParameters.Add("oid", clientOrderId);
             actionParameters.Add("order", orderParameters);
             parameters.Add("action", actionParameters);
 
@@ -786,7 +792,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var orderRequests = new List<ParameterCollection>();
+            var orderRequests = new List<Parameters>();
             foreach (var order in requests)
             {
                 if ((order.OrderId == null) == (order.ClientOrderId == null))
@@ -799,21 +805,21 @@ namespace HyperLiquid.Net.Clients.BaseApi
                 if (!symbolId)
                     return new WebCallResult<CallResult<HyperLiquidOrderResult>[]>(symbolId.Error!);
 
-                var modifyParameters = new ParameterCollection();
-                modifyParameters.AddOptional("oid", order.OrderId);
-                modifyParameters.AddOptional("oid", order.ClientOrderId);
-                var orderParameters = new ParameterCollection();
+                var modifyParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+                modifyParameters.Add("oid", order.OrderId);
+                modifyParameters.Add("oid", order.ClientOrderId);
+                var orderParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
                 orderParameters.Add("a", symbolId.Data);
                 orderParameters.Add("b", order.Side == OrderSide.Buy);
-                orderParameters.AddString("p", order.Price.Normalize());
-                orderParameters.AddString("s", order.Quantity.Normalize());
+                orderParameters.Add("p", order.Price.Normalize());
+                orderParameters.Add("s", order.Quantity.Normalize());
                 orderParameters.Add("r", order.ReduceOnly ?? false);
 
-                var orderTypeParameters = new ParameterCollection();
+                var orderTypeParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
                 if (order.OrderType is OrderType.Limit or OrderType.Market)
                 {
-                    var limitParameters = new ParameterCollection();
-                    limitParameters.AddEnum("tif", order.OrderType == OrderType.Market ? TimeInForce.ImmediateOrCancel : order.TimeInForce ?? TimeInForce.GoodTillCanceled);
+                    var limitParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+                    limitParameters.Add("tif", order.OrderType == OrderType.Market ? TimeInForce.ImmediateOrCancel : order.TimeInForce ?? TimeInForce.GoodTillCanceled);
                     orderTypeParameters.Add("limit", limitParameters);
                 }
                 else
@@ -824,25 +830,25 @@ namespace HyperLiquid.Net.Clients.BaseApi
                     if (order.TpSlType == null)
                         throw new ArgumentNullException(nameof(order.TpSlType), "Stop order should have a TpSlType");
 
-                    var triggerParameters = new ParameterCollection();
+                    var triggerParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
                     triggerParameters.Add("isMarket", order.OrderType == OrderType.StopMarket);
-                    triggerParameters.AddString("triggerPx", order.TriggerPrice.Value.Normalize());
-                    triggerParameters.AddEnum("tpsl", order.TpSlType.Value);
+                    triggerParameters.Add("triggerPx", order.TriggerPrice.Value.Normalize());
+                    triggerParameters.Add("tpsl", order.TpSlType.Value);
                     orderTypeParameters.Add("trigger", triggerParameters);
                 }
 
                 orderParameters.Add("t", orderTypeParameters);
 
-                orderParameters.AddOptional("c", order.ClientOrderId);
+                orderParameters.Add("c", order.ClientOrderId);
 
                 modifyParameters.Add("order", orderParameters);
                 orderRequests.Add(modifyParameters);
             }
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 {
-                    "action", new ParameterCollection
+                    "action", new Parameters(HyperLiquidExchange._parameterSerializationSettings)
                     {
                         { "type", "batchModify" },
                         { "modifies", orderRequests }
@@ -897,20 +903,20 @@ namespace HyperLiquid.Net.Clients.BaseApi
             if (!symbolId)
                 return new WebCallResult<HyperLiquidTwapOrderResult>(symbolId.Error);
 
-            var orderParameters = new ParameterCollection();
+            var orderParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
             orderParameters.Add("a", symbolId.Data);
             orderParameters.Add("b", orderSide == OrderSide.Buy);
-            orderParameters.AddString("s", quantity.Normalize());
+            orderParameters.Add("s", quantity.Normalize());
             orderParameters.Add("r", reduceOnly);
             orderParameters.Add("m", minutes);
             orderParameters.Add("t", randomize);
 
-            var actionParameters = new ParameterCollection()
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "twapOrder" },
                 { "twap", orderParameters }
             };
-            var parameters = new ParameterCollection
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "action", actionParameters }
             };
@@ -949,14 +955,14 @@ namespace HyperLiquid.Net.Clients.BaseApi
             if (!symbolId)
                 return new WebCallResult(symbolId.Error!);
 
-            var actionParameters = new ParameterCollection()
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "twapCancel" },
                 { "a", symbolId.Data },
                 { "t", twapId }
             };
 
-            var parameters = new ParameterCollection
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "action", actionParameters }
             };

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApi.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApi.cs
@@ -41,7 +41,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #endregion
 
         /// <inheritdoc />
-        protected override Task<WebCallResult<DateTime>> GetServerTimestampAsync() => throw new NotImplementedException();
+        protected override Task<HttpResult<DateTime>> GetServerTimestampAsync() => throw new NotImplementedException();
 
         /// <inheritdoc />
         public IHyperLiquidRestClientFuturesApiShared SharedClient => this;

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApi.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApi.cs
@@ -28,15 +28,15 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
         #region constructor/destructor
         internal HyperLiquidRestClientFuturesApi(
-            ILogger logger,
+            ILoggerFactory? loggerFactory,
             HyperLiquidRestClient baseClient,
             HttpClient? httpClient,
             HyperLiquidRestOptions options)
-            : base(logger, baseClient, httpClient, options, options.FuturesOptions)
+            : base(loggerFactory, baseClient, httpClient, options, options.FuturesOptions)
         {
             Account = new HyperLiquidRestClientFuturesApiAccount(this);
-            ExchangeData = new HyperLiquidRestClientFuturesApiExchangeData(logger, this);
-            Trading = new HyperLiquidRestClientFuturesApiTrading(logger, this);
+            ExchangeData = new HyperLiquidRestClientFuturesApiExchangeData(_logger, this);
+            Trading = new HyperLiquidRestClientFuturesApiTrading(_logger, this);
         }
         #endregion
 

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiAccount.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiAccount.cs
@@ -13,11 +13,6 @@ namespace HyperLiquid.Net.Clients.FuturesApi
     /// <inheritdoc />
     internal class HyperLiquidRestClientFuturesApiAccount : HyperLiquidRestClientApiAccount, IHyperLiquidRestClientFuturesApiAccount
     {
-        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
-        {
-            Decimal = DecimalSerialization.String,
-            Sort = false
-        };
         private static readonly RequestDefinitionCache _definitions = new RequestDefinitionCache();
         private readonly new HyperLiquidRestClientFuturesApi _baseClient;
 

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiAccount.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiAccount.cs
@@ -29,7 +29,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Get Futures Account
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidFuturesAccount>> GetAccountInfoAsync(string? address = null, string? dex = null, CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidFuturesAccount>> GetAccountInfoAsync(string? address = null, string? dex = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -42,7 +42,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
             };
             parameters.Add("dex", dex);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
             return await _baseClient.SendAsync<HyperLiquidFuturesAccount>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -51,7 +51,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Get Funding History
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidUserLedger<HyperLiquidUserFunding>[]>> GetFundingHistoryAsync(DateTime startTime, DateTime? endTime = null, string? address = null, CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidUserLedger<HyperLiquidUserFunding>[]>> GetFundingHistoryAsync(DateTime startTime, DateTime? endTime = null, string? address = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -65,7 +65,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             };
             parameters.Add("startTime", startTime);
             parameters.Add("endTime", endTime);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
             return await _baseClient.SendAsync<HyperLiquidUserLedger<HyperLiquidUserFunding>[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -74,7 +74,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Get User Symbol
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidFuturesUserSymbolUpdate>> GetUserSymbolAsync(string symbol, string? address = null, CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidFuturesUserSymbolUpdate>> GetUserSymbolAsync(string symbol, string? address = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -87,7 +87,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 { "coin", symbol },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
             return await _baseClient.SendAsync<HyperLiquidFuturesUserSymbolUpdate>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -96,7 +96,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Get HIP-3 DEX Abstraction
 
         /// <inheritdoc />
-        public async Task<WebCallResult<bool>> GetHip3DexAbstractionAsync(string? user = null, CancellationToken ct = default)
+        public async Task<HttpResult<bool>> GetHip3DexAbstractionAsync(string? user = null, CancellationToken ct = default)
         {
             if (user == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(user), "User needs to be provided if API credentials not set");
@@ -108,7 +108,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 { "type", "userDexAbstraction" },
                 { "user", user ?? _baseClient.AuthenticationProvider!.Key }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
             return await _baseClient.SendAsync<bool>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -117,7 +117,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Toggle HIP-3 DEX Abstraction
 
         /// <inheritdoc />
-        public async Task<WebCallResult> ToggleHip3DexAbstractionAsync(bool enabled, string? user = null, CancellationToken ct = default)
+        public async Task<HttpResult> ToggleHip3DexAbstractionAsync(bool enabled, string? user = null, CancellationToken ct = default)
         {
             if (user == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(user), "User needs to be provided if API credentials not set");
@@ -137,9 +137,8 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             actionParameters.Add("nonce", DateTime.UtcNow);
             parameters.Add("action", actionParameters);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, true);
-            var result = await _baseClient.SendAsync<HyperLiquidDefault>(request, parameters, ct).ConfigureAwait(false);
-            return result.AsDataless();
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, true);
+            return await _baseClient.SendAsync<HyperLiquidDefault>(request, parameters, ct).ConfigureAwait(false);
         }
 
         #endregion

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiAccount.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiAccount.cs
@@ -13,6 +13,11 @@ namespace HyperLiquid.Net.Clients.FuturesApi
     /// <inheritdoc />
     internal class HyperLiquidRestClientFuturesApiAccount : HyperLiquidRestClientApiAccount, IHyperLiquidRestClientFuturesApiAccount
     {
+        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
+        {
+            Decimal = DecimalSerialization.String,
+            Sort = false
+        };
         private static readonly RequestDefinitionCache _definitions = new RequestDefinitionCache();
         private readonly new HyperLiquidRestClientFuturesApi _baseClient;
 
@@ -31,12 +36,12 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "clearinghouseState" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
             };
-            parameters.AddOptional("dex", dex);
+            parameters.Add("dex", dex);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
             return await _baseClient.SendAsync<HyperLiquidFuturesAccount>(request, parameters, ct).ConfigureAwait(false);
         }
@@ -53,13 +58,13 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "userFunding" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
             };
-            parameters.AddMilliseconds("startTime", startTime);
-            parameters.AddOptionalMilliseconds("endTime", endTime);
+            parameters.Add("startTime", startTime);
+            parameters.Add("endTime", endTime);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
             return await _baseClient.SendAsync<HyperLiquidUserLedger<HyperLiquidUserFunding>[]>(request, parameters, ct).ConfigureAwait(false);
         }
@@ -76,7 +81,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "activeAssetData" },
                 { "coin", symbol },
@@ -98,7 +103,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "userDexAbstraction" },
                 { "user", user ?? _baseClient.AuthenticationProvider!.Key }
@@ -119,8 +124,8 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection();
-            var actionParameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "userDexAbstraction" },
                 { "hyperliquidChain", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? "Testnet" : "Mainnet" },
@@ -129,7 +134,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             };
 
             actionParameters.Add("enabled", enabled);
-            actionParameters.AddMilliseconds("nonce", DateTime.UtcNow);
+            actionParameters.Add("nonce", DateTime.UtcNow);
             parameters.Add("action", actionParameters);
 
             var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, true);

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiExchangeData.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiExchangeData.cs
@@ -44,6 +44,8 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             };
             var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             var result = await _baseClient.SendAsync<HyperLiquidFuturesExchangeInfo[]>(request, parameters, ct).ConfigureAwait(false);
+            if (!result.Success)
+                return HttpResult.Fail<HyperLiquidFuturesDexInfo[]>(result);
 
             for (var j = 0; j < result.Data.Length; j++)
             {

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiExchangeData.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiExchangeData.cs
@@ -26,7 +26,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
         public async Task<WebCallResult<HyperLiquidPerpDex[]>> GetPerpDexesAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "perpDexs" }
             };
@@ -38,7 +38,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
         public async Task<WebCallResult<HyperLiquidFuturesDexInfo[]>> GetExchangeInfoAllDexesAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "allPerpMetas" }
             };
@@ -89,11 +89,11 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         /// <inheritdoc />
         public async Task<WebCallResult<HyperLiquidFuturesSymbol[]>> GetExchangeInfoAsync(string? dex = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "meta" }
             };
-            parameters.AddOptional("dex", dex);
+            parameters.Add("dex", dex);
 
             var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             var result = await _baseClient.SendAsync<HyperLiquidFuturesExchangeInfo>(request, parameters, ct).ConfigureAwait(false);
@@ -132,7 +132,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         /// <inheritdoc />
         public async Task<WebCallResult<HyperLiquidFuturesExchangeInfoAndTickers>> GetExchangeInfoAndTickersAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "metaAndAssetCtxs" }
             };
@@ -157,14 +157,14 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         /// <inheritdoc />
         public async Task<WebCallResult<HyperLiquidFundingRate[]>> GetFundingRateHistoryAsync(string symbol, DateTime startTime, DateTime? endTime = null, CancellationToken ct = default)
         {
-            var innerParameters = new ParameterCollection();
-            var parameters = new ParameterCollection()
+            var innerParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "fundingHistory" },
             };
             parameters.Add("coin", symbol);
-            parameters.AddMilliseconds("startTime", startTime);
-            parameters.AddOptionalMilliseconds("endTime", endTime);
+            parameters.Add("startTime", startTime);
+            parameters.Add("endTime", endTime);
 
             var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             var result = await _baseClient.SendAsync<HyperLiquidFundingRate[]>(request, parameters, ct).ConfigureAwait(false);
@@ -181,11 +181,11 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         /// <inheritdoc />
         public async Task<WebCallResult<string[]>> GetSymbolsAtMaxOpenInterestAsync(string? dex = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "perpsAtOpenInterestCap" },
             };
-            parameters.AddOptional("dex", dex);
+            parameters.Add("dex", dex);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             return await _baseClient.SendAsync<string[]>(request, parameters, ct).ConfigureAwait(false);
         }
@@ -197,11 +197,11 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         /// <inheritdoc />
         public async Task<WebCallResult<HyperLiquidPerpDexLimit>> GetPerpDexMarketLimitsAsync(string? dex = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "perpDexLimits" },
             };
-            parameters.AddOptional("dex", dex);
+            parameters.Add("dex", dex);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             return await _baseClient.SendAsync<HyperLiquidPerpDexLimit>(request, parameters, ct).ConfigureAwait(false);
         }
@@ -213,11 +213,11 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         /// <inheritdoc />
         public async Task<WebCallResult<HyperLiquidPerpDexStatus>> GetPerpDexMarketStatusAsync(string? dex = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "perpDexStatus" },
             };
-            parameters.AddOptional("dex", dex);
+            parameters.Add("dex", dex);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             return await _baseClient.SendAsync<HyperLiquidPerpDexStatus>(request, parameters, ct).ConfigureAwait(false);
         }

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiExchangeData.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiExchangeData.cs
@@ -24,25 +24,25 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             _baseClient = baseClient;
         }
 
-        public async Task<WebCallResult<HyperLiquidPerpDex[]>> GetPerpDexesAsync(CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidPerpDex[]>> GetPerpDexesAsync(CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "perpDexs" }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             var result = await _baseClient.SendAsync<HyperLiquidPerpDex[]>(request, parameters, ct).ConfigureAwait(false);
 
             return result;
         }
 
-        public async Task<WebCallResult<HyperLiquidFuturesDexInfo[]>> GetExchangeInfoAllDexesAsync(CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidFuturesDexInfo[]>> GetExchangeInfoAllDexesAsync(CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "allPerpMetas" }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             var result = await _baseClient.SendAsync<HyperLiquidFuturesExchangeInfo[]>(request, parameters, ct).ConfigureAwait(false);
 
             for (var j = 0; j < result.Data.Length; j++)
@@ -72,7 +72,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             }
 
             int index = 0;
-            return result.As(result.Data.Select(x =>
+            return HttpResult.Ok(result, result.Data.Select(x =>
             {
                 var symbolName = x.Symbols.FirstOrDefault()?.Name;
                 return new HyperLiquidFuturesDexInfo
@@ -87,7 +87,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Get Futures Exchange Info
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidFuturesSymbol[]>> GetExchangeInfoAsync(string? dex = null, CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidFuturesSymbol[]>> GetExchangeInfoAsync(string? dex = null, CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
@@ -95,10 +95,10 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             };
             parameters.Add("dex", dex);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             var result = await _baseClient.SendAsync<HyperLiquidFuturesExchangeInfo>(request, parameters, ct).ConfigureAwait(false);
-            if (!result)
-                return result.As<HyperLiquidFuturesSymbol[]>(default);
+            if (!result.Success)
+                return HttpResult.Fail<HyperLiquidFuturesSymbol[]>(result);
 
             for (var i = 0; i < result.Data.Symbols.Count(); i++)
             {
@@ -122,7 +122,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 }
             }
 
-            return result.As<HyperLiquidFuturesSymbol[]>(result.Data?.Symbols);
+            return HttpResult.Ok(result, result.Data.Symbols);
         }
 
         #endregion
@@ -130,15 +130,15 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Get Futures Exchange Info And Tickers
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidFuturesExchangeInfoAndTickers>> GetExchangeInfoAndTickersAsync(CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidFuturesExchangeInfoAndTickers>> GetExchangeInfoAndTickersAsync(CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "metaAndAssetCtxs" }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             var result = await _baseClient.SendAsync<HyperLiquidFuturesExchangeInfoAndTickers>(request, parameters, ct).ConfigureAwait(false);
-            if (!result)
+            if (!result.Success)
                 return result;
 
             for (var i = 0; i < result.Data.ExchangeInfo.Symbols.Count(); i++)
@@ -155,7 +155,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Get Funding Rate History
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidFundingRate[]>> GetFundingRateHistoryAsync(string symbol, DateTime startTime, DateTime? endTime = null, CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidFundingRate[]>> GetFundingRateHistoryAsync(string symbol, DateTime startTime, DateTime? endTime = null, CancellationToken ct = default)
         {
             var innerParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
@@ -166,10 +166,10 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             parameters.Add("startTime", startTime);
             parameters.Add("endTime", endTime);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             var result = await _baseClient.SendAsync<HyperLiquidFundingRate[]>(request, parameters, ct).ConfigureAwait(false);
             if (result.ResponseStatusCode == (HttpStatusCode)500 && result.Error?.ErrorType == ErrorType.Unknown)
-                return result.AsError<HyperLiquidFundingRate[]>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
+                return HttpResult.Fail<HyperLiquidFundingRate[]>(result, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
             return result;
         }
@@ -179,14 +179,14 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Get Futures Symbols At Max Open Interest
 
         /// <inheritdoc />
-        public async Task<WebCallResult<string[]>> GetSymbolsAtMaxOpenInterestAsync(string? dex = null, CancellationToken ct = default)
+        public async Task<HttpResult<string[]>> GetSymbolsAtMaxOpenInterestAsync(string? dex = null, CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "perpsAtOpenInterestCap" },
             };
             parameters.Add("dex", dex);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             return await _baseClient.SendAsync<string[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -195,14 +195,14 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Get Perp DEX Market Limits
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidPerpDexLimit>> GetPerpDexMarketLimitsAsync(string? dex = null, CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidPerpDexLimit>> GetPerpDexMarketLimitsAsync(string? dex = null, CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "perpDexLimits" },
             };
             parameters.Add("dex", dex);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             return await _baseClient.SendAsync<HyperLiquidPerpDexLimit>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -211,14 +211,14 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Get Perp Market Status
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidPerpDexStatus>> GetPerpDexMarketStatusAsync(string? dex = null, CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidPerpDexStatus>> GetPerpDexMarketStatusAsync(string? dex = null, CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "perpDexStatus" },
             };
             parameters.Add("dex", dex);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             return await _baseClient.SendAsync<HyperLiquidPerpDexStatus>(request, parameters, ct).ConfigureAwait(false);
         }
 

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiShared.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiShared.cs
@@ -45,6 +45,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
                     return HttpResult.Ok<SharedBalance[]>(result, [
                         new SharedBalance(
+                            SupportedTradingModes,
                             "USDC",
                             result.Data.MarginSummary.AccountValue - result.Data.MarginSummary.TotalMarginUsed,
                             result.Data.MarginSummary.AccountValue)

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiShared.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiShared.cs
@@ -17,12 +17,11 @@ namespace HyperLiquid.Net.Clients.FuturesApi
     {
         private const string _exchangeName = "HyperLiquid";
         private const string _topicId = "HyperLiquidFutures";
-        public string Exchange => "HyperLiquid";
-
         public TradingMode[] SupportedTradingModes => new[] { TradingMode.PerpetualLinear };
 
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
 
 
         #region Balance Client
@@ -34,26 +33,23 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             }
         };
 
-        Task<HttpResult<SharedBalance[]>> IBalanceRestClient.GetBalancesAsync(GetBalancesRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedBalance[]>> IBalanceRestClient.GetBalancesAsync(GetBalancesRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IBalanceRestClient, GetBalancesRequest, SharedBalance[]>(
-                this,
-                client => client.GetBalancesOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetBalancesOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedBalance[]>(Exchange, validationError);
                     string? dex = request.GetParamValue<string>(Exchange, "dex");
                     var result = await Account.GetAccountInfoAsync(dex: dex, ct: ct).ConfigureAwait(false);
-                    if (!result)
-                        return SharedExecutionResult<SharedBalance[]>.Error(result);
+                    if (!result.Success)
+                        return HttpResult.Fail<SharedBalance[]>(result);
 
-                    return SharedExecutionResult<SharedBalance[]>.Ok(result, [
+                    return HttpResult.Ok<SharedBalance[]>(result, [
                         new SharedBalance(
                             "USDC",
                             result.Data.MarginSummary.AccountValue - result.Data.MarginSummary.TotalMarginUsed,
                             result.Data.MarginSummary.AccountValue)
                         ]);
-                });
+                
         }
 
         #endregion
@@ -77,17 +73,12 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             MaxTotalDataPoints = 5000
         };
 
-        Task<HttpResult<SharedKline[]>> IKlineRestClient.GetKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        async Task<HttpResult<SharedKline[]>> IKlineRestClient.GetKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IKlineRestClient, GetKlinesRequest, SharedKline[]>(
-                this,
-                client => client.GetKlinesOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetKlinesOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedKline[]>(Exchange, validationError);
             var interval = (Enums.KlineInterval)request.Interval;
-            if (!Enum.IsDefined(typeof(Enums.KlineInterval), interval))
-                return SharedExecutionResult<SharedKline[]>.Error(ArgumentError.Invalid(nameof(GetKlinesRequest.Interval), "Interval not supported"));
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             int limit = request.Limit ?? 1000;
@@ -102,8 +93,8 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 endTime: pageParams.EndTime ?? DateTime.UtcNow,
                 ct: ct
                 ).ConfigureAwait(false);
-            if (!result)
-                return SharedExecutionResult<SharedKline[]>.Error(result);
+            if (!result.Success)
+                return HttpResult.Fail<SharedKline[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                      () => Pagination.NextPageFromTime(pageParams, result.Data.Min(x => x.OpenTime)),
@@ -113,7 +104,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                      request.EndTime ?? DateTime.UtcNow,
                      pageParams);
 
-            return SharedExecutionResult<SharedKline[]>.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.OpenTime, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.OpenTime, request.StartTime, request.EndTime, direction)
                     .Select(x =>
                         new SharedKline(
                             request.Symbol,
@@ -125,30 +116,27 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                             x.OpenPrice,
                             x.Volume))
                     .ToArray(), nextPageRequest);
-                                });
+                                
         }
 
         #endregion
 
         #region Order Book client
         GetOrderBookOptions IOrderBookRestClient.GetOrderBookOptions { get; } = new GetOrderBookOptions(_exchangeName, [20], false);
-        Task<HttpResult<SharedOrderBook>> IOrderBookRestClient.GetOrderBookAsync(GetOrderBookRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedOrderBook>> IOrderBookRestClient.GetOrderBookAsync(GetOrderBookRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IOrderBookRestClient, GetOrderBookRequest, SharedOrderBook>(
-                this,
-                client => client.GetOrderBookOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetOrderBookOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedOrderBook>(Exchange, validationError);
 
             var result = await ExchangeData.GetOrderBookAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return SharedExecutionResult<SharedOrderBook>.Error(result);
+            if (!result.Success)
+                return HttpResult.Fail<SharedOrderBook>(result);
 
-            return SharedExecutionResult<SharedOrderBook>.Ok(result, new SharedOrderBook(result.Data.Levels.Asks, result.Data.Levels.Bids));
-                                });
+            return HttpResult.Ok(result, new SharedOrderBook(result.Data.Levels.Asks, result.Data.Levels.Bids));
+                                
         }
 
         #endregion
@@ -156,87 +144,78 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Ticker client
 
         GetFuturesTickerOptions IFuturesTickerRestClient.GetFuturesTickerOptions { get; } = new GetFuturesTickerOptions(_exchangeName);
-        Task<HttpResult<SharedFuturesTicker>> IFuturesTickerRestClient.GetFuturesTickerAsync(GetTickerRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedFuturesTicker>> IFuturesTickerRestClient.GetFuturesTickerAsync(GetTickerRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IFuturesTickerRestClient, GetTickerRequest, SharedFuturesTicker>(
-                this,
-                client => client.GetFuturesTickerOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetFuturesTickerOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedFuturesTicker>(Exchange, validationError);
 
             var symbolName = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.GetExchangeInfoAndTickersAsync(ct: ct).ConfigureAwait(false);
-            if (!result)
-                return SharedExecutionResult<SharedFuturesTicker>.Error(result);
+            if (!result.Success)
+                return HttpResult.Fail<SharedFuturesTicker>(result);
 
             var symbol = result.Data.Tickers.SingleOrDefault(x => x.Symbol == symbolName);
             if (symbol == null)
-                return SharedExecutionResult<SharedFuturesTicker>.Error(result.AsError<SharedFuturesTicker>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found"))));
+                return HttpResult.Fail<SharedFuturesTicker>(result, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
-            return SharedExecutionResult<SharedFuturesTicker>.Ok(result, new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicId, symbol.Symbol), symbol.Symbol, symbol.MidPrice, null, null, symbol.NotionalVolume, (symbol.MidPrice == null || symbol.PreviousDayPrice == 0) ? null : Math.Round((symbol.MidPrice.Value / symbol.PreviousDayPrice * 100 - 100), 3))
+            return HttpResult.Ok(result, new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicId, symbol.Symbol), symbol.Symbol, symbol.MidPrice, null, null, symbol.NotionalVolume, (symbol.MidPrice == null || symbol.PreviousDayPrice == 0) ? null : Math.Round((symbol.MidPrice.Value / symbol.PreviousDayPrice * 100 - 100), 3))
             {
                 FundingRate = symbol.FundingRate,
                 MarkPrice = symbol.MarkPrice
             });
-                                });
+                                
         }
 
         GetFuturesTickersOptions IFuturesTickerRestClient.GetFuturesTickersOptions { get; } = new GetFuturesTickersOptions(_exchangeName);
-        Task<HttpResult<SharedFuturesTicker[]>> IFuturesTickerRestClient.GetFuturesTickersAsync(GetTickersRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedFuturesTicker[]>> IFuturesTickerRestClient.GetFuturesTickersAsync(GetTickersRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IFuturesTickerRestClient, GetTickersRequest, SharedFuturesTicker[]>(
-                this,
-                client => client.GetFuturesTickersOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetFuturesTickersOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedFuturesTicker[]>(Exchange, validationError);
 
             var result = await ExchangeData.GetExchangeInfoAndTickersAsync(ct: ct).ConfigureAwait(false);
-            if (!result)
-                return SharedExecutionResult<SharedFuturesTicker[]>.Error(result);
+            if (!result.Success)
+                return HttpResult.Fail<SharedFuturesTicker[]>(result);
 
-            return SharedExecutionResult<SharedFuturesTicker[]>.Ok(result, result.Data.Tickers.Select(x => new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), x.Symbol, x.MidPrice, null, null, x.NotionalVolume, (x.MidPrice == null || x.PreviousDayPrice == 0) ? null : Math.Round((x.MidPrice.Value / x.PreviousDayPrice * 100 - 100), 3))
+            return HttpResult.Ok(result, result.Data.Tickers.Select(x => new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), x.Symbol, x.MidPrice, null, null, x.NotionalVolume, (x.MidPrice == null || x.PreviousDayPrice == 0) ? null : Math.Round((x.MidPrice.Value / x.PreviousDayPrice * 100 - 100), 3))
             {
                 FundingRate = x.FundingRate,
                 MarkPrice = x.MarkPrice
             }).ToArray());
-                                });
+                                
         }
 
         #endregion
 
         #region Book Ticker client
 
-        EndpointOptions<GetBookTickerRequest, IBookTickerRestClient> IBookTickerRestClient.GetBookTickerOptions { get; } = new EndpointOptions<GetBookTickerRequest, IBookTickerRestClient>(_exchangeName, false);
-        Task<HttpResult<SharedBookTicker>> IBookTickerRestClient.GetBookTickerAsync(GetBookTickerRequest request, CancellationToken ct)
+        GetBookTickerOptions IBookTickerRestClient.GetBookTickerOptions { get; } = new GetBookTickerOptions(_exchangeName, false);
+        async Task<HttpResult<SharedBookTicker>> IBookTickerRestClient.GetBookTickerAsync(GetBookTickerRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IBookTickerRestClient, GetBookTickerRequest, SharedBookTicker>(
-                this,
-                client => client.GetBookTickerOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetBookTickerOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedBookTicker>(Exchange, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var resultTicker = await ExchangeData.GetOrderBookAsync(symbol, ct: ct).ConfigureAwait(false);
-            if (!resultTicker)
-                return SharedExecutionResult<SharedBookTicker>.Error(resultTicker);
+            if (!resultTicker.Success)
+                return HttpResult.Fail<SharedBookTicker>(resultTicker);
 
-            return SharedExecutionResult<SharedBookTicker>.Ok(resultTicker, new SharedBookTicker(
+            return HttpResult.Ok(resultTicker, new SharedBookTicker(
                 ExchangeSymbolCache.ParseSymbol(_topicId, symbol),
                 symbol,
                 resultTicker.Data.Levels.Asks[0].Price,
                 resultTicker.Data.Levels.Asks[0].Quantity,
                 resultTicker.Data.Levels.Bids[0].Price,
                 resultTicker.Data.Levels.Bids[0].Quantity));
-                                });
+                                
         }
 
         #endregion
 
         #region Futures Symbol client
-        EndpointOptions<GetSymbolsRequest, IFuturesSymbolRestClient> IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new EndpointOptions<GetSymbolsRequest, IFuturesSymbolRestClient>(_exchangeName, false)
+        GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false)
         {
             OptionalExchangeParameters = new List<ParameterDescription>
             {
@@ -244,19 +223,16 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             }
         };
 
-        Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IFuturesSymbolRestClient, GetSymbolsRequest, SharedFuturesSymbol[]>(
-                this,
-                client => client.GetFuturesSymbolsOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetFuturesSymbolsOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedFuturesSymbol[]>(Exchange, validationError);
 
-            string? dex = ExchangeParameters.GetProcessValue<string>(request.ExchangeParameters, Exchange, "dex");
+            string? dex = ExchangeParameters.GetValue<string>(request.ExchangeParameters, Exchange, "dex");
             var result = await ExchangeData.GetExchangeInfoAllDexesAsync(ct: ct).ConfigureAwait(false);
-            if (!result)
-                return SharedExecutionResult<SharedFuturesSymbol[]>.Error(result);
+            if (!result.Success)
+                return HttpResult.Fail<SharedFuturesSymbol[]>(result);
 
             var data = result.Data.SelectMany(x => x.Symbols);
             if (dex != null)
@@ -269,8 +245,8 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 .Concat(result.Data.SelectMany(x => x.Symbols.Select(x => new SharedSpotSymbol(x.Name, "USDC", x.Name, true, TradingMode.PerpetualLinear)))).ToArray();
 
             ExchangeSymbolCache.UpdateSymbolInfo(_topicId, symbolRegistrations);
-            return SharedExecutionResult<SharedFuturesSymbol[]>.Ok(result, response);
-                                });
+            return HttpResult.Ok(result, response);
+                                
         }
 
         private SharedFuturesSymbol ParseSymbol(HyperLiquidFuturesSymbol symbol)
@@ -292,19 +268,19 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             };
         }
 
-        async Task<WebSocketResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)
+        async Task<ExchangeCallResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)
         {
             if (!ExchangeSymbolCache.HasCached(_topicId))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new WebSocketResult<SharedSymbol[]>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<SharedSymbol[]>.Fail(Exchange, symbols.Error!);
             }
 
-            return new WebSocketResult<SharedSymbol[]>(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicId, baseAsset));
+            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicId, baseAsset));
         }
 
-        async Task<WebSocketResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(SharedSymbol symbol)
+        async Task<ExchangeCallResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(SharedSymbol symbol)
         {
             if (symbol.TradingMode == TradingMode.Spot)
                 throw new ArgumentException(nameof(symbol), "Spot symbols not allowed");
@@ -312,60 +288,54 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             if (!ExchangeSymbolCache.HasCached(_topicId))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new WebSocketResult<bool>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return new WebSocketResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbol));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbol));
         }
 
-        async Task<WebSocketResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(string symbolName)
+        async Task<ExchangeCallResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(string symbolName)
         {
             if (!ExchangeSymbolCache.HasCached(_topicId))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new WebSocketResult<bool>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return new WebSocketResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbolName));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbolName));
         }
         #endregion
 
         #region Fee Client
-        EndpointOptions<GetFeeRequest, IFeeRestClient> IFeeRestClient.GetFeeOptions { get; } = new EndpointOptions<GetFeeRequest, IFeeRestClient>(_exchangeName, true);
+        GetFeeOptions IFeeRestClient.GetFeeOptions { get; } = new GetFeeOptions(_exchangeName, true);
 
-        Task<HttpResult<SharedFee>> IFeeRestClient.GetFeesAsync(GetFeeRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedFee>> IFeeRestClient.GetFeesAsync(GetFeeRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IFeeRestClient, GetFeeRequest, SharedFee>(
-                this,
-                client => client.GetFeeOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetFeeOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedFee>(Exchange, validationError);
 
             // Get data
             var result = await Account.GetFeeInfoAsync(ct: ct).ConfigureAwait(false);
-            if (!result)
-                return SharedExecutionResult<SharedFee>.Error(result);
+            if (!result.Success)
+                return HttpResult.Fail<SharedFee>(result);
 
             // Return
-            return SharedExecutionResult<SharedFee>.Ok(result, new SharedFee(result.Data.MakerFeeRate * 100, result.Data.TakerFeeRate * 100));
-                                });
+            return HttpResult.Ok(result, new SharedFee(result.Data.MakerFeeRate * 100, result.Data.TakerFeeRate * 100));
+                                
         }
         #endregion
 
         #region Funding Rate client
         GetFundingRateHistoryOptions IFundingRateRestClient.GetFundingRateHistoryOptions { get; } = new GetFundingRateHistoryOptions(_exchangeName, true, false, true, 500, false);
 
-        Task<HttpResult<SharedFundingRate[]>> IFundingRateRestClient.GetFundingRateHistoryAsync(GetFundingRateHistoryRequest request, PageRequest? pageToken, CancellationToken ct)
+        async Task<HttpResult<SharedFundingRate[]>> IFundingRateRestClient.GetFundingRateHistoryAsync(GetFundingRateHistoryRequest request, PageRequest? pageToken, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IFundingRateRestClient, GetFundingRateHistoryRequest, SharedFundingRate[]>(
-                this,
-                client => client.GetFundingRateHistoryOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetFundingRateHistoryOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedFundingRate[]>(Exchange, validationError);
 
             //DateTime? fromTime = null;
             //if (pageToken is DateTimeToken token)
@@ -377,49 +347,46 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 request.StartTime ?? DateTime.UtcNow.AddDays(-30),
                 //endTime: request.EndTime,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return SharedExecutionResult<SharedFundingRate[]>.Error(result);
+            if (!result.Success)
+                return HttpResult.Fail<SharedFundingRate[]>(result);
 
             //DateTimeToken? nextToken = null;
             //if (result.Data.Count() == (request.Limit ?? 500))
             //    nextToken = new DateTimeToken(result.Data.Max(x => x.Timestamp).AddSeconds(1));
 
             // Return
-            return SharedExecutionResult<SharedFundingRate[]>.Ok(result, result.Data.Select(x => new SharedFundingRate(x.FundingRate, x.Timestamp)).ToArray()/*, nextToken*/);
-                                });
+            return HttpResult.Ok(result, result.Data.Select(x => new SharedFundingRate(x.FundingRate, x.Timestamp)).ToArray()/*, nextToken*/);
+                                
         }
         #endregion
 
         #region Leverage client
         SharedLeverageSettingMode ILeverageRestClient.LeverageSettingType => SharedLeverageSettingMode.PerSymbol;
 
-        EndpointOptions<GetLeverageRequest, ILeverageRestClient> ILeverageRestClient.GetLeverageOptions { get; } = new EndpointOptions<GetLeverageRequest, ILeverageRestClient>(_exchangeName, true)
+        GetLeverageOptions ILeverageRestClient.GetLeverageOptions { get; } = new GetLeverageOptions(_exchangeName, true)
         {
             OptionalExchangeParameters = new List<ParameterDescription>
             {
                 new ParameterDescription("dex", typeof(string), "DEX to retrieve leverage for", "xyz")
             }
         };
-        Task<HttpResult<SharedLeverage>> ILeverageRestClient.GetLeverageAsync(GetLeverageRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedLeverage>> ILeverageRestClient.GetLeverageAsync(GetLeverageRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<ILeverageRestClient, GetLeverageRequest, SharedLeverage>(
-                this,
-                client => client.GetLeverageOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetLeverageOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedLeverage>(Exchange, validationError);
 
-            string? dex = ExchangeParameters.GetProcessValue<string>(request.ExchangeParameters, Exchange, "dex");
+            string? dex = ExchangeParameters.GetValue<string>(request.ExchangeParameters, Exchange, "dex");
             var result = await Account.GetAccountInfoAsync(dex: dex, ct: ct).ConfigureAwait(false);
-            if (!result)
-                return SharedExecutionResult<SharedLeverage>.Error(result);
+            if (!result.Success)
+                return HttpResult.Fail<SharedLeverage>(result);
 
             var position = result.Data.Positions.SingleOrDefault(x => x.Position.Symbol == request.Symbol!.GetSymbol(FormatSymbol));
             if (position == null)
-                return SharedExecutionResult<SharedLeverage>.Error(result.AsError<SharedLeverage>(new ServerError(new ErrorInfo(ErrorType.NoPosition, "Not found"))));
+                return HttpResult.Fail<SharedLeverage>(result, new ServerError(new ErrorInfo(ErrorType.NoPosition, "Not found")));
 
-            return SharedExecutionResult<SharedLeverage>.Ok(result, new SharedLeverage(position.Position.Leverage!.Value));
-                                });
+            return HttpResult.Ok(result, new SharedLeverage(position.Position.Leverage!.Value));
+                                
         }
 
         SetLeverageOptions ILeverageRestClient.SetLeverageOptions { get; } = new SetLeverageOptions(_exchangeName)
@@ -429,49 +396,43 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 new ParameterDescription(nameof(SetLeverageRequest.MarginMode), typeof(SharedMarginMode), "Margin mode", SharedMarginMode.Isolated)
             }
         };
-        Task<HttpResult<SharedLeverage>> ILeverageRestClient.SetLeverageAsync(SetLeverageRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedLeverage>> ILeverageRestClient.SetLeverageAsync(SetLeverageRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<ILeverageRestClient, SetLeverageRequest, SharedLeverage>(
-                this,
-                client => client.SetLeverageOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.SetLeverageOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedLeverage>(Exchange, validationError);
 
             var result = await Trading.SetLeverageAsync(symbol: request.Symbol!.GetSymbol(FormatSymbol), (int)request.Leverage, request.MarginMode == SharedMarginMode.Isolated ? Enums.MarginType.Isolated : Enums.MarginType.Cross, ct: ct).ConfigureAwait(false);
-            if (!result)
-                return SharedExecutionResult<SharedLeverage>.Error(result);
+            if (!result.Success)
+                return HttpResult.Fail<SharedLeverage>(result);
 
-            return SharedExecutionResult<SharedLeverage>.Ok(result, new SharedLeverage(request.Leverage)
+            return HttpResult.Ok(result, new SharedLeverage(request.Leverage)
             {
                 MarginMode = request.MarginMode
             });
-                                });
+                                
         }
         #endregion
 
         #region Open Interest client
 
-        EndpointOptions<GetOpenInterestRequest, IOpenInterestRestClient> IOpenInterestRestClient.GetOpenInterestOptions { get; } = new EndpointOptions<GetOpenInterestRequest, IOpenInterestRestClient>(_exchangeName, true);
-        Task<HttpResult<SharedOpenInterest>> IOpenInterestRestClient.GetOpenInterestAsync(GetOpenInterestRequest request, CancellationToken ct)
+        GetOpenInterestOptions IOpenInterestRestClient.GetOpenInterestOptions { get; } = new GetOpenInterestOptions(_exchangeName, true);
+        async Task<HttpResult<SharedOpenInterest>> IOpenInterestRestClient.GetOpenInterestAsync(GetOpenInterestRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IOpenInterestRestClient, GetOpenInterestRequest, SharedOpenInterest>(
-                this,
-                client => client.GetOpenInterestOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetOpenInterestOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedOpenInterest>(Exchange, validationError);
 
             var result = await ExchangeData.GetExchangeInfoAndTickersAsync(ct: ct).ConfigureAwait(false);
-            if (!result)
-                return SharedExecutionResult<SharedOpenInterest>.Error(result);
+            if (!result.Success)
+                return HttpResult.Fail<SharedOpenInterest>(result);
 
             var ticker = result.Data.Tickers.SingleOrDefault(x => x.Symbol == request.Symbol!.GetSymbol(FormatSymbol));
             if (ticker == null)
-                return SharedExecutionResult<SharedOpenInterest>.Error(result.AsError<SharedOpenInterest>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found"))));
+                return HttpResult.Fail<SharedOpenInterest>(result, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
-            return SharedExecutionResult<SharedOpenInterest>.Ok(result, new SharedOpenInterest(ticker.OpenInterest ?? 0));
-                                });
+            return HttpResult.Ok(result, new SharedOpenInterest(ticker.OpenInterest ?? 0));
+                                
         }
 
         #endregion
@@ -498,14 +459,11 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 new ParameterDescription(nameof(PlaceSpotOrderRequest.Price), typeof(decimal), "Price for the order. For market orders this should be the current symbol price", 21.5m)
             }
         };
-        Task<HttpResult<SharedId>> IFuturesOrderRestClient.PlaceFuturesOrderAsync(PlaceFuturesOrderRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> IFuturesOrderRestClient.PlaceFuturesOrderAsync(PlaceFuturesOrderRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IFuturesOrderRestClient, PlaceFuturesOrderRequest, SharedId>(
-                this,
-                client => client.PlaceFuturesOrderOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.PlaceFuturesOrderOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var result = await Trading.PlaceOrderAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
@@ -518,31 +476,28 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 clientOrderId: request.ClientOrderId,
                 ct: ct).ConfigureAwait(false);
 
-            if (!result)
-                return SharedExecutionResult<SharedId>.Error(result);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
-            return SharedExecutionResult<SharedId>.Ok(result, new SharedId(result.Data.OrderId.ToString()));
-                                });
+            return HttpResult.Ok(result, new SharedId(result.Data.OrderId.ToString()));
+                                
         }
 
-        EndpointOptions<GetOrderRequest, IFuturesOrderRestClient> IFuturesOrderRestClient.GetFuturesOrderOptions { get; } = new EndpointOptions<GetOrderRequest, IFuturesOrderRestClient>(_exchangeName, true);
-        Task<HttpResult<SharedFuturesOrder>> IFuturesOrderRestClient.GetFuturesOrderAsync(GetOrderRequest request, CancellationToken ct)
+        GetFuturesOrderOptions IFuturesOrderRestClient.GetFuturesOrderOptions { get; } = new GetFuturesOrderOptions(_exchangeName, true);
+        async Task<HttpResult<SharedFuturesOrder>> IFuturesOrderRestClient.GetFuturesOrderAsync(GetOrderRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IFuturesOrderRestClient, GetOrderRequest, SharedFuturesOrder>(
-                this,
-                client => client.GetFuturesOrderOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetFuturesOrderOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedFuturesOrder>(Exchange, validationError);
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return SharedExecutionResult<SharedFuturesOrder>.Error(ArgumentError.Invalid(nameof(GetOrderRequest.OrderId), "Invalid order id"));
+                return HttpResult.Fail<SharedFuturesOrder>(Exchange, ArgumentError.Invalid(nameof(GetOrderRequest.OrderId), "Invalid order id"));
 
             var order = await Trading.GetOrderAsync(orderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return SharedExecutionResult<SharedFuturesOrder>.Error(order);
+            if (!order.Success)
+                return HttpResult.Fail<SharedFuturesOrder>(order);
 
-            return SharedExecutionResult<SharedFuturesOrder>.Ok(order, new SharedFuturesOrder(
+            return HttpResult.Ok(order, new SharedFuturesOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicId, order.Data.Order.Symbol),
                 order.Data.Order.Symbol!,
                 order.Data.Order.OrderId.ToString(),
@@ -561,29 +516,26 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 TriggerPrice = order.Data.Order.TriggerPrice == 0 ? null : order.Data.Order.TriggerPrice,
                 IsTriggerOrder = order.Data.Order.TriggerPrice > 0
             });
-                                });
+                                
         }
 
-        EndpointOptions<GetOpenOrdersRequest, IFuturesOrderRestClient> IFuturesOrderRestClient.GetOpenFuturesOrdersOptions { get; } = new EndpointOptions<GetOpenOrdersRequest, IFuturesOrderRestClient>(_exchangeName, true)
+        GetOpenFuturesOrdersOptions IFuturesOrderRestClient.GetOpenFuturesOrdersOptions { get; } = new GetOpenFuturesOrdersOptions(_exchangeName, true)
         {
             OptionalExchangeParameters = new List<ParameterDescription>
             {
                 new ParameterDescription("dex", typeof(string), "DEX to retrieve open orders for", "xyz")
             }
         };
-        Task<HttpResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetOpenFuturesOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetOpenFuturesOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IFuturesOrderRestClient, GetOpenOrdersRequest, SharedFuturesOrder[]>(
-                this,
-                client => client.GetOpenFuturesOrdersOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetOpenFuturesOrdersOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedFuturesOrder[]>(Exchange, validationError);
 
             var symbol = request.Symbol?.GetSymbol(FormatSymbol);
 
             // Get dex from parameters or symbol (if symbol is in format DEX:SYMBOL)
-            string? dex = ExchangeParameters.GetProcessValue<string>(request.ExchangeParameters, Exchange, "dex");
+            string? dex = ExchangeParameters.GetValue<string>(request.ExchangeParameters, Exchange, "dex");
             if (dex == null && symbol != null)
             {
                 var dexSeparatorIndex = symbol.IndexOf(':');
@@ -592,14 +544,14 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             }
 
             var orders = await Trading.GetOpenOrdersExtendedAsync(dex: dex, ct: ct).ConfigureAwait(false);
-            if (!orders)
-                return SharedExecutionResult<SharedFuturesOrder[]>.Error(orders);
+            if (!orders.Success)
+                return HttpResult.Fail<SharedFuturesOrder[]>(orders);
 
             var data = orders.Data.Where(x => x.SymbolType == Enums.SymbolType.Futures);
             if (symbol != null)
                 data = data.Where(x => x.Symbol == symbol);
 
-            return SharedExecutionResult<SharedFuturesOrder[]>.Ok(orders, orders.Data.Select(x => new SharedFuturesOrder(
+            return HttpResult.Ok(orders, orders.Data.Select(x => new SharedFuturesOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol),
                 x.Symbol!,
                 x.OrderId.ToString(),
@@ -618,23 +570,20 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 TriggerPrice = x.TriggerPrice == 0 ? null : x.TriggerPrice,
                 IsTriggerOrder = x.TriggerPrice > 0
             }).ToArray());
-                                });
+                                
         }
 
         GetFuturesClosedOrdersOptions IFuturesOrderRestClient.GetClosedFuturesOrdersOptions { get; } = new GetFuturesClosedOrdersOptions(_exchangeName, true, true, false, 2000);
-        Task<HttpResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetClosedFuturesOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageToken, CancellationToken ct)
+        async Task<HttpResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetClosedFuturesOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageToken, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IFuturesOrderRestClient, GetClosedOrdersRequest, SharedFuturesOrder[]>(
-                this,
-                client => client.GetClosedFuturesOrdersOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetClosedFuturesOrdersOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedFuturesOrder[]>(Exchange, validationError);
 
             // Get data
             var orders = await Trading.GetOrderHistoryAsync(ct: ct).ConfigureAwait(false);
-            if (!orders)
-                return SharedExecutionResult<SharedFuturesOrder[]>.Error(orders);
+            if (!orders.Success)
+                return HttpResult.Fail<SharedFuturesOrder[]>(orders);
 
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
@@ -645,7 +594,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             if (request.Limit != null)
                 data = data.Take(request.Limit.Value);
 
-            return SharedExecutionResult<SharedFuturesOrder[]>.Ok(orders, ExchangeHelpers.ApplyFilter(data, x => x.Timestamp, request.StartTime, request.EndTime, request.Direction ?? DataDirection.Descending)
+            return HttpResult.Ok(orders, ExchangeHelpers.ApplyFilter(data, x => x.Timestamp, request.StartTime, request.EndTime, request.Direction ?? DataDirection.Descending)
                 .Select(x =>
                     new SharedFuturesOrder(
                         ExchangeSymbolCache.ParseSymbol(_topicId, x.Order.Symbol!), 
@@ -666,28 +615,25 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                         TriggerPrice = x.Order.TriggerPrice == 0 ? null : x.Order.TriggerPrice,
                         IsTriggerOrder = x.Order.TriggerPrice > 0
                     }).ToArray());
-                                });
+                                
         }
 
-        EndpointOptions<GetOrderTradesRequest, IFuturesOrderRestClient> IFuturesOrderRestClient.GetFuturesOrderTradesOptions { get; } = new EndpointOptions<GetOrderTradesRequest, IFuturesOrderRestClient>(_exchangeName, true);
-        Task<HttpResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
+        GetFuturesOrderTradesOptions IFuturesOrderRestClient.GetFuturesOrderTradesOptions { get; } = new GetFuturesOrderTradesOptions(_exchangeName, true);
+        async Task<HttpResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IFuturesOrderRestClient, GetOrderTradesRequest, SharedUserTrade[]>(
-                this,
-                client => client.GetFuturesOrderTradesOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetFuturesOrderTradesOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, validationError);
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return SharedExecutionResult<SharedUserTrade[]>.Error(ArgumentError.Invalid(nameof(GetOrderTradesRequest.OrderId), "Invalid order id"));
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, ArgumentError.Invalid(nameof(GetOrderTradesRequest.OrderId), "Invalid order id"));
 
             var orders = await Trading.GetUserTradesAsync(ct: ct).ConfigureAwait(false);
-            if (!orders)
-                return SharedExecutionResult<SharedUserTrade[]>.Error(orders);
+            if (!orders.Success)
+                return HttpResult.Fail<SharedUserTrade[]>(orders);
 
             var data = orders.Data.Where(x => x.OrderId == orderId);
-            return SharedExecutionResult<SharedUserTrade[]>.Ok(orders, data.Select(x => new SharedUserTrade(
+            return HttpResult.Ok(orders, data.Select(x => new SharedUserTrade(
                 ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), 
                 x.Symbol,
                 x.OrderId.ToString(),
@@ -701,18 +647,15 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 FeeAsset = x.FeeToken,
                 Role = x.Crossed ? SharedRole.Taker : SharedRole.Maker
             }).ToArray());
-                                });
+                                
         }
 
         GetFuturesUserTradesOptions IFuturesOrderRestClient.GetFuturesUserTradesOptions { get; } = new GetFuturesUserTradesOptions(_exchangeName, true, false, true, 2000);
-        Task<HttpResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        async Task<HttpResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IFuturesOrderRestClient, GetUserTradesRequest, SharedUserTrade[]>(
-                this,
-                client => client.GetFuturesUserTradesOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetFuturesUserTradesOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, validationError);
 
             int limit = request.Limit ?? 2000;
             var direction = DataDirection.Ascending;
@@ -723,8 +666,8 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 startTime: pageParams.StartTime ?? DateTime.UtcNow.AddDays(-7),
                 ct: ct
                 ).ConfigureAwait(false);
-            if (!result)
-                return SharedExecutionResult<SharedUserTrade[]>.Error(result);
+            if (!result.Success)
+                return HttpResult.Fail<SharedUserTrade[]>(result);
 
             var data = result.Data.Where(x => x.Symbol == request.Symbol!.GetSymbol(FormatSymbol));
             var nextPageRequest = Pagination.GetNextPageRequest(
@@ -735,7 +678,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                      request.EndTime ?? DateTime.UtcNow,
                      pageParams);
 
-            return SharedExecutionResult<SharedUserTrade[]>.Ok(result, ExchangeHelpers.ApplyFilter(data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
                     .Select(x =>
                         new SharedUserTrade(
                             ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), 
@@ -752,57 +695,51 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                             Role = x.Crossed ? SharedRole.Taker : SharedRole.Maker
                         })
                     .ToArray(), nextPageRequest);
-                                });
+                                
         }
 
-        EndpointOptions<CancelOrderRequest, IFuturesOrderRestClient> IFuturesOrderRestClient.CancelFuturesOrderOptions { get; } = new EndpointOptions<CancelOrderRequest, IFuturesOrderRestClient>(_exchangeName, true);
-        Task<HttpResult<SharedId>> IFuturesOrderRestClient.CancelFuturesOrderAsync(CancelOrderRequest request, CancellationToken ct)
+        CancelFuturesOrderOptions IFuturesOrderRestClient.CancelFuturesOrderOptions { get; } = new CancelFuturesOrderOptions(_exchangeName, true);
+        async Task<HttpResult<SharedId>> IFuturesOrderRestClient.CancelFuturesOrderAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IFuturesOrderRestClient, CancelOrderRequest, SharedId>(
-                this,
-                client => client.CancelFuturesOrderOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.CancelFuturesOrderOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return SharedExecutionResult<SharedId>.Error(ArgumentError.Invalid(nameof(CancelOrderRequest.OrderId), "Invalid order id"));
+                return HttpResult.Fail<SharedId>(Exchange, ArgumentError.Invalid(nameof(CancelOrderRequest.OrderId), "Invalid order id"));
 
             var order = await Trading.CancelOrderAsync(request.Symbol!.GetSymbol(FormatSymbol), orderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return SharedExecutionResult<SharedId>.Error(order);
+            if (!order.Success)
+                return HttpResult.Fail<SharedId>(order);
 
-            return SharedExecutionResult<SharedId>.Ok(order, new SharedId(request.OrderId));
-                                });
+            return HttpResult.Ok(order, new SharedId(request.OrderId));
+                                
         }
 
-        EndpointOptions<GetPositionsRequest, IFuturesOrderRestClient> IFuturesOrderRestClient.GetPositionsOptions { get; } = new EndpointOptions<GetPositionsRequest, IFuturesOrderRestClient>(_exchangeName, true)
+        GetPositionsOptions IFuturesOrderRestClient.GetPositionsOptions { get; } = new GetPositionsOptions(_exchangeName, true)
         {
             OptionalExchangeParameters = new List<ParameterDescription>
             {
                 new ParameterDescription("dex", typeof(string), "DEX to retrieve leverage for", "xyz")
             }
         };
-        Task<HttpResult<SharedPosition[]>> IFuturesOrderRestClient.GetPositionsAsync(GetPositionsRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedPosition[]>> IFuturesOrderRestClient.GetPositionsAsync(GetPositionsRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IFuturesOrderRestClient, GetPositionsRequest, SharedPosition[]>(
-                this,
-                client => client.GetPositionsOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetPositionsOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedPosition[]>(Exchange, validationError);
 
-            string? dex = ExchangeParameters.GetProcessValue<string>(request.ExchangeParameters, Exchange, "dex");
+            string? dex = ExchangeParameters.GetValue<string>(request.ExchangeParameters, Exchange, "dex");
             var result = await Account.GetAccountInfoAsync(dex: dex, ct: ct).ConfigureAwait(false);
-            if (!result)
-                return SharedExecutionResult<SharedPosition[]>.Error(result);
+            if (!result.Success)
+                return HttpResult.Fail<SharedPosition[]>(result);
 
             IEnumerable<HyperLiquidPosition> data = result.Data.Positions;
             if (request.Symbol != null)
                 data = data.Where(x => x.Position.Symbol == request.Symbol.GetSymbol(FormatSymbol));
 
             var resultTypes = request.Symbol == null && request.TradingMode == null ? SupportedTradingModes : request.Symbol != null ? new[] { request.Symbol.TradingMode } : new[] { request.TradingMode!.Value };
-            return SharedExecutionResult<SharedPosition[]>.Ok(result, data.Select(x => new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicId, x.Position.Symbol), x.Position.Symbol, Math.Abs(x.Position.PositionQuantity ?? 0), null)
+            return HttpResult.Ok(result, data.Select(x => new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicId, x.Position.Symbol), x.Position.Symbol, Math.Abs(x.Position.PositionQuantity ?? 0), null)
             {
                 UnrealizedPnl = x.Position.UnrealizedPnl,
                 LiquidationPrice = x.Position.LiquidationPrice == 0 ? null : x.Position.LiquidationPrice,
@@ -811,10 +748,10 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 PositionMode = SharedPositionMode.OneWay,
                 PositionSide = x.Position.PositionQuantity >= 0 ? SharedPositionSide.Long : SharedPositionSide.Short
             }).ToArray());
-                                });
+                                
         }
 
-        EndpointOptions<ClosePositionRequest, IFuturesOrderRestClient> IFuturesOrderRestClient.ClosePositionOptions { get; } = new EndpointOptions<ClosePositionRequest, IFuturesOrderRestClient>(_exchangeName, true)
+        ClosePositionOptions IFuturesOrderRestClient.ClosePositionOptions { get; } = new ClosePositionOptions(_exchangeName, true)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
@@ -826,14 +763,11 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 new ParameterDescription("Price", typeof(decimal), "The current price of the symbol. Required to calculate max slippage.", 21.5m)
             }
         };
-        Task<HttpResult<SharedId>> IFuturesOrderRestClient.ClosePositionAsync(ClosePositionRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> IFuturesOrderRestClient.ClosePositionAsync(ClosePositionRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IFuturesOrderRestClient, ClosePositionRequest, SharedId>(
-                this,
-                client => client.ClosePositionOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.ClosePositionOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await Trading.PlaceOrderAsync(
@@ -841,15 +775,15 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 request.PositionSide == SharedPositionSide.Long ? Enums.OrderSide.Sell : Enums.OrderSide.Buy,
                 Enums.OrderType.Market,
                 quantity: request.Quantity!.Value,
-                price: ExchangeParameters.GetProcessValue<decimal>(request.ExchangeParameters, ExchangeName, "Price"),
+                price: ExchangeParameters.GetValue<decimal>(request.ExchangeParameters, Exchange, "Price"),
                 reduceOnly: true,
                 timeInForce: Enums.TimeInForce.ImmediateOrCancel,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return SharedExecutionResult<SharedId>.Error(result);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
-            return SharedExecutionResult<SharedId>.Ok(result, new SharedId(result.Data.OrderId.ToString()));
-                                });
+            return HttpResult.Ok(result, new SharedId(result.Data.OrderId.ToString()));
+                                
         }
 
         private SharedTimeInForce? ParseTimeInForce(TimeInForce? timeInForce)
@@ -917,21 +851,18 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
         #region Futures Client Id Order Client
 
-        EndpointOptions<GetOrderRequest, IFuturesOrderClientIdRestClient> IFuturesOrderClientIdRestClient.GetFuturesOrderByClientOrderIdOptions { get; } = new EndpointOptions<GetOrderRequest, IFuturesOrderClientIdRestClient>(_exchangeName, true);
-        Task<HttpResult<SharedFuturesOrder>> IFuturesOrderClientIdRestClient.GetFuturesOrderByClientOrderIdAsync(GetOrderRequest request, CancellationToken ct)
+        GetFuturesOrderByClientOrderIdOptions IFuturesOrderClientIdRestClient.GetFuturesOrderByClientOrderIdOptions { get; } = new GetFuturesOrderByClientOrderIdOptions(_exchangeName, true);
+        async Task<HttpResult<SharedFuturesOrder>> IFuturesOrderClientIdRestClient.GetFuturesOrderByClientOrderIdAsync(GetOrderRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IFuturesOrderClientIdRestClient, GetOrderRequest, SharedFuturesOrder>(
-                this,
-                client => client.GetFuturesOrderByClientOrderIdOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetFuturesOrderByClientOrderIdOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedFuturesOrder>(Exchange, validationError);
 
             var order = await Trading.GetOrderAsync(clientOrderId: request.OrderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return SharedExecutionResult<SharedFuturesOrder>.Error(order);
+            if (!order.Success)
+                return HttpResult.Fail<SharedFuturesOrder>(order);
 
-            return SharedExecutionResult<SharedFuturesOrder>.Ok(order, new SharedFuturesOrder(
+            return HttpResult.Ok(order, new SharedFuturesOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicId, order.Data.Order.Symbol!),
                 order.Data.Order.Symbol!,
                 order.Data.Order.OrderId.ToString(),
@@ -949,30 +880,27 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 TriggerPrice = order.Data.Order.TriggerPrice == 0 ? null : order.Data.Order.TriggerPrice,
                 IsTriggerOrder = order.Data.Order.TriggerPrice > 0
             });
-                                });
+                                
         }
 
-        EndpointOptions<CancelOrderRequest, IFuturesOrderClientIdRestClient> IFuturesOrderClientIdRestClient.CancelFuturesOrderByClientOrderIdOptions { get; } = new EndpointOptions<CancelOrderRequest, IFuturesOrderClientIdRestClient>(_exchangeName, true);
-        Task<HttpResult<SharedId>> IFuturesOrderClientIdRestClient.CancelFuturesOrderByClientOrderIdAsync(CancelOrderRequest request, CancellationToken ct)
+        CancelFuturesOrderByClientOrderIdOptions IFuturesOrderClientIdRestClient.CancelFuturesOrderByClientOrderIdOptions { get; } = new CancelFuturesOrderByClientOrderIdOptions(_exchangeName, true);
+        async Task<HttpResult<SharedId>> IFuturesOrderClientIdRestClient.CancelFuturesOrderByClientOrderIdAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IFuturesOrderClientIdRestClient, CancelOrderRequest, SharedId>(
-                this,
-                client => client.CancelFuturesOrderByClientOrderIdOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.CancelFuturesOrderByClientOrderIdOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var order = await Trading.CancelOrderByClientOrderIdAsync(request.Symbol!.GetSymbol(FormatSymbol), clientOrderId: request.OrderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return SharedExecutionResult<SharedId>.Error(order);
+            if (!order.Success)
+                return HttpResult.Fail<SharedId>(order);
 
-            return SharedExecutionResult<SharedId>.Ok(order, new SharedId(request.OrderId));
-                                });
+            return HttpResult.Ok(order, new SharedId(request.OrderId));
+                                
         }
         #endregion
 
         #region Tp/SL Client
-        EndpointOptions<SetTpSlRequest, IFuturesTpSlRestClient> IFuturesTpSlRestClient.SetFuturesTpSlOptions { get; } = new EndpointOptions<SetTpSlRequest, IFuturesTpSlRestClient>(_exchangeName, true)
+        SetFuturesTpSlOptions IFuturesTpSlRestClient.SetFuturesTpSlOptions { get; } = new SetFuturesTpSlOptions(_exchangeName, true)
         {
             RequestNotes = "API doesn't return an id for trigger orders",
             RequiredOptionalParameters = new List<ParameterDescription>
@@ -981,14 +909,11 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             }
         };
 
-        Task<HttpResult<SharedId>> IFuturesTpSlRestClient.SetFuturesTpSlAsync(SetTpSlRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> IFuturesTpSlRestClient.SetFuturesTpSlAsync(SetTpSlRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IFuturesTpSlRestClient, SetTpSlRequest, SharedId>(
-                this,
-                client => client.SetFuturesTpSlOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.SetFuturesTpSlOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var result = await Trading.PlaceOrderAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
@@ -1002,15 +927,15 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 reduceOnly: true,
                 ct: ct).ConfigureAwait(false);
 
-            if (!result)
-                return SharedExecutionResult<SharedId>.Error(result);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
             // Return
-            return SharedExecutionResult<SharedId>.Ok(result, new SharedId(result.Data.OrderId.ToString()));
-                                });
+            return HttpResult.Ok(result, new SharedId(result.Data.OrderId.ToString()));
+                                
         }
 
-        EndpointOptions<CancelTpSlRequest, IFuturesTpSlRestClient> IFuturesTpSlRestClient.CancelFuturesTpSlOptions { get; } = new EndpointOptions<CancelTpSlRequest, IFuturesTpSlRestClient>(_exchangeName, true)
+        CancelFuturesTpSlOptions IFuturesTpSlRestClient.CancelFuturesTpSlOptions { get; } = new CancelFuturesTpSlOptions(_exchangeName, true)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
@@ -1018,28 +943,25 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             }
         };
 
-        Task<HttpResult<bool>> IFuturesTpSlRestClient.CancelFuturesTpSlAsync(CancelTpSlRequest request, CancellationToken ct)
+        async Task<HttpResult<bool>> IFuturesTpSlRestClient.CancelFuturesTpSlAsync(CancelTpSlRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IFuturesTpSlRestClient, CancelTpSlRequest, bool>(
-                this,
-                client => client.CancelFuturesTpSlOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.CancelFuturesTpSlOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<bool>(Exchange, validationError);
 
             if (!long.TryParse(request.OrderId, out var orderId) || orderId == 0)
-                return SharedExecutionResult<bool>.Error(ArgumentError.Invalid(nameof(CancelTpSlRequest.OrderId), "Invalid order id"));
+                return HttpResult.Fail<bool>(Exchange, ArgumentError.Invalid(nameof(CancelTpSlRequest.OrderId), "Invalid order id"));
 
             var result = await Trading.CancelOrderAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
                 orderId,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return SharedExecutionResult<bool>.Error(result);
+            if (!result.Success)
+                return HttpResult.Fail<bool>(result);
 
             // Return
-            return SharedExecutionResult<bool>.Ok(result, true);
-                                });
+            return HttpResult.Ok(result, true);
+                                
         }
 
         #endregion

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiShared.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiShared.cs
@@ -457,6 +457,10 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             RequiredOptionalParameters = new List<ParameterDescription>
             {
                 new ParameterDescription(nameof(PlaceSpotOrderRequest.Price), typeof(decimal), "Price for the order. For market orders this should be the current symbol price", 21.5m)
+            },
+            OptionalExchangeParameters = new List<ParameterDescription>
+            {
+                new ParameterDescription("vaultAddress", typeof(string), "Vault address to place the order on behalf of", "0x123...")
             }
         };
         async Task<HttpResult<SharedId>> IFuturesOrderRestClient.PlaceFuturesOrderAsync(PlaceFuturesOrderRequest request, CancellationToken ct)
@@ -474,6 +478,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 reduceOnly: request.ReduceOnly,
                 timeInForce: GetTimeInForce(request.TimeInForce, request.OrderType),
                 clientOrderId: request.ClientOrderId,
+                vaultAddress: request.GetParamValue<string?>(Exchange, "vaultAddress"),
                 ct: ct).ConfigureAwait(false);
 
             if (!result.Success)
@@ -698,7 +703,13 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                                 
         }
 
-        CancelFuturesOrderOptions IFuturesOrderRestClient.CancelFuturesOrderOptions { get; } = new CancelFuturesOrderOptions(_exchangeName, true);
+        CancelFuturesOrderOptions IFuturesOrderRestClient.CancelFuturesOrderOptions { get; } = new CancelFuturesOrderOptions(_exchangeName, true)
+        {
+            OptionalExchangeParameters = new List<ParameterDescription>
+            {
+                new ParameterDescription("vaultAddress", typeof(string), "Vault address to cancel the order on behalf of", "0x123...")
+            }
+        };
         async Task<HttpResult<SharedId>> IFuturesOrderRestClient.CancelFuturesOrderAsync(CancelOrderRequest request, CancellationToken ct)
         {
             var validationError = SharedClient.CancelFuturesOrderOptions.ValidateRequest(request, this);
@@ -708,7 +719,11 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             if (!long.TryParse(request.OrderId, out var orderId))
                 return HttpResult.Fail<SharedId>(Exchange, ArgumentError.Invalid(nameof(CancelOrderRequest.OrderId), "Invalid order id"));
 
-            var order = await Trading.CancelOrderAsync(request.Symbol!.GetSymbol(FormatSymbol), orderId, ct: ct).ConfigureAwait(false);
+            var order = await Trading.CancelOrderAsync(
+                request.Symbol!.GetSymbol(FormatSymbol),
+                orderId,
+                vaultAddress: request.GetParamValue<string?>(Exchange, "vaultAddress"),
+                ct: ct).ConfigureAwait(false);
             if (!order.Success)
                 return HttpResult.Fail<SharedId>(order);
 
@@ -761,6 +776,10 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             RequiredExchangeParameters = new List<ParameterDescription>
             {
                 new ParameterDescription("Price", typeof(decimal), "The current price of the symbol. Required to calculate max slippage.", 21.5m)
+            },
+            OptionalExchangeParameters = new List<ParameterDescription>
+            {
+                new ParameterDescription("vaultAddress", typeof(string), "Vault address to place the order on behalf of", "0x123...")
             }
         };
         async Task<HttpResult<SharedId>> IFuturesOrderRestClient.ClosePositionAsync(ClosePositionRequest request, CancellationToken ct)
@@ -778,6 +797,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 price: ExchangeParameters.GetValue<decimal>(request.ExchangeParameters, Exchange, "Price"),
                 reduceOnly: true,
                 timeInForce: Enums.TimeInForce.ImmediateOrCancel,
+                vaultAddress: request.GetParamValue<string?>(Exchange, "vaultAddress"),
                 ct: ct).ConfigureAwait(false);
             if (!result.Success)
                 return HttpResult.Fail<SharedId>(result);
@@ -883,14 +903,24 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                                 
         }
 
-        CancelFuturesOrderByClientOrderIdOptions IFuturesOrderClientIdRestClient.CancelFuturesOrderByClientOrderIdOptions { get; } = new CancelFuturesOrderByClientOrderIdOptions(_exchangeName, true);
+        CancelFuturesOrderByClientOrderIdOptions IFuturesOrderClientIdRestClient.CancelFuturesOrderByClientOrderIdOptions { get; } = new CancelFuturesOrderByClientOrderIdOptions(_exchangeName, true)
+        {
+            OptionalExchangeParameters = new List<ParameterDescription>
+            {
+                new ParameterDescription("vaultAddress", typeof(string), "Vault address to cancel the order on behalf of", "0x123...")
+            }
+        };
         async Task<HttpResult<SharedId>> IFuturesOrderClientIdRestClient.CancelFuturesOrderByClientOrderIdAsync(CancelOrderRequest request, CancellationToken ct)
         {
             var validationError = SharedClient.CancelFuturesOrderByClientOrderIdOptions.ValidateRequest(request, this);
             if (validationError != null)
                 return HttpResult.Fail<SharedId>(Exchange, validationError);
 
-            var order = await Trading.CancelOrderByClientOrderIdAsync(request.Symbol!.GetSymbol(FormatSymbol), clientOrderId: request.OrderId, ct: ct).ConfigureAwait(false);
+            var order = await Trading.CancelOrderByClientOrderIdAsync(
+                request.Symbol!.GetSymbol(FormatSymbol), 
+                clientOrderId: request.OrderId,
+                vaultAddress: request.GetParamValue<string?>(Exchange, "vaultAddress"),
+                ct: ct).ConfigureAwait(false);
             if (!order.Success)
                 return HttpResult.Fail<SharedId>(order);
 

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiShared.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiShared.cs
@@ -15,6 +15,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 {
     internal partial class HyperLiquidRestClientFuturesApi : IHyperLiquidRestClientFuturesApiShared
     {
+        private const string _exchangeName = "HyperLiquid";
         private const string _topicId = "HyperLiquidFutures";
         public string Exchange => "HyperLiquid";
 
@@ -23,8 +24,9 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
 
+
         #region Balance Client
-        GetBalancesOptions IBalanceRestClient.GetBalancesOptions { get; } = new GetBalancesOptions(AccountTypeFilter.Futures)
+        GetBalancesOptions IBalanceRestClient.GetBalancesOptions { get; } = new GetBalancesOptions(_exchangeName, AccountTypeFilter.Futures)
         {
             OptionalExchangeParameters = new List<ParameterDescription>
             {
@@ -32,30 +34,34 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             }
         };
 
-        async Task<ExchangeWebResult<SharedBalance[]>> IBalanceRestClient.GetBalancesAsync(GetBalancesRequest request, CancellationToken ct)
+        Task<ExchangeWebResult<SharedBalance[]>> IBalanceRestClient.GetBalancesAsync(GetBalancesRequest request, CancellationToken ct)
         {
-            var validationError = ((IBalanceRestClient)this).GetBalancesOptions.ValidateRequest(Exchange, request, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedBalance[]>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<IBalanceRestClient, GetBalancesRequest, SharedBalance[]>(
+                this,
+                client => client.GetBalancesOptions,
+                request,
+                async () =>
+                {
 
             string? dex = ExchangeParameters.GetValue<string>(request.ExchangeParameters, Exchange, "dex");
             var result = await Account.GetAccountInfoAsync(dex: dex, ct: ct).ConfigureAwait(false);
             if (!result)
-                return result.AsExchangeResult<SharedBalance[]>(Exchange, null, default);
+                return SharedExecutionResult<SharedBalance[]>.Error(result);
 
-            return result.AsExchangeResult<SharedBalance[]>(Exchange, SupportedTradingModes, [
+            return SharedExecutionResult<SharedBalance[]>.Ok(result, [
                 new SharedBalance(
                     "USDC",
                     result.Data.MarginSummary.AccountValue - result.Data.MarginSummary.TotalMarginUsed,
                     result.Data.MarginSummary.AccountValue)
                 ]);
+                                });
         }
 
         #endregion
 
         #region Klines Client
 
-        GetKlinesOptions IKlineRestClient.GetKlinesOptions { get; } = new GetKlinesOptions(false, true, true, 1000, false,
+        GetKlinesOptions IKlineRestClient.GetKlinesOptions { get; } = new GetKlinesOptions(_exchangeName, false, true, true, 1000, false,
             SharedKlineInterval.OneMinute,
             SharedKlineInterval.FiveMinutes,
             SharedKlineInterval.FifteenMinutes,
@@ -72,15 +78,17 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             MaxTotalDataPoints = 5000
         };
 
-        async Task<ExchangeWebResult<SharedKline[]>> IKlineRestClient.GetKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        Task<ExchangeWebResult<SharedKline[]>> IKlineRestClient.GetKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
+            return SharedUtils.ExecuteSharedAsync<IKlineRestClient, GetKlinesRequest, SharedKline[]>(
+                this,
+                client => client.GetKlinesOptions,
+                request,
+                async () =>
+                {
             var interval = (Enums.KlineInterval)request.Interval;
             if (!Enum.IsDefined(typeof(Enums.KlineInterval), interval))
-                return new ExchangeWebResult<SharedKline[]>(Exchange, ArgumentError.Invalid(nameof(GetKlinesRequest.Interval), "Interval not supported"));
-
-            var validationError = ((IKlineRestClient)this).GetKlinesOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedKline[]>(Exchange, validationError);
+                return SharedExecutionResult<SharedKline[]>.Error(ArgumentError.Invalid(nameof(GetKlinesRequest.Interval), "Interval not supported"));
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             int limit = request.Limit ?? 1000;
@@ -96,7 +104,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 ct: ct
                 ).ConfigureAwait(false);
             if (!result)
-                return new ExchangeWebResult<SharedKline[]>(Exchange, request.Symbol.TradingMode, result.As<SharedKline[]>(default));
+                return SharedExecutionResult<SharedKline[]>.Error(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                      () => Pagination.NextPageFromTime(pageParams, result.Data.Min(x => x.OpenTime)),
@@ -106,10 +114,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                      request.EndTime ?? DateTime.UtcNow,
                      pageParams);
 
-            return result.AsExchangeResult(
-                    Exchange,
-                    request.Symbol.TradingMode,
-                    ExchangeHelpers.ApplyFilter(result.Data, x => x.OpenTime, request.StartTime, request.EndTime, direction)
+            return SharedExecutionResult<SharedKline[]>.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.OpenTime, request.StartTime, request.EndTime, direction)
                     .Select(x =>
                         new SharedKline(
                             request.Symbol,
@@ -121,101 +126,118 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                             x.OpenPrice,
                             x.Volume))
                     .ToArray(), nextPageRequest);
+                                });
         }
 
         #endregion
 
         #region Order Book client
-        GetOrderBookOptions IOrderBookRestClient.GetOrderBookOptions { get; } = new GetOrderBookOptions([20], false);
-        async Task<ExchangeWebResult<SharedOrderBook>> IOrderBookRestClient.GetOrderBookAsync(GetOrderBookRequest request, CancellationToken ct)
+        GetOrderBookOptions IOrderBookRestClient.GetOrderBookOptions { get; } = new GetOrderBookOptions(_exchangeName, [20], false);
+        Task<ExchangeWebResult<SharedOrderBook>> IOrderBookRestClient.GetOrderBookAsync(GetOrderBookRequest request, CancellationToken ct)
         {
-            var validationError = ((IOrderBookRestClient)this).GetOrderBookOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedOrderBook>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<IOrderBookRestClient, GetOrderBookRequest, SharedOrderBook>(
+                this,
+                client => client.GetOrderBookOptions,
+                request,
+                async () =>
+                {
 
             var result = await ExchangeData.GetOrderBookAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
                 ct: ct).ConfigureAwait(false);
             if (!result)
-                return result.AsExchangeResult<SharedOrderBook>(Exchange, null, default);
+                return SharedExecutionResult<SharedOrderBook>.Error(result);
 
-            return result.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedOrderBook(result.Data.Levels.Asks, result.Data.Levels.Bids));
+            return SharedExecutionResult<SharedOrderBook>.Ok(result, new SharedOrderBook(result.Data.Levels.Asks, result.Data.Levels.Bids));
+                                });
         }
 
         #endregion
 
         #region Ticker client
 
-        GetTickerOptions IFuturesTickerRestClient.GetFuturesTickerOptions { get; } = new GetTickerOptions();
-        async Task<ExchangeWebResult<SharedFuturesTicker>> IFuturesTickerRestClient.GetFuturesTickerAsync(GetTickerRequest request, CancellationToken ct)
+        GetFuturesTickerOptions IFuturesTickerRestClient.GetFuturesTickerOptions { get; } = new GetFuturesTickerOptions(_exchangeName);
+        Task<ExchangeWebResult<SharedFuturesTicker>> IFuturesTickerRestClient.GetFuturesTickerAsync(GetTickerRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTickerRestClient)this).GetFuturesTickerOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesTicker>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<IFuturesTickerRestClient, GetTickerRequest, SharedFuturesTicker>(
+                this,
+                client => client.GetFuturesTickerOptions,
+                request,
+                async () =>
+                {
 
             var symbolName = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.GetExchangeInfoAndTickersAsync(ct: ct).ConfigureAwait(false);
             if (!result)
-                return result.AsExchangeResult<SharedFuturesTicker>(Exchange, null, default);
+                return SharedExecutionResult<SharedFuturesTicker>.Error(result);
 
             var symbol = result.Data.Tickers.SingleOrDefault(x => x.Symbol == symbolName);
             if (symbol == null)
-                return result.AsExchangeError<SharedFuturesTicker>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
+                return SharedExecutionResult<SharedFuturesTicker>.Error(result.AsError<SharedFuturesTicker>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found"))));
 
-            return result.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicId, symbol.Symbol), symbol.Symbol, symbol.MidPrice, null, null, symbol.NotionalVolume, (symbol.MidPrice == null || symbol.PreviousDayPrice == 0) ? null : Math.Round((symbol.MidPrice.Value / symbol.PreviousDayPrice * 100 - 100), 3))
+            return SharedExecutionResult<SharedFuturesTicker>.Ok(result, new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicId, symbol.Symbol), symbol.Symbol, symbol.MidPrice, null, null, symbol.NotionalVolume, (symbol.MidPrice == null || symbol.PreviousDayPrice == 0) ? null : Math.Round((symbol.MidPrice.Value / symbol.PreviousDayPrice * 100 - 100), 3))
             {
                 FundingRate = symbol.FundingRate,
                 MarkPrice = symbol.MarkPrice
             });
+                                });
         }
 
-        GetTickersOptions IFuturesTickerRestClient.GetFuturesTickersOptions { get; } = new GetTickersOptions();
-        async Task<ExchangeWebResult<SharedFuturesTicker[]>> IFuturesTickerRestClient.GetFuturesTickersAsync(GetTickersRequest request, CancellationToken ct)
+        GetFuturesTickersOptions IFuturesTickerRestClient.GetFuturesTickersOptions { get; } = new GetFuturesTickersOptions(_exchangeName);
+        Task<ExchangeWebResult<SharedFuturesTicker[]>> IFuturesTickerRestClient.GetFuturesTickersAsync(GetTickersRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTickerRestClient)this).GetFuturesTickersOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesTicker[]>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<IFuturesTickerRestClient, GetTickersRequest, SharedFuturesTicker[]>(
+                this,
+                client => client.GetFuturesTickersOptions,
+                request,
+                async () =>
+                {
 
             var result = await ExchangeData.GetExchangeInfoAndTickersAsync(ct: ct).ConfigureAwait(false);
             if (!result)
-                return result.AsExchangeResult<SharedFuturesTicker[]>(Exchange, null, default);
+                return SharedExecutionResult<SharedFuturesTicker[]>.Error(result);
 
-            return result.AsExchangeResult<SharedFuturesTicker[]>(Exchange, TradingMode.PerpetualLinear, result.Data.Tickers.Select(x => new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), x.Symbol, x.MidPrice, null, null, x.NotionalVolume, (x.MidPrice == null || x.PreviousDayPrice == 0) ? null : Math.Round((x.MidPrice.Value / x.PreviousDayPrice * 100 - 100), 3))
+            return SharedExecutionResult<SharedFuturesTicker[]>.Ok(result, result.Data.Tickers.Select(x => new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), x.Symbol, x.MidPrice, null, null, x.NotionalVolume, (x.MidPrice == null || x.PreviousDayPrice == 0) ? null : Math.Round((x.MidPrice.Value / x.PreviousDayPrice * 100 - 100), 3))
             {
                 FundingRate = x.FundingRate,
                 MarkPrice = x.MarkPrice
             }).ToArray());
+                                });
         }
 
         #endregion
 
         #region Book Ticker client
 
-        EndpointOptions<GetBookTickerRequest> IBookTickerRestClient.GetBookTickerOptions { get; } = new EndpointOptions<GetBookTickerRequest>(false);
-        async Task<ExchangeWebResult<SharedBookTicker>> IBookTickerRestClient.GetBookTickerAsync(GetBookTickerRequest request, CancellationToken ct)
+        EndpointOptions<GetBookTickerRequest, IBookTickerRestClient> IBookTickerRestClient.GetBookTickerOptions { get; } = new EndpointOptions<GetBookTickerRequest, IBookTickerRestClient>(_exchangeName, false);
+        Task<ExchangeWebResult<SharedBookTicker>> IBookTickerRestClient.GetBookTickerAsync(GetBookTickerRequest request, CancellationToken ct)
         {
-            var validationError = ((IBookTickerRestClient)this).GetBookTickerOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedBookTicker>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<IBookTickerRestClient, GetBookTickerRequest, SharedBookTicker>(
+                this,
+                client => client.GetBookTickerOptions,
+                request,
+                async () =>
+                {
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var resultTicker = await ExchangeData.GetOrderBookAsync(symbol, ct: ct).ConfigureAwait(false);
             if (!resultTicker)
-                return resultTicker.AsExchangeResult<SharedBookTicker>(Exchange, null, default);
+                return SharedExecutionResult<SharedBookTicker>.Error(resultTicker);
 
-            return resultTicker.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedBookTicker(
+            return SharedExecutionResult<SharedBookTicker>.Ok(resultTicker, new SharedBookTicker(
                 ExchangeSymbolCache.ParseSymbol(_topicId, symbol),
                 symbol,
                 resultTicker.Data.Levels.Asks[0].Price,
                 resultTicker.Data.Levels.Asks[0].Quantity,
                 resultTicker.Data.Levels.Bids[0].Price,
                 resultTicker.Data.Levels.Bids[0].Quantity));
+                                });
         }
 
         #endregion
 
         #region Futures Symbol client
-        EndpointOptions<GetSymbolsRequest> IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new EndpointOptions<GetSymbolsRequest>(false)
+        EndpointOptions<GetSymbolsRequest, IFuturesSymbolRestClient> IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new EndpointOptions<GetSymbolsRequest, IFuturesSymbolRestClient>(_exchangeName, false)
         {
             OptionalExchangeParameters = new List<ParameterDescription>
             {
@@ -223,29 +245,33 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             }
         };
 
-        async Task<ExchangeWebResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
+        Task<ExchangeWebResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesSymbolRestClient)this).GetFuturesSymbolsOptions.ValidateRequest(Exchange, request, TradingMode.PerpetualLinear, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesSymbol[]>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<IFuturesSymbolRestClient, GetSymbolsRequest, SharedFuturesSymbol[]>(
+                this,
+                client => client.GetFuturesSymbolsOptions,
+                request,
+                async () =>
+                {
 
             string? dex = ExchangeParameters.GetValue<string>(request.ExchangeParameters, Exchange, "dex");
             var result = await ExchangeData.GetExchangeInfoAllDexesAsync(ct: ct).ConfigureAwait(false);
             if (!result)
-                return result.AsExchangeResult<SharedFuturesSymbol[]>(Exchange, null, default);
+                return SharedExecutionResult<SharedFuturesSymbol[]>.Error(result);
 
             var data = result.Data.SelectMany(x => x.Symbols);
             if (dex != null)
                 data = result.Data.SingleOrDefault(x => x.Name == dex)?.Symbols ?? [];
 
-            var response = result.AsExchangeResult<SharedFuturesSymbol[]>(Exchange, SupportedTradingModes, data.Where(x => !x.IsDelisted).Select(ParseSymbol).ToArray());
+            var response = data.Where(x => !x.IsDelisted).Select(ParseSymbol).ToArray();
 
             // Register both HYPE/USDC and HYPE as symbol names
             var symbolRegistrations = result.Data.SelectMany(x => x.Symbols.Where(x => !x.IsDelisted).Select(ParseSymbol))
                 .Concat(result.Data.SelectMany(x => x.Symbols.Select(x => new SharedSpotSymbol(x.Name, "USDC", x.Name, true, TradingMode.PerpetualLinear)))).ToArray();
 
             ExchangeSymbolCache.UpdateSymbolInfo(_topicId, symbolRegistrations);
-            return response;
+            return SharedExecutionResult<SharedFuturesSymbol[]>.Ok(result, response);
+                                });
         }
 
         private SharedFuturesSymbol ParseSymbol(HyperLiquidFuturesSymbol symbol)
@@ -308,32 +334,39 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #endregion
 
         #region Fee Client
-        EndpointOptions<GetFeeRequest> IFeeRestClient.GetFeeOptions { get; } = new EndpointOptions<GetFeeRequest>(true);
+        EndpointOptions<GetFeeRequest, IFeeRestClient> IFeeRestClient.GetFeeOptions { get; } = new EndpointOptions<GetFeeRequest, IFeeRestClient>(_exchangeName, true);
 
-        async Task<ExchangeWebResult<SharedFee>> IFeeRestClient.GetFeesAsync(GetFeeRequest request, CancellationToken ct)
+        Task<ExchangeWebResult<SharedFee>> IFeeRestClient.GetFeesAsync(GetFeeRequest request, CancellationToken ct)
         {
-            var validationError = ((IFeeRestClient)this).GetFeeOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedFee>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<IFeeRestClient, GetFeeRequest, SharedFee>(
+                this,
+                client => client.GetFeeOptions,
+                request,
+                async () =>
+                {
 
             // Get data
             var result = await Account.GetFeeInfoAsync(ct: ct).ConfigureAwait(false);
             if (!result)
-                return result.AsExchangeResult<SharedFee>(Exchange, null, default);
+                return SharedExecutionResult<SharedFee>.Error(result);
 
             // Return
-            return result.AsExchangeResult(Exchange, request.TradingMode, new SharedFee(result.Data.MakerFeeRate * 100, result.Data.TakerFeeRate * 100));
+            return SharedExecutionResult<SharedFee>.Ok(result, new SharedFee(result.Data.MakerFeeRate * 100, result.Data.TakerFeeRate * 100));
+                                });
         }
         #endregion
 
         #region Funding Rate client
-        GetFundingRateHistoryOptions IFundingRateRestClient.GetFundingRateHistoryOptions { get; } = new GetFundingRateHistoryOptions(true, false, true, 500, false);
+        GetFundingRateHistoryOptions IFundingRateRestClient.GetFundingRateHistoryOptions { get; } = new GetFundingRateHistoryOptions(_exchangeName, true, false, true, 500, false);
 
-        async Task<ExchangeWebResult<SharedFundingRate[]>> IFundingRateRestClient.GetFundingRateHistoryAsync(GetFundingRateHistoryRequest request, PageRequest? pageToken, CancellationToken ct)
+        Task<ExchangeWebResult<SharedFundingRate[]>> IFundingRateRestClient.GetFundingRateHistoryAsync(GetFundingRateHistoryRequest request, PageRequest? pageToken, CancellationToken ct)
         {
-            var validationError = ((IFundingRateRestClient)this).GetFundingRateHistoryOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedFundingRate[]>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<IFundingRateRestClient, GetFundingRateHistoryRequest, SharedFundingRate[]>(
+                this,
+                client => client.GetFundingRateHistoryOptions,
+                request,
+                async () =>
+                {
 
             //DateTime? fromTime = null;
             //if (pageToken is DateTimeToken token)
@@ -346,87 +379,100 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 //endTime: request.EndTime,
                 ct: ct).ConfigureAwait(false);
             if (!result)
-                return result.AsExchangeResult<SharedFundingRate[]>(Exchange, null, default);
+                return SharedExecutionResult<SharedFundingRate[]>.Error(result);
 
             //DateTimeToken? nextToken = null;
             //if (result.Data.Count() == (request.Limit ?? 500))
             //    nextToken = new DateTimeToken(result.Data.Max(x => x.Timestamp).AddSeconds(1));
 
             // Return
-            return result.AsExchangeResult<SharedFundingRate[]>(Exchange, request.Symbol.TradingMode, result.Data.Select(x => new SharedFundingRate(x.FundingRate, x.Timestamp)).ToArray()/*, nextToken*/);
+            return SharedExecutionResult<SharedFundingRate[]>.Ok(result, result.Data.Select(x => new SharedFundingRate(x.FundingRate, x.Timestamp)).ToArray()/*, nextToken*/);
+                                });
         }
         #endregion
 
         #region Leverage client
         SharedLeverageSettingMode ILeverageRestClient.LeverageSettingType => SharedLeverageSettingMode.PerSymbol;
 
-        EndpointOptions<GetLeverageRequest> ILeverageRestClient.GetLeverageOptions { get; } = new EndpointOptions<GetLeverageRequest>(true)
+        EndpointOptions<GetLeverageRequest, ILeverageRestClient> ILeverageRestClient.GetLeverageOptions { get; } = new EndpointOptions<GetLeverageRequest, ILeverageRestClient>(_exchangeName, true)
         {
             OptionalExchangeParameters = new List<ParameterDescription>
             {
                 new ParameterDescription("dex", typeof(string), "DEX to retrieve leverage for", "xyz")
             }
         };
-        async Task<ExchangeWebResult<SharedLeverage>> ILeverageRestClient.GetLeverageAsync(GetLeverageRequest request, CancellationToken ct)
+        Task<ExchangeWebResult<SharedLeverage>> ILeverageRestClient.GetLeverageAsync(GetLeverageRequest request, CancellationToken ct)
         {
-            var validationError = ((ILeverageRestClient)this).GetLeverageOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedLeverage>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<ILeverageRestClient, GetLeverageRequest, SharedLeverage>(
+                this,
+                client => client.GetLeverageOptions,
+                request,
+                async () =>
+                {
 
             string? dex = ExchangeParameters.GetValue<string>(request.ExchangeParameters, Exchange, "dex");
             var result = await Account.GetAccountInfoAsync(dex: dex, ct: ct).ConfigureAwait(false);
             if (!result)
-                return result.AsExchangeResult<SharedLeverage>(Exchange, null, default);
+                return SharedExecutionResult<SharedLeverage>.Error(result);
 
             var position = result.Data.Positions.SingleOrDefault(x => x.Position.Symbol == request.Symbol!.GetSymbol(FormatSymbol));
             if (position == null)
-                return result.AsExchangeError<SharedLeverage>(Exchange, new ServerError(new ErrorInfo(ErrorType.NoPosition, "Not found")));
+                return SharedExecutionResult<SharedLeverage>.Error(result.AsError<SharedLeverage>(new ServerError(new ErrorInfo(ErrorType.NoPosition, "Not found"))));
 
-            return result.AsExchangeResult(Exchange, request.TradingMode, new SharedLeverage(position.Position.Leverage!.Value));
+            return SharedExecutionResult<SharedLeverage>.Ok(result, new SharedLeverage(position.Position.Leverage!.Value));
+                                });
         }
 
-        SetLeverageOptions ILeverageRestClient.SetLeverageOptions { get; } = new SetLeverageOptions()
+        SetLeverageOptions ILeverageRestClient.SetLeverageOptions { get; } = new SetLeverageOptions(_exchangeName)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
                 new ParameterDescription(nameof(SetLeverageRequest.MarginMode), typeof(SharedMarginMode), "Margin mode", SharedMarginMode.Isolated)
             }
         };
-        async Task<ExchangeWebResult<SharedLeverage>> ILeverageRestClient.SetLeverageAsync(SetLeverageRequest request, CancellationToken ct)
+        Task<ExchangeWebResult<SharedLeverage>> ILeverageRestClient.SetLeverageAsync(SetLeverageRequest request, CancellationToken ct)
         {
-            var validationError = ((ILeverageRestClient)this).SetLeverageOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedLeverage>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<ILeverageRestClient, SetLeverageRequest, SharedLeverage>(
+                this,
+                client => client.SetLeverageOptions,
+                request,
+                async () =>
+                {
 
             var result = await Trading.SetLeverageAsync(symbol: request.Symbol!.GetSymbol(FormatSymbol), (int)request.Leverage, request.MarginMode == SharedMarginMode.Isolated ? Enums.MarginType.Isolated : Enums.MarginType.Cross, ct: ct).ConfigureAwait(false);
             if (!result)
-                return result.AsExchangeResult<SharedLeverage>(Exchange, null, default);
+                return SharedExecutionResult<SharedLeverage>.Error(result);
 
-            return result.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedLeverage(request.Leverage)
+            return SharedExecutionResult<SharedLeverage>.Ok(result, new SharedLeverage(request.Leverage)
             {
                 MarginMode = request.MarginMode
             });
+                                });
         }
         #endregion
 
         #region Open Interest client
 
-        EndpointOptions<GetOpenInterestRequest> IOpenInterestRestClient.GetOpenInterestOptions { get; } = new EndpointOptions<GetOpenInterestRequest>(true);
-        async Task<ExchangeWebResult<SharedOpenInterest>> IOpenInterestRestClient.GetOpenInterestAsync(GetOpenInterestRequest request, CancellationToken ct)
+        EndpointOptions<GetOpenInterestRequest, IOpenInterestRestClient> IOpenInterestRestClient.GetOpenInterestOptions { get; } = new EndpointOptions<GetOpenInterestRequest, IOpenInterestRestClient>(_exchangeName, true);
+        Task<ExchangeWebResult<SharedOpenInterest>> IOpenInterestRestClient.GetOpenInterestAsync(GetOpenInterestRequest request, CancellationToken ct)
         {
-            var validationError = ((IOpenInterestRestClient)this).GetOpenInterestOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedOpenInterest>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<IOpenInterestRestClient, GetOpenInterestRequest, SharedOpenInterest>(
+                this,
+                client => client.GetOpenInterestOptions,
+                request,
+                async () =>
+                {
 
             var result = await ExchangeData.GetExchangeInfoAndTickersAsync(ct: ct).ConfigureAwait(false);
             if (!result)
-                return result.AsExchangeResult<SharedOpenInterest>(Exchange, null, default);
+                return SharedExecutionResult<SharedOpenInterest>.Error(result);
 
             var ticker = result.Data.Tickers.SingleOrDefault(x => x.Symbol == request.Symbol!.GetSymbol(FormatSymbol));
             if (ticker == null)
-                return result.AsExchangeError<SharedOpenInterest>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
+                return SharedExecutionResult<SharedOpenInterest>.Error(result.AsError<SharedOpenInterest>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found"))));
 
-            return result.AsExchangeResult(Exchange, request.TradingMode, new SharedOpenInterest(ticker.OpenInterest ?? 0));
+            return SharedExecutionResult<SharedOpenInterest>.Ok(result, new SharedOpenInterest(ticker.OpenInterest ?? 0));
+                                });
         }
 
         #endregion
@@ -446,25 +492,21 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
         string IFuturesOrderRestClient.GenerateClientOrderId() => ExchangeHelpers.RandomHexString(16)!.ToLowerInvariant();
 
-        PlaceFuturesOrderOptions IFuturesOrderRestClient.PlaceFuturesOrderOptions { get; } = new PlaceFuturesOrderOptions(false)
+        PlaceFuturesOrderOptions IFuturesOrderRestClient.PlaceFuturesOrderOptions { get; } = new PlaceFuturesOrderOptions(_exchangeName, false)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
                 new ParameterDescription(nameof(PlaceSpotOrderRequest.Price), typeof(decimal), "Price for the order. For market orders this should be the current symbol price", 21.5m)
             }
         };
-        async Task<ExchangeWebResult<SharedId>> IFuturesOrderRestClient.PlaceFuturesOrderAsync(PlaceFuturesOrderRequest request, CancellationToken ct)
+        Task<ExchangeWebResult<SharedId>> IFuturesOrderRestClient.PlaceFuturesOrderAsync(PlaceFuturesOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).PlaceFuturesOrderOptions.ValidateRequest(
-                Exchange,
+            return SharedUtils.ExecuteSharedAsync<IFuturesOrderRestClient, PlaceFuturesOrderRequest, SharedId>(
+                this,
+                client => client.PlaceFuturesOrderOptions,
                 request,
-                request.TradingMode,
-                SupportedTradingModes,
-                ((IFuturesOrderRestClient)this).FuturesSupportedOrderTypes,
-                ((IFuturesOrderRestClient)this).FuturesSupportedTimeInForce,
-                ((IFuturesOrderRestClient)this).FuturesSupportedOrderQuantity);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                async () =>
+                {
 
             var result = await Trading.PlaceOrderAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
@@ -478,26 +520,30 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 ct: ct).ConfigureAwait(false);
 
             if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+                return SharedExecutionResult<SharedId>.Error(result);
 
-            return result.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedId(result.Data.OrderId.ToString()));
+            return SharedExecutionResult<SharedId>.Ok(result, new SharedId(result.Data.OrderId.ToString()));
+                                });
         }
 
-        EndpointOptions<GetOrderRequest> IFuturesOrderRestClient.GetFuturesOrderOptions { get; } = new EndpointOptions<GetOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedFuturesOrder>> IFuturesOrderRestClient.GetFuturesOrderAsync(GetOrderRequest request, CancellationToken ct)
+        EndpointOptions<GetOrderRequest, IFuturesOrderRestClient> IFuturesOrderRestClient.GetFuturesOrderOptions { get; } = new EndpointOptions<GetOrderRequest, IFuturesOrderRestClient>(_exchangeName, true);
+        Task<ExchangeWebResult<SharedFuturesOrder>> IFuturesOrderRestClient.GetFuturesOrderAsync(GetOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetFuturesOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesOrder>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<IFuturesOrderRestClient, GetOrderRequest, SharedFuturesOrder>(
+                this,
+                client => client.GetFuturesOrderOptions,
+                request,
+                async () =>
+                {
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedFuturesOrder>(Exchange, ArgumentError.Invalid(nameof(GetOrderRequest.OrderId), "Invalid order id"));
+                return SharedExecutionResult<SharedFuturesOrder>.Error(ArgumentError.Invalid(nameof(GetOrderRequest.OrderId), "Invalid order id"));
 
             var order = await Trading.GetOrderAsync(orderId, ct: ct).ConfigureAwait(false);
             if (!order)
-                return order.AsExchangeResult<SharedFuturesOrder>(Exchange, null, default);
+                return SharedExecutionResult<SharedFuturesOrder>.Error(order);
 
-            return order.AsExchangeResult(Exchange, TradingMode.PerpetualLinear, new SharedFuturesOrder(
+            return SharedExecutionResult<SharedFuturesOrder>.Ok(order, new SharedFuturesOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicId, order.Data.Order.Symbol),
                 order.Data.Order.Symbol!,
                 order.Data.Order.OrderId.ToString(),
@@ -516,20 +562,24 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 TriggerPrice = order.Data.Order.TriggerPrice == 0 ? null : order.Data.Order.TriggerPrice,
                 IsTriggerOrder = order.Data.Order.TriggerPrice > 0
             });
+                                });
         }
 
-        EndpointOptions<GetOpenOrdersRequest> IFuturesOrderRestClient.GetOpenFuturesOrdersOptions { get; } = new EndpointOptions<GetOpenOrdersRequest>(true)
+        EndpointOptions<GetOpenOrdersRequest, IFuturesOrderRestClient> IFuturesOrderRestClient.GetOpenFuturesOrdersOptions { get; } = new EndpointOptions<GetOpenOrdersRequest, IFuturesOrderRestClient>(_exchangeName, true)
         {
             OptionalExchangeParameters = new List<ParameterDescription>
             {
                 new ParameterDescription("dex", typeof(string), "DEX to retrieve open orders for", "xyz")
             }
         };
-        async Task<ExchangeWebResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetOpenFuturesOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
+        Task<ExchangeWebResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetOpenFuturesOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetOpenFuturesOrdersOptions.ValidateRequest(Exchange, request, request.Symbol?.TradingMode ?? request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesOrder[]>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<IFuturesOrderRestClient, GetOpenOrdersRequest, SharedFuturesOrder[]>(
+                this,
+                client => client.GetOpenFuturesOrdersOptions,
+                request,
+                async () =>
+                {
 
             var symbol = request.Symbol?.GetSymbol(FormatSymbol);
 
@@ -544,13 +594,13 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
             var orders = await Trading.GetOpenOrdersExtendedAsync(dex: dex, ct: ct).ConfigureAwait(false);
             if (!orders)
-                return orders.AsExchangeResult<SharedFuturesOrder[]>(Exchange, null, default);
+                return SharedExecutionResult<SharedFuturesOrder[]>.Error(orders);
 
             var data = orders.Data.Where(x => x.SymbolType == Enums.SymbolType.Futures);
             if (symbol != null)
                 data = data.Where(x => x.Symbol == symbol);
 
-            return orders.AsExchangeResult<SharedFuturesOrder[]>(Exchange, request.Symbol == null ? SupportedTradingModes : new[] { request.Symbol.TradingMode }, orders.Data.Select(x => new SharedFuturesOrder(
+            return SharedExecutionResult<SharedFuturesOrder[]>.Ok(orders, orders.Data.Select(x => new SharedFuturesOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol),
                 x.Symbol!,
                 x.OrderId.ToString(),
@@ -569,19 +619,23 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 TriggerPrice = x.TriggerPrice == 0 ? null : x.TriggerPrice,
                 IsTriggerOrder = x.TriggerPrice > 0
             }).ToArray());
+                                });
         }
 
-        GetClosedOrdersOptions IFuturesOrderRestClient.GetClosedFuturesOrdersOptions { get; } = new GetClosedOrdersOptions(true, true, false, 2000);
-        async Task<ExchangeWebResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetClosedFuturesOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageToken, CancellationToken ct)
+        GetFuturesClosedOrdersOptions IFuturesOrderRestClient.GetClosedFuturesOrdersOptions { get; } = new GetFuturesClosedOrdersOptions(_exchangeName, true, true, false, 2000);
+        Task<ExchangeWebResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetClosedFuturesOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageToken, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetClosedFuturesOrdersOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesOrder[]>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<IFuturesOrderRestClient, GetClosedOrdersRequest, SharedFuturesOrder[]>(
+                this,
+                client => client.GetClosedFuturesOrdersOptions,
+                request,
+                async () =>
+                {
 
             // Get data
             var orders = await Trading.GetOrderHistoryAsync(ct: ct).ConfigureAwait(false);
             if (!orders)
-                return orders.AsExchangeResult<SharedFuturesOrder[]>(Exchange, null, default);
+                return SharedExecutionResult<SharedFuturesOrder[]>.Error(orders);
 
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
@@ -592,10 +646,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             if (request.Limit != null)
                 data = data.Take(request.Limit.Value);
 
-            return orders.AsExchangeResult(
-                Exchange,
-                request.Symbol.TradingMode,
-                ExchangeHelpers.ApplyFilter(data, x => x.Timestamp, request.StartTime, request.EndTime, request.Direction ?? DataDirection.Descending)
+            return SharedExecutionResult<SharedFuturesOrder[]>.Ok(orders, ExchangeHelpers.ApplyFilter(data, x => x.Timestamp, request.StartTime, request.EndTime, request.Direction ?? DataDirection.Descending)
                 .Select(x =>
                     new SharedFuturesOrder(
                         ExchangeSymbolCache.ParseSymbol(_topicId, x.Order.Symbol!), 
@@ -616,24 +667,28 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                         TriggerPrice = x.Order.TriggerPrice == 0 ? null : x.Order.TriggerPrice,
                         IsTriggerOrder = x.Order.TriggerPrice > 0
                     }).ToArray());
+                                });
         }
 
-        EndpointOptions<GetOrderTradesRequest> IFuturesOrderRestClient.GetFuturesOrderTradesOptions { get; } = new EndpointOptions<GetOrderTradesRequest>(true);
-        async Task<ExchangeWebResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
+        EndpointOptions<GetOrderTradesRequest, IFuturesOrderRestClient> IFuturesOrderRestClient.GetFuturesOrderTradesOptions { get; } = new EndpointOptions<GetOrderTradesRequest, IFuturesOrderRestClient>(_exchangeName, true);
+        Task<ExchangeWebResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetFuturesOrderTradesOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<IFuturesOrderRestClient, GetOrderTradesRequest, SharedUserTrade[]>(
+                this,
+                client => client.GetFuturesOrderTradesOptions,
+                request,
+                async () =>
+                {
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, ArgumentError.Invalid(nameof(GetOrderTradesRequest.OrderId), "Invalid order id"));
+                return SharedExecutionResult<SharedUserTrade[]>.Error(ArgumentError.Invalid(nameof(GetOrderTradesRequest.OrderId), "Invalid order id"));
 
             var orders = await Trading.GetUserTradesAsync(ct: ct).ConfigureAwait(false);
             if (!orders)
-                return orders.AsExchangeResult<SharedUserTrade[]>(Exchange, null, default);
+                return SharedExecutionResult<SharedUserTrade[]>.Error(orders);
 
             var data = orders.Data.Where(x => x.OrderId == orderId);
-            return orders.AsExchangeResult<SharedUserTrade[]>(Exchange, TradingMode.PerpetualLinear, data.Select(x => new SharedUserTrade(
+            return SharedExecutionResult<SharedUserTrade[]>.Ok(orders, data.Select(x => new SharedUserTrade(
                 ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), 
                 x.Symbol,
                 x.OrderId.ToString(),
@@ -647,14 +702,18 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 FeeAsset = x.FeeToken,
                 Role = x.Crossed ? SharedRole.Taker : SharedRole.Maker
             }).ToArray());
+                                });
         }
 
-        GetUserTradesOptions IFuturesOrderRestClient.GetFuturesUserTradesOptions { get; } = new GetUserTradesOptions(true, false, true, 2000);
-        async Task<ExchangeWebResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        GetFuturesUserTradesOptions IFuturesOrderRestClient.GetFuturesUserTradesOptions { get; } = new GetFuturesUserTradesOptions(_exchangeName, true, false, true, 2000);
+        Task<ExchangeWebResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetFuturesUserTradesOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<IFuturesOrderRestClient, GetUserTradesRequest, SharedUserTrade[]>(
+                this,
+                client => client.GetFuturesUserTradesOptions,
+                request,
+                async () =>
+                {
 
             int limit = request.Limit ?? 2000;
             var direction = DataDirection.Ascending;
@@ -666,7 +725,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 ct: ct
                 ).ConfigureAwait(false);
             if (!result)
-                return result.AsExchangeResult<SharedUserTrade[]>(Exchange, null, default);
+                return SharedExecutionResult<SharedUserTrade[]>.Error(result);
 
             var data = result.Data.Where(x => x.Symbol == request.Symbol!.GetSymbol(FormatSymbol));
             var nextPageRequest = Pagination.GetNextPageRequest(
@@ -677,10 +736,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                      request.EndTime ?? DateTime.UtcNow,
                      pageParams);
 
-            return result.AsExchangeResult(
-                    Exchange,
-                    request.Symbol!.TradingMode,
-                    ExchangeHelpers.ApplyFilter(data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
+            return SharedExecutionResult<SharedUserTrade[]>.Ok(result, ExchangeHelpers.ApplyFilter(data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
                     .Select(x =>
                         new SharedUserTrade(
                             ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), 
@@ -697,49 +753,57 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                             Role = x.Crossed ? SharedRole.Taker : SharedRole.Maker
                         })
                     .ToArray(), nextPageRequest);
+                                });
         }
 
-        EndpointOptions<CancelOrderRequest> IFuturesOrderRestClient.CancelFuturesOrderOptions { get; } = new EndpointOptions<CancelOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedId>> IFuturesOrderRestClient.CancelFuturesOrderAsync(CancelOrderRequest request, CancellationToken ct)
+        EndpointOptions<CancelOrderRequest, IFuturesOrderRestClient> IFuturesOrderRestClient.CancelFuturesOrderOptions { get; } = new EndpointOptions<CancelOrderRequest, IFuturesOrderRestClient>(_exchangeName, true);
+        Task<ExchangeWebResult<SharedId>> IFuturesOrderRestClient.CancelFuturesOrderAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).CancelFuturesOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<IFuturesOrderRestClient, CancelOrderRequest, SharedId>(
+                this,
+                client => client.CancelFuturesOrderOptions,
+                request,
+                async () =>
+                {
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedId>(Exchange, ArgumentError.Invalid(nameof(CancelOrderRequest.OrderId), "Invalid order id"));
+                return SharedExecutionResult<SharedId>.Error(ArgumentError.Invalid(nameof(CancelOrderRequest.OrderId), "Invalid order id"));
 
             var order = await Trading.CancelOrderAsync(request.Symbol!.GetSymbol(FormatSymbol), orderId, ct: ct).ConfigureAwait(false);
             if (!order)
-                return order.AsExchangeResult<SharedId>(Exchange, null, default);
+                return SharedExecutionResult<SharedId>.Error(order);
 
-            return order.AsExchangeResult(Exchange, TradingMode.PerpetualLinear, new SharedId(request.OrderId));
+            return SharedExecutionResult<SharedId>.Ok(order, new SharedId(request.OrderId));
+                                });
         }
 
-        EndpointOptions<GetPositionsRequest> IFuturesOrderRestClient.GetPositionsOptions { get; } = new EndpointOptions<GetPositionsRequest>(true)
+        EndpointOptions<GetPositionsRequest, IFuturesOrderRestClient> IFuturesOrderRestClient.GetPositionsOptions { get; } = new EndpointOptions<GetPositionsRequest, IFuturesOrderRestClient>(_exchangeName, true)
         {
             OptionalExchangeParameters = new List<ParameterDescription>
             {
                 new ParameterDescription("dex", typeof(string), "DEX to retrieve leverage for", "xyz")
             }
         };
-        async Task<ExchangeWebResult<SharedPosition[]>> IFuturesOrderRestClient.GetPositionsAsync(GetPositionsRequest request, CancellationToken ct)
+        Task<ExchangeWebResult<SharedPosition[]>> IFuturesOrderRestClient.GetPositionsAsync(GetPositionsRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetPositionsOptions.ValidateRequest(Exchange, request, request.Symbol?.TradingMode ?? request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedPosition[]>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<IFuturesOrderRestClient, GetPositionsRequest, SharedPosition[]>(
+                this,
+                client => client.GetPositionsOptions,
+                request,
+                async () =>
+                {
 
             string? dex = ExchangeParameters.GetValue<string>(request.ExchangeParameters, Exchange, "dex");
             var result = await Account.GetAccountInfoAsync(dex: dex, ct: ct).ConfigureAwait(false);
             if (!result)
-                return result.AsExchangeResult<SharedPosition[]>(Exchange, null, default);
+                return SharedExecutionResult<SharedPosition[]>.Error(result);
 
             IEnumerable<HyperLiquidPosition> data = result.Data.Positions;
             if (request.Symbol != null)
                 data = data.Where(x => x.Position.Symbol == request.Symbol.GetSymbol(FormatSymbol));
 
             var resultTypes = request.Symbol == null && request.TradingMode == null ? SupportedTradingModes : request.Symbol != null ? new[] { request.Symbol.TradingMode } : new[] { request.TradingMode!.Value };
-            return result.AsExchangeResult<SharedPosition[]>(Exchange, resultTypes, data.Select(x => new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicId, x.Position.Symbol), x.Position.Symbol, Math.Abs(x.Position.PositionQuantity ?? 0), null)
+            return SharedExecutionResult<SharedPosition[]>.Ok(result, data.Select(x => new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicId, x.Position.Symbol), x.Position.Symbol, Math.Abs(x.Position.PositionQuantity ?? 0), null)
             {
                 UnrealizedPnl = x.Position.UnrealizedPnl,
                 LiquidationPrice = x.Position.LiquidationPrice == 0 ? null : x.Position.LiquidationPrice,
@@ -748,9 +812,10 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 PositionMode = SharedPositionMode.OneWay,
                 PositionSide = x.Position.PositionQuantity >= 0 ? SharedPositionSide.Long : SharedPositionSide.Short
             }).ToArray());
+                                });
         }
 
-        EndpointOptions<ClosePositionRequest> IFuturesOrderRestClient.ClosePositionOptions { get; } = new EndpointOptions<ClosePositionRequest>(true)
+        EndpointOptions<ClosePositionRequest, IFuturesOrderRestClient> IFuturesOrderRestClient.ClosePositionOptions { get; } = new EndpointOptions<ClosePositionRequest, IFuturesOrderRestClient>(_exchangeName, true)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
@@ -762,11 +827,14 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 new ParameterDescription("Price", typeof(decimal), "The current price of the symbol. Required to calculate max slippage.", 21.5m)
             }
         };
-        async Task<ExchangeWebResult<SharedId>> IFuturesOrderRestClient.ClosePositionAsync(ClosePositionRequest request, CancellationToken ct)
+        Task<ExchangeWebResult<SharedId>> IFuturesOrderRestClient.ClosePositionAsync(ClosePositionRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).ClosePositionOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<IFuturesOrderRestClient, ClosePositionRequest, SharedId>(
+                this,
+                client => client.ClosePositionOptions,
+                request,
+                async () =>
+                {
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await Trading.PlaceOrderAsync(
@@ -779,9 +847,10 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 timeInForce: Enums.TimeInForce.ImmediateOrCancel,
                 ct: ct).ConfigureAwait(false);
             if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+                return SharedExecutionResult<SharedId>.Error(result);
 
-            return result.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedId(result.Data.OrderId.ToString()));
+            return SharedExecutionResult<SharedId>.Ok(result, new SharedId(result.Data.OrderId.ToString()));
+                                });
         }
 
         private SharedTimeInForce? ParseTimeInForce(TimeInForce? timeInForce)
@@ -849,18 +918,21 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
         #region Futures Client Id Order Client
 
-        EndpointOptions<GetOrderRequest> IFuturesOrderClientIdRestClient.GetFuturesOrderByClientOrderIdOptions { get; } = new EndpointOptions<GetOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedFuturesOrder>> IFuturesOrderClientIdRestClient.GetFuturesOrderByClientOrderIdAsync(GetOrderRequest request, CancellationToken ct)
+        EndpointOptions<GetOrderRequest, IFuturesOrderClientIdRestClient> IFuturesOrderClientIdRestClient.GetFuturesOrderByClientOrderIdOptions { get; } = new EndpointOptions<GetOrderRequest, IFuturesOrderClientIdRestClient>(_exchangeName, true);
+        Task<ExchangeWebResult<SharedFuturesOrder>> IFuturesOrderClientIdRestClient.GetFuturesOrderByClientOrderIdAsync(GetOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetFuturesOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesOrder>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<IFuturesOrderClientIdRestClient, GetOrderRequest, SharedFuturesOrder>(
+                this,
+                client => client.GetFuturesOrderByClientOrderIdOptions,
+                request,
+                async () =>
+                {
 
             var order = await Trading.GetOrderAsync(clientOrderId: request.OrderId, ct: ct).ConfigureAwait(false);
             if (!order)
-                return order.AsExchangeResult<SharedFuturesOrder>(Exchange, null, default);
+                return SharedExecutionResult<SharedFuturesOrder>.Error(order);
 
-            return order.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedFuturesOrder(
+            return SharedExecutionResult<SharedFuturesOrder>.Ok(order, new SharedFuturesOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicId, order.Data.Order.Symbol!),
                 order.Data.Order.Symbol!,
                 order.Data.Order.OrderId.ToString(),
@@ -878,25 +950,30 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 TriggerPrice = order.Data.Order.TriggerPrice == 0 ? null : order.Data.Order.TriggerPrice,
                 IsTriggerOrder = order.Data.Order.TriggerPrice > 0
             });
+                                });
         }
 
-        EndpointOptions<CancelOrderRequest> IFuturesOrderClientIdRestClient.CancelFuturesOrderByClientOrderIdOptions { get; } = new EndpointOptions<CancelOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedId>> IFuturesOrderClientIdRestClient.CancelFuturesOrderByClientOrderIdAsync(CancelOrderRequest request, CancellationToken ct)
+        EndpointOptions<CancelOrderRequest, IFuturesOrderClientIdRestClient> IFuturesOrderClientIdRestClient.CancelFuturesOrderByClientOrderIdOptions { get; } = new EndpointOptions<CancelOrderRequest, IFuturesOrderClientIdRestClient>(_exchangeName, true);
+        Task<ExchangeWebResult<SharedId>> IFuturesOrderClientIdRestClient.CancelFuturesOrderByClientOrderIdAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).CancelFuturesOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<IFuturesOrderClientIdRestClient, CancelOrderRequest, SharedId>(
+                this,
+                client => client.CancelFuturesOrderByClientOrderIdOptions,
+                request,
+                async () =>
+                {
 
             var order = await Trading.CancelOrderByClientOrderIdAsync(request.Symbol!.GetSymbol(FormatSymbol), clientOrderId: request.OrderId, ct: ct).ConfigureAwait(false);
             if (!order)
-                return order.AsExchangeResult<SharedId>(Exchange, null, default);
+                return SharedExecutionResult<SharedId>.Error(order);
 
-            return order.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedId(request.OrderId));
+            return SharedExecutionResult<SharedId>.Ok(order, new SharedId(request.OrderId));
+                                });
         }
         #endregion
 
         #region Tp/SL Client
-        EndpointOptions<SetTpSlRequest> IFuturesTpSlRestClient.SetFuturesTpSlOptions { get; } = new EndpointOptions<SetTpSlRequest>(true)
+        EndpointOptions<SetTpSlRequest, IFuturesTpSlRestClient> IFuturesTpSlRestClient.SetFuturesTpSlOptions { get; } = new EndpointOptions<SetTpSlRequest, IFuturesTpSlRestClient>(_exchangeName, true)
         {
             RequestNotes = "API doesn't return an id for trigger orders",
             RequiredOptionalParameters = new List<ParameterDescription>
@@ -905,11 +982,14 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             }
         };
 
-        async Task<ExchangeWebResult<SharedId>> IFuturesTpSlRestClient.SetFuturesTpSlAsync(SetTpSlRequest request, CancellationToken ct)
+        Task<ExchangeWebResult<SharedId>> IFuturesTpSlRestClient.SetFuturesTpSlAsync(SetTpSlRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTpSlRestClient)this).SetFuturesTpSlOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<IFuturesTpSlRestClient, SetTpSlRequest, SharedId>(
+                this,
+                client => client.SetFuturesTpSlOptions,
+                request,
+                async () =>
+                {
 
             var result = await Trading.PlaceOrderAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
@@ -924,13 +1004,14 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 ct: ct).ConfigureAwait(false);
 
             if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+                return SharedExecutionResult<SharedId>.Error(result);
 
             // Return
-            return result.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedId(result.Data.OrderId.ToString()));
+            return SharedExecutionResult<SharedId>.Ok(result, new SharedId(result.Data.OrderId.ToString()));
+                                });
         }
 
-        EndpointOptions<CancelTpSlRequest> IFuturesTpSlRestClient.CancelFuturesTpSlOptions { get; } = new EndpointOptions<CancelTpSlRequest>(true)
+        EndpointOptions<CancelTpSlRequest, IFuturesTpSlRestClient> IFuturesTpSlRestClient.CancelFuturesTpSlOptions { get; } = new EndpointOptions<CancelTpSlRequest, IFuturesTpSlRestClient>(_exchangeName, true)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
@@ -938,24 +1019,28 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             }
         };
 
-        async Task<ExchangeWebResult<bool>> IFuturesTpSlRestClient.CancelFuturesTpSlAsync(CancelTpSlRequest request, CancellationToken ct)
+        Task<ExchangeWebResult<bool>> IFuturesTpSlRestClient.CancelFuturesTpSlAsync(CancelTpSlRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTpSlRestClient)this).CancelFuturesTpSlOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<bool>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<IFuturesTpSlRestClient, CancelTpSlRequest, bool>(
+                this,
+                client => client.CancelFuturesTpSlOptions,
+                request,
+                async () =>
+                {
 
             if (!long.TryParse(request.OrderId, out var orderId) || orderId == 0)
-                return new ExchangeWebResult<bool>(Exchange, ArgumentError.Invalid(nameof(CancelTpSlRequest.OrderId), "Invalid order id"));
+                return SharedExecutionResult<bool>.Error(ArgumentError.Invalid(nameof(CancelTpSlRequest.OrderId), "Invalid order id"));
 
             var result = await Trading.CancelOrderAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
                 orderId,
                 ct: ct).ConfigureAwait(false);
             if (!result)
-                return result.AsExchangeResult<bool>(Exchange, null, default);
+                return SharedExecutionResult<bool>.Error(result);
 
             // Return
-            return result.AsExchangeResult(Exchange, request.Symbol.TradingMode, true);
+            return SharedExecutionResult<bool>.Ok(result, true);
+                                });
         }
 
         #endregion

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiShared.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiShared.cs
@@ -42,19 +42,18 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 request,
                 async () =>
                 {
+                    string? dex = request.GetParamValue<string>(Exchange, "dex");
+                    var result = await Account.GetAccountInfoAsync(dex: dex, ct: ct).ConfigureAwait(false);
+                    if (!result)
+                        return SharedExecutionResult<SharedBalance[]>.Error(result);
 
-            string? dex = ExchangeParameters.GetValue<string>(request.ExchangeParameters, Exchange, "dex");
-            var result = await Account.GetAccountInfoAsync(dex: dex, ct: ct).ConfigureAwait(false);
-            if (!result)
-                return SharedExecutionResult<SharedBalance[]>.Error(result);
-
-            return SharedExecutionResult<SharedBalance[]>.Ok(result, [
-                new SharedBalance(
-                    "USDC",
-                    result.Data.MarginSummary.AccountValue - result.Data.MarginSummary.TotalMarginUsed,
-                    result.Data.MarginSummary.AccountValue)
-                ]);
-                                });
+                    return SharedExecutionResult<SharedBalance[]>.Ok(result, [
+                        new SharedBalance(
+                            "USDC",
+                            result.Data.MarginSummary.AccountValue - result.Data.MarginSummary.TotalMarginUsed,
+                            result.Data.MarginSummary.AccountValue)
+                        ]);
+                });
         }
 
         #endregion
@@ -254,7 +253,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 async () =>
                 {
 
-            string? dex = ExchangeParameters.GetValue<string>(request.ExchangeParameters, Exchange, "dex");
+            string? dex = ExchangeParameters.GetProcessValue<string>(request.ExchangeParameters, Exchange, "dex");
             var result = await ExchangeData.GetExchangeInfoAllDexesAsync(ct: ct).ConfigureAwait(false);
             if (!result)
                 return SharedExecutionResult<SharedFuturesSymbol[]>.Error(result);
@@ -410,7 +409,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 async () =>
                 {
 
-            string? dex = ExchangeParameters.GetValue<string>(request.ExchangeParameters, Exchange, "dex");
+            string? dex = ExchangeParameters.GetProcessValue<string>(request.ExchangeParameters, Exchange, "dex");
             var result = await Account.GetAccountInfoAsync(dex: dex, ct: ct).ConfigureAwait(false);
             if (!result)
                 return SharedExecutionResult<SharedLeverage>.Error(result);
@@ -584,7 +583,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             var symbol = request.Symbol?.GetSymbol(FormatSymbol);
 
             // Get dex from parameters or symbol (if symbol is in format DEX:SYMBOL)
-            string? dex = ExchangeParameters.GetValue<string>(request.ExchangeParameters, Exchange, "dex");
+            string? dex = ExchangeParameters.GetProcessValue<string>(request.ExchangeParameters, Exchange, "dex");
             if (dex == null && symbol != null)
             {
                 var dexSeparatorIndex = symbol.IndexOf(':');
@@ -793,7 +792,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 async () =>
                 {
 
-            string? dex = ExchangeParameters.GetValue<string>(request.ExchangeParameters, Exchange, "dex");
+            string? dex = ExchangeParameters.GetProcessValue<string>(request.ExchangeParameters, Exchange, "dex");
             var result = await Account.GetAccountInfoAsync(dex: dex, ct: ct).ConfigureAwait(false);
             if (!result)
                 return SharedExecutionResult<SharedPosition[]>.Error(result);
@@ -842,7 +841,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 request.PositionSide == SharedPositionSide.Long ? Enums.OrderSide.Sell : Enums.OrderSide.Buy,
                 Enums.OrderType.Market,
                 quantity: request.Quantity!.Value,
-                price: ExchangeParameters.GetValue<decimal>(request.ExchangeParameters, ExchangeName, "Price"),
+                price: ExchangeParameters.GetProcessValue<decimal>(request.ExchangeParameters, ExchangeName, "Price"),
                 reduceOnly: true,
                 timeInForce: Enums.TimeInForce.ImmediateOrCancel,
                 ct: ct).ConfigureAwait(false);

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiShared.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiShared.cs
@@ -21,7 +21,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
-        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(HyperLiquidExchange.Metadata, this);
 
 
         #region Balance Client
@@ -159,7 +159,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             if (symbol == null)
                 return HttpResult.Fail<SharedFuturesTicker>(result, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
-            return HttpResult.Ok(result, new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicId, symbol.Symbol), symbol.Symbol, symbol.MidPrice, null, null, symbol.NotionalVolume, (symbol.MidPrice == null || symbol.PreviousDayPrice == 0) ? null : Math.Round((symbol.MidPrice.Value / symbol.PreviousDayPrice * 100 - 100), 3))
+            return HttpResult.Ok(result, new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, symbol.Symbol), symbol.Symbol, symbol.MidPrice, null, null, symbol.NotionalVolume, (symbol.MidPrice == null || symbol.PreviousDayPrice == 0) ? null : Math.Round((symbol.MidPrice.Value / symbol.PreviousDayPrice * 100 - 100), 3))
             {
                 FundingRate = symbol.FundingRate,
                 MarkPrice = symbol.MarkPrice
@@ -178,7 +178,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             if (!result.Success)
                 return HttpResult.Fail<SharedFuturesTicker[]>(result);
 
-            return HttpResult.Ok(result, result.Data.Tickers.Select(x => new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), x.Symbol, x.MidPrice, null, null, x.NotionalVolume, (x.MidPrice == null || x.PreviousDayPrice == 0) ? null : Math.Round((x.MidPrice.Value / x.PreviousDayPrice * 100 - 100), 3))
+            return HttpResult.Ok(result, result.Data.Tickers.Select(x => new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Symbol), x.Symbol, x.MidPrice, null, null, x.NotionalVolume, (x.MidPrice == null || x.PreviousDayPrice == 0) ? null : Math.Round((x.MidPrice.Value / x.PreviousDayPrice * 100 - 100), 3))
             {
                 FundingRate = x.FundingRate,
                 MarkPrice = x.MarkPrice
@@ -203,7 +203,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 return HttpResult.Fail<SharedBookTicker>(resultTicker);
 
             return HttpResult.Ok(resultTicker, new SharedBookTicker(
-                ExchangeSymbolCache.ParseSymbol(_topicId, symbol),
+                ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, symbol),
                 symbol,
                 resultTicker.Data.Levels.Asks[0].Price,
                 resultTicker.Data.Levels.Asks[0].Quantity,
@@ -244,7 +244,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             var symbolRegistrations = result.Data.SelectMany(x => x.Symbols.Where(x => !x.IsDelisted).Select(ParseSymbol))
                 .Concat(result.Data.SelectMany(x => x.Symbols.Select(x => new SharedSpotSymbol(x.Name, "USDC", x.Name, true, TradingMode.PerpetualLinear)))).ToArray();
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, symbolRegistrations);
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, symbolRegistrations);
             return HttpResult.Ok(result, response);
                                 
         }
@@ -270,14 +270,14 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
         async Task<ExchangeCallResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)
         {
-            if (!ExchangeSymbolCache.HasCached(_topicId))
+            if (!ExchangeSymbolCache.HasCached(_topicId, EnvironmentName, null))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<SharedSymbol[]>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicId, baseAsset));
+            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicId, EnvironmentName, null, baseAsset));
         }
 
         async Task<ExchangeCallResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(SharedSymbol symbol)
@@ -285,26 +285,26 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             if (symbol.TradingMode == TradingMode.Spot)
                 throw new ArgumentException(nameof(symbol), "Spot symbols not allowed");
 
-            if (!ExchangeSymbolCache.HasCached(_topicId))
+            if (!ExchangeSymbolCache.HasCached(_topicId, EnvironmentName, null))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbol));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, EnvironmentName, null, symbol));
         }
 
         async Task<ExchangeCallResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(string symbolName)
         {
-            if (!ExchangeSymbolCache.HasCached(_topicId))
+            if (!ExchangeSymbolCache.HasCached(_topicId, EnvironmentName, null))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbolName));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, EnvironmentName, null, symbolName));
         }
         #endregion
 
@@ -503,7 +503,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 return HttpResult.Fail<SharedFuturesOrder>(order);
 
             return HttpResult.Ok(order, new SharedFuturesOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicId, order.Data.Order.Symbol),
+                ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, order.Data.Order.Symbol),
                 order.Data.Order.Symbol!,
                 order.Data.Order.OrderId.ToString(),
                 ParseOrderType(order.Data.Order.OrderType),
@@ -557,7 +557,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 data = data.Where(x => x.Symbol == symbol);
 
             return HttpResult.Ok(orders, orders.Data.Select(x => new SharedFuturesOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol),
+                ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Symbol),
                 x.Symbol!,
                 x.OrderId.ToString(),
                 ParseOrderType(x.OrderType),
@@ -602,7 +602,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             return HttpResult.Ok(orders, ExchangeHelpers.ApplyFilter(data, x => x.Timestamp, request.StartTime, request.EndTime, request.Direction ?? DataDirection.Descending)
                 .Select(x =>
                     new SharedFuturesOrder(
-                        ExchangeSymbolCache.ParseSymbol(_topicId, x.Order.Symbol!), 
+                        ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Order.Symbol!), 
                         x.Order.Symbol!,
                         x.Order.OrderId.ToString(),
                         ParseOrderType(x.Order.OrderType),
@@ -639,7 +639,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
             var data = orders.Data.Where(x => x.OrderId == orderId);
             return HttpResult.Ok(orders, data.Select(x => new SharedUserTrade(
-                ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), 
+                ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Symbol), 
                 x.Symbol,
                 x.OrderId.ToString(),
                 x.TradeId.ToString(),
@@ -686,7 +686,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
                     .Select(x =>
                         new SharedUserTrade(
-                            ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), 
+                            ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Symbol), 
                             x.Symbol,
                             x.OrderId.ToString(),
                             x.TradeId.ToString(),
@@ -754,7 +754,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 data = data.Where(x => x.Position.Symbol == request.Symbol.GetSymbol(FormatSymbol));
 
             var resultTypes = request.Symbol == null && request.TradingMode == null ? SupportedTradingModes : request.Symbol != null ? new[] { request.Symbol.TradingMode } : new[] { request.TradingMode!.Value };
-            return HttpResult.Ok(result, data.Select(x => new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicId, x.Position.Symbol), x.Position.Symbol, Math.Abs(x.Position.PositionQuantity ?? 0), null)
+            return HttpResult.Ok(result, data.Select(x => new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Position.Symbol), x.Position.Symbol, Math.Abs(x.Position.PositionQuantity ?? 0), null)
             {
                 UnrealizedPnl = x.Position.UnrealizedPnl,
                 LiquidationPrice = x.Position.LiquidationPrice == 0 ? null : x.Position.LiquidationPrice,
@@ -883,7 +883,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 return HttpResult.Fail<SharedFuturesOrder>(order);
 
             return HttpResult.Ok(order, new SharedFuturesOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicId, order.Data.Order.Symbol!),
+                ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, order.Data.Order.Symbol!),
                 order.Data.Order.Symbol!,
                 order.Data.Order.OrderId.ToString(),
                 ParseOrderType(order.Data.Order.OrderType),

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiShared.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiShared.cs
@@ -34,7 +34,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             }
         };
 
-        Task<ExchangeWebResult<SharedBalance[]>> IBalanceRestClient.GetBalancesAsync(GetBalancesRequest request, CancellationToken ct)
+        Task<HttpResult<SharedBalance[]>> IBalanceRestClient.GetBalancesAsync(GetBalancesRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IBalanceRestClient, GetBalancesRequest, SharedBalance[]>(
                 this,
@@ -77,7 +77,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             MaxTotalDataPoints = 5000
         };
 
-        Task<ExchangeWebResult<SharedKline[]>> IKlineRestClient.GetKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        Task<HttpResult<SharedKline[]>> IKlineRestClient.GetKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IKlineRestClient, GetKlinesRequest, SharedKline[]>(
                 this,
@@ -132,7 +132,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
         #region Order Book client
         GetOrderBookOptions IOrderBookRestClient.GetOrderBookOptions { get; } = new GetOrderBookOptions(_exchangeName, [20], false);
-        Task<ExchangeWebResult<SharedOrderBook>> IOrderBookRestClient.GetOrderBookAsync(GetOrderBookRequest request, CancellationToken ct)
+        Task<HttpResult<SharedOrderBook>> IOrderBookRestClient.GetOrderBookAsync(GetOrderBookRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IOrderBookRestClient, GetOrderBookRequest, SharedOrderBook>(
                 this,
@@ -156,7 +156,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Ticker client
 
         GetFuturesTickerOptions IFuturesTickerRestClient.GetFuturesTickerOptions { get; } = new GetFuturesTickerOptions(_exchangeName);
-        Task<ExchangeWebResult<SharedFuturesTicker>> IFuturesTickerRestClient.GetFuturesTickerAsync(GetTickerRequest request, CancellationToken ct)
+        Task<HttpResult<SharedFuturesTicker>> IFuturesTickerRestClient.GetFuturesTickerAsync(GetTickerRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IFuturesTickerRestClient, GetTickerRequest, SharedFuturesTicker>(
                 this,
@@ -183,7 +183,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         }
 
         GetFuturesTickersOptions IFuturesTickerRestClient.GetFuturesTickersOptions { get; } = new GetFuturesTickersOptions(_exchangeName);
-        Task<ExchangeWebResult<SharedFuturesTicker[]>> IFuturesTickerRestClient.GetFuturesTickersAsync(GetTickersRequest request, CancellationToken ct)
+        Task<HttpResult<SharedFuturesTicker[]>> IFuturesTickerRestClient.GetFuturesTickersAsync(GetTickersRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IFuturesTickerRestClient, GetTickersRequest, SharedFuturesTicker[]>(
                 this,
@@ -209,7 +209,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Book Ticker client
 
         EndpointOptions<GetBookTickerRequest, IBookTickerRestClient> IBookTickerRestClient.GetBookTickerOptions { get; } = new EndpointOptions<GetBookTickerRequest, IBookTickerRestClient>(_exchangeName, false);
-        Task<ExchangeWebResult<SharedBookTicker>> IBookTickerRestClient.GetBookTickerAsync(GetBookTickerRequest request, CancellationToken ct)
+        Task<HttpResult<SharedBookTicker>> IBookTickerRestClient.GetBookTickerAsync(GetBookTickerRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IBookTickerRestClient, GetBookTickerRequest, SharedBookTicker>(
                 this,
@@ -244,7 +244,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             }
         };
 
-        Task<ExchangeWebResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
+        Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IFuturesSymbolRestClient, GetSymbolsRequest, SharedFuturesSymbol[]>(
                 this,
@@ -292,19 +292,19 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             };
         }
 
-        async Task<ExchangeResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)
+        async Task<WebSocketResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)
         {
             if (!ExchangeSymbolCache.HasCached(_topicId))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols)
-                    return new ExchangeResult<SharedSymbol[]>(Exchange, symbols.Error!);
+                    return new WebSocketResult<SharedSymbol[]>(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<SharedSymbol[]>(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicId, baseAsset));
+            return new WebSocketResult<SharedSymbol[]>(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicId, baseAsset));
         }
 
-        async Task<ExchangeResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(SharedSymbol symbol)
+        async Task<WebSocketResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(SharedSymbol symbol)
         {
             if (symbol.TradingMode == TradingMode.Spot)
                 throw new ArgumentException(nameof(symbol), "Spot symbols not allowed");
@@ -313,29 +313,29 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols)
-                    return new ExchangeResult<bool>(Exchange, symbols.Error!);
+                    return new WebSocketResult<bool>(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbol));
+            return new WebSocketResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbol));
         }
 
-        async Task<ExchangeResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(string symbolName)
+        async Task<WebSocketResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(string symbolName)
         {
             if (!ExchangeSymbolCache.HasCached(_topicId))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols)
-                    return new ExchangeResult<bool>(Exchange, symbols.Error!);
+                    return new WebSocketResult<bool>(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbolName));
+            return new WebSocketResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbolName));
         }
         #endregion
 
         #region Fee Client
         EndpointOptions<GetFeeRequest, IFeeRestClient> IFeeRestClient.GetFeeOptions { get; } = new EndpointOptions<GetFeeRequest, IFeeRestClient>(_exchangeName, true);
 
-        Task<ExchangeWebResult<SharedFee>> IFeeRestClient.GetFeesAsync(GetFeeRequest request, CancellationToken ct)
+        Task<HttpResult<SharedFee>> IFeeRestClient.GetFeesAsync(GetFeeRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IFeeRestClient, GetFeeRequest, SharedFee>(
                 this,
@@ -358,7 +358,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Funding Rate client
         GetFundingRateHistoryOptions IFundingRateRestClient.GetFundingRateHistoryOptions { get; } = new GetFundingRateHistoryOptions(_exchangeName, true, false, true, 500, false);
 
-        Task<ExchangeWebResult<SharedFundingRate[]>> IFundingRateRestClient.GetFundingRateHistoryAsync(GetFundingRateHistoryRequest request, PageRequest? pageToken, CancellationToken ct)
+        Task<HttpResult<SharedFundingRate[]>> IFundingRateRestClient.GetFundingRateHistoryAsync(GetFundingRateHistoryRequest request, PageRequest? pageToken, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IFundingRateRestClient, GetFundingRateHistoryRequest, SharedFundingRate[]>(
                 this,
@@ -400,7 +400,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 new ParameterDescription("dex", typeof(string), "DEX to retrieve leverage for", "xyz")
             }
         };
-        Task<ExchangeWebResult<SharedLeverage>> ILeverageRestClient.GetLeverageAsync(GetLeverageRequest request, CancellationToken ct)
+        Task<HttpResult<SharedLeverage>> ILeverageRestClient.GetLeverageAsync(GetLeverageRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<ILeverageRestClient, GetLeverageRequest, SharedLeverage>(
                 this,
@@ -429,7 +429,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 new ParameterDescription(nameof(SetLeverageRequest.MarginMode), typeof(SharedMarginMode), "Margin mode", SharedMarginMode.Isolated)
             }
         };
-        Task<ExchangeWebResult<SharedLeverage>> ILeverageRestClient.SetLeverageAsync(SetLeverageRequest request, CancellationToken ct)
+        Task<HttpResult<SharedLeverage>> ILeverageRestClient.SetLeverageAsync(SetLeverageRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<ILeverageRestClient, SetLeverageRequest, SharedLeverage>(
                 this,
@@ -453,7 +453,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Open Interest client
 
         EndpointOptions<GetOpenInterestRequest, IOpenInterestRestClient> IOpenInterestRestClient.GetOpenInterestOptions { get; } = new EndpointOptions<GetOpenInterestRequest, IOpenInterestRestClient>(_exchangeName, true);
-        Task<ExchangeWebResult<SharedOpenInterest>> IOpenInterestRestClient.GetOpenInterestAsync(GetOpenInterestRequest request, CancellationToken ct)
+        Task<HttpResult<SharedOpenInterest>> IOpenInterestRestClient.GetOpenInterestAsync(GetOpenInterestRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IOpenInterestRestClient, GetOpenInterestRequest, SharedOpenInterest>(
                 this,
@@ -498,7 +498,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 new ParameterDescription(nameof(PlaceSpotOrderRequest.Price), typeof(decimal), "Price for the order. For market orders this should be the current symbol price", 21.5m)
             }
         };
-        Task<ExchangeWebResult<SharedId>> IFuturesOrderRestClient.PlaceFuturesOrderAsync(PlaceFuturesOrderRequest request, CancellationToken ct)
+        Task<HttpResult<SharedId>> IFuturesOrderRestClient.PlaceFuturesOrderAsync(PlaceFuturesOrderRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IFuturesOrderRestClient, PlaceFuturesOrderRequest, SharedId>(
                 this,
@@ -526,7 +526,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         }
 
         EndpointOptions<GetOrderRequest, IFuturesOrderRestClient> IFuturesOrderRestClient.GetFuturesOrderOptions { get; } = new EndpointOptions<GetOrderRequest, IFuturesOrderRestClient>(_exchangeName, true);
-        Task<ExchangeWebResult<SharedFuturesOrder>> IFuturesOrderRestClient.GetFuturesOrderAsync(GetOrderRequest request, CancellationToken ct)
+        Task<HttpResult<SharedFuturesOrder>> IFuturesOrderRestClient.GetFuturesOrderAsync(GetOrderRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IFuturesOrderRestClient, GetOrderRequest, SharedFuturesOrder>(
                 this,
@@ -571,7 +571,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 new ParameterDescription("dex", typeof(string), "DEX to retrieve open orders for", "xyz")
             }
         };
-        Task<ExchangeWebResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetOpenFuturesOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
+        Task<HttpResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetOpenFuturesOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IFuturesOrderRestClient, GetOpenOrdersRequest, SharedFuturesOrder[]>(
                 this,
@@ -622,7 +622,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         }
 
         GetFuturesClosedOrdersOptions IFuturesOrderRestClient.GetClosedFuturesOrdersOptions { get; } = new GetFuturesClosedOrdersOptions(_exchangeName, true, true, false, 2000);
-        Task<ExchangeWebResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetClosedFuturesOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageToken, CancellationToken ct)
+        Task<HttpResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetClosedFuturesOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageToken, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IFuturesOrderRestClient, GetClosedOrdersRequest, SharedFuturesOrder[]>(
                 this,
@@ -670,7 +670,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         }
 
         EndpointOptions<GetOrderTradesRequest, IFuturesOrderRestClient> IFuturesOrderRestClient.GetFuturesOrderTradesOptions { get; } = new EndpointOptions<GetOrderTradesRequest, IFuturesOrderRestClient>(_exchangeName, true);
-        Task<ExchangeWebResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
+        Task<HttpResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IFuturesOrderRestClient, GetOrderTradesRequest, SharedUserTrade[]>(
                 this,
@@ -705,7 +705,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         }
 
         GetFuturesUserTradesOptions IFuturesOrderRestClient.GetFuturesUserTradesOptions { get; } = new GetFuturesUserTradesOptions(_exchangeName, true, false, true, 2000);
-        Task<ExchangeWebResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        Task<HttpResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IFuturesOrderRestClient, GetUserTradesRequest, SharedUserTrade[]>(
                 this,
@@ -756,7 +756,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         }
 
         EndpointOptions<CancelOrderRequest, IFuturesOrderRestClient> IFuturesOrderRestClient.CancelFuturesOrderOptions { get; } = new EndpointOptions<CancelOrderRequest, IFuturesOrderRestClient>(_exchangeName, true);
-        Task<ExchangeWebResult<SharedId>> IFuturesOrderRestClient.CancelFuturesOrderAsync(CancelOrderRequest request, CancellationToken ct)
+        Task<HttpResult<SharedId>> IFuturesOrderRestClient.CancelFuturesOrderAsync(CancelOrderRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IFuturesOrderRestClient, CancelOrderRequest, SharedId>(
                 this,
@@ -783,7 +783,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 new ParameterDescription("dex", typeof(string), "DEX to retrieve leverage for", "xyz")
             }
         };
-        Task<ExchangeWebResult<SharedPosition[]>> IFuturesOrderRestClient.GetPositionsAsync(GetPositionsRequest request, CancellationToken ct)
+        Task<HttpResult<SharedPosition[]>> IFuturesOrderRestClient.GetPositionsAsync(GetPositionsRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IFuturesOrderRestClient, GetPositionsRequest, SharedPosition[]>(
                 this,
@@ -826,7 +826,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 new ParameterDescription("Price", typeof(decimal), "The current price of the symbol. Required to calculate max slippage.", 21.5m)
             }
         };
-        Task<ExchangeWebResult<SharedId>> IFuturesOrderRestClient.ClosePositionAsync(ClosePositionRequest request, CancellationToken ct)
+        Task<HttpResult<SharedId>> IFuturesOrderRestClient.ClosePositionAsync(ClosePositionRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IFuturesOrderRestClient, ClosePositionRequest, SharedId>(
                 this,
@@ -918,7 +918,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Futures Client Id Order Client
 
         EndpointOptions<GetOrderRequest, IFuturesOrderClientIdRestClient> IFuturesOrderClientIdRestClient.GetFuturesOrderByClientOrderIdOptions { get; } = new EndpointOptions<GetOrderRequest, IFuturesOrderClientIdRestClient>(_exchangeName, true);
-        Task<ExchangeWebResult<SharedFuturesOrder>> IFuturesOrderClientIdRestClient.GetFuturesOrderByClientOrderIdAsync(GetOrderRequest request, CancellationToken ct)
+        Task<HttpResult<SharedFuturesOrder>> IFuturesOrderClientIdRestClient.GetFuturesOrderByClientOrderIdAsync(GetOrderRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IFuturesOrderClientIdRestClient, GetOrderRequest, SharedFuturesOrder>(
                 this,
@@ -953,7 +953,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         }
 
         EndpointOptions<CancelOrderRequest, IFuturesOrderClientIdRestClient> IFuturesOrderClientIdRestClient.CancelFuturesOrderByClientOrderIdOptions { get; } = new EndpointOptions<CancelOrderRequest, IFuturesOrderClientIdRestClient>(_exchangeName, true);
-        Task<ExchangeWebResult<SharedId>> IFuturesOrderClientIdRestClient.CancelFuturesOrderByClientOrderIdAsync(CancelOrderRequest request, CancellationToken ct)
+        Task<HttpResult<SharedId>> IFuturesOrderClientIdRestClient.CancelFuturesOrderByClientOrderIdAsync(CancelOrderRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IFuturesOrderClientIdRestClient, CancelOrderRequest, SharedId>(
                 this,
@@ -981,7 +981,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             }
         };
 
-        Task<ExchangeWebResult<SharedId>> IFuturesTpSlRestClient.SetFuturesTpSlAsync(SetTpSlRequest request, CancellationToken ct)
+        Task<HttpResult<SharedId>> IFuturesTpSlRestClient.SetFuturesTpSlAsync(SetTpSlRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IFuturesTpSlRestClient, SetTpSlRequest, SharedId>(
                 this,
@@ -1018,7 +1018,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             }
         };
 
-        Task<ExchangeWebResult<bool>> IFuturesTpSlRestClient.CancelFuturesTpSlAsync(CancelTpSlRequest request, CancellationToken ct)
+        Task<HttpResult<bool>> IFuturesTpSlRestClient.CancelFuturesTpSlAsync(CancelTpSlRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IFuturesTpSlRestClient, CancelTpSlRequest, bool>(
                 this,

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiTrading.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiTrading.cs
@@ -15,11 +15,6 @@ namespace HyperLiquid.Net.Clients.FuturesApi
     /// <inheritdoc />
     internal class HyperLiquidRestClientFuturesApiTrading : HyperLiquidRestClientApiTrading, IHyperLiquidRestClientFuturesApiTrading
     {
-        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
-        {
-            Decimal = DecimalSerialization.String,
-            Sort = false
-        };
         private static readonly RequestDefinitionCache _definitions = new RequestDefinitionCache();
         private readonly HyperLiquidRestClientFuturesApi _baseClient;
         private readonly ILogger _logger;

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiTrading.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiTrading.cs
@@ -33,7 +33,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Set Leverage
 
         /// <inheritdoc />
-        public async Task<WebCallResult> SetLeverageAsync(
+        public async Task<HttpResult> SetLeverageAsync(
             string symbol,
             int leverage,
             MarginType marginType,
@@ -42,8 +42,8 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             CancellationToken ct = default)
         {
             var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
-            if (!symbolId)
-                return new WebCallResult(symbolId.Error!);
+            if (!symbolId.Success)
+                return HttpResult.Fail(_baseClient.Exchange, symbolId.Error!);
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
@@ -61,9 +61,8 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
             _baseClient.AddExpiresAfter(parameters, expiresAfter);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
-            var result = await _baseClient.SendAsync<HyperLiquidResponse>(request, parameters, ct).ConfigureAwait(false);
-            return result.AsDataless();
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
+            return await _baseClient.SendAsync<HyperLiquidResponse>(request, parameters, ct).ConfigureAwait(false);
         }
 
         #endregion
@@ -71,7 +70,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Update Isolated Margin
 
         /// <inheritdoc />
-        public async Task<WebCallResult> UpdateIsolatedMarginAsync(
+        public async Task<HttpResult> UpdateIsolatedMarginAsync(
             string symbol,
             decimal updateValue,
             string? vaultAddress = null,
@@ -79,8 +78,8 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             CancellationToken ct = default)
         {
             var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
-            if (!symbolId)
-                return new WebCallResult(symbolId.Error!);
+            if (!symbolId.Success)
+                return HttpResult.Fail(_baseClient.Exchange, symbolId.Error!);
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
@@ -98,9 +97,8 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
             _baseClient.AddExpiresAfter(parameters, expiresAfter);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
-            var result = await _baseClient.SendAsync<HyperLiquidResponse>(request, parameters, ct).ConfigureAwait(false);
-            return result.AsDataless();
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
+            return await _baseClient.SendAsync<HyperLiquidResponse>(request, parameters, ct).ConfigureAwait(false);
         }
 
         #endregion

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiTrading.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiTrading.cs
@@ -15,6 +15,11 @@ namespace HyperLiquid.Net.Clients.FuturesApi
     /// <inheritdoc />
     internal class HyperLiquidRestClientFuturesApiTrading : HyperLiquidRestClientApiTrading, IHyperLiquidRestClientFuturesApiTrading
     {
+        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
+        {
+            Decimal = DecimalSerialization.String,
+            Sort = false
+        };
         private static readonly RequestDefinitionCache _definitions = new RequestDefinitionCache();
         private readonly HyperLiquidRestClientFuturesApi _baseClient;
         private readonly ILogger _logger;
@@ -42,8 +47,8 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection();
-            var actionParameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "updateLeverage" },
                 { "asset", symbolId.Data }
@@ -79,8 +84,8 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection();
-            var actionParameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "updateIsolatedMargin" },
                 { "asset", symbolId.Data },

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApi.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApi.cs
@@ -24,13 +24,13 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         /// <summary>
         /// ctor
         /// </summary>
-        internal HyperLiquidSocketClientFuturesApi(ILogger logger, HyperLiquidSocketClient baseClient, HyperLiquidSocketOptions options) :
-            base(logger, baseClient, options, options.FuturesOptions)
+        internal HyperLiquidSocketClientFuturesApi(ILoggerFactory? loggerFactory, HyperLiquidSocketClient baseClient, HyperLiquidSocketOptions options) :
+            base(loggerFactory, baseClient, options, options.FuturesOptions)
         {
 
-            Account = new HyperLiquidSocketClientFuturesApiAccount(logger, this);
-            ExchangeData = new HyperLiquidSocketClientFuturesApiExchangeData(logger, this);
-            Trading = new HyperLiquidSocketClientFuturesApiTrading(logger, this);
+            Account = new HyperLiquidSocketClientFuturesApiAccount(_logger, this);
+            ExchangeData = new HyperLiquidSocketClientFuturesApiExchangeData(_logger, this);
+            Trading = new HyperLiquidSocketClientFuturesApiTrading(_logger, this);
         }
         #endregion
 

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApiAccount.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApiAccount.cs
@@ -21,6 +21,12 @@ namespace HyperLiquid.Net.Clients.FuturesApi
     /// </summary>
     internal partial class HyperLiquidSocketClientFuturesApiAccount : HyperLiquidSocketClientApiAccount, IHyperLiquidSocketClientFuturesApiAccount
     {
+        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
+        {
+            Decimal = DecimalSerialization.String,
+            Sort = false
+        };
+
         #region constructor/destructor
 
         /// <summary>
@@ -42,12 +48,12 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "clearinghouseState" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
             };
-            parameters.AddOptional("dex", dex);
+            parameters.Add("dex", dex);
             return await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidFuturesAccount>(_baseClient, "post", "info", parameters, false), ct).ConfigureAwait(false);
         }
@@ -64,13 +70,13 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "userFunding" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
             };
-            parameters.AddMilliseconds("startTime", startTime);
-            parameters.AddOptionalMilliseconds("endTime", endTime);
+            parameters.Add("startTime", startTime);
+            parameters.Add("endTime", endTime);
             return await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidUserLedger<HyperLiquidUserFunding>[]>(_baseClient, "post", "info", parameters, false), ct).ConfigureAwait(false);
         }
@@ -87,7 +93,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "activeAssetData" },
                 { "coin", symbol },
@@ -109,7 +115,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "userDexAbstraction" },
                 { "user", user ?? _baseClient.AuthenticationProvider!.Key }
@@ -130,8 +136,8 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection();
-            var actionParameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "userDexAbstraction" },
                 { "hyperliquidChain", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? "Testnet" : "Mainnet" },
@@ -140,7 +146,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             };
 
             actionParameters.Add("enabled", enabled);
-            actionParameters.AddMilliseconds("nonce", DateTime.UtcNow);
+            actionParameters.Add("nonce", DateTime.UtcNow);
             parameters.Add("action", actionParameters);
 
             var result = await _baseClient.QueryInternalAsync(

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApiAccount.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApiAccount.cs
@@ -21,12 +21,6 @@ namespace HyperLiquid.Net.Clients.FuturesApi
     /// </summary>
     internal partial class HyperLiquidSocketClientFuturesApiAccount : HyperLiquidSocketClientApiAccount, IHyperLiquidSocketClientFuturesApiAccount
     {
-        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
-        {
-            Decimal = DecimalSerialization.String,
-            Sort = false
-        };
-
         #region constructor/destructor
 
         /// <summary>
@@ -41,7 +35,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Get Futures Account
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidFuturesAccount>> GetAccountInfoAsync(string? address = null, string? dex = null, CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidFuturesAccount>> GetAccountInfoAsync(string? address = null, string? dex = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -63,7 +57,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Get Funding History
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidUserLedger<HyperLiquidUserFunding>[]>> GetFundingHistoryAsync(DateTime startTime, DateTime? endTime = null, string? address = null, CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidUserLedger<HyperLiquidUserFunding>[]>> GetFundingHistoryAsync(DateTime startTime, DateTime? endTime = null, string? address = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -86,7 +80,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Get User Symbol
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidFuturesUserSymbolUpdate>> GetUserSymbolAsync(string symbol, string? address = null, CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidFuturesUserSymbolUpdate>> GetUserSymbolAsync(string symbol, string? address = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -108,7 +102,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Get HIP-3 DEX Abstraction
 
         /// <inheritdoc />
-        public async Task<CallResult<bool>> GetHip3DexAbstractionAsync(string? user = null, CancellationToken ct = default)
+        public async Task<QueryResult<bool>> GetHip3DexAbstractionAsync(string? user = null, CancellationToken ct = default)
         {
             if (user == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(user), "User needs to be provided if API credentials not set");
@@ -129,7 +123,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Toggle HIP-3 DEX Abstraction
 
         /// <inheritdoc />
-        public async Task<CallResult> ToggleHip3DexAbstractionAsync(bool enabled, string? user = null, CancellationToken ct = default)
+        public async Task<QueryResult> ToggleHip3DexAbstractionAsync(bool enabled, string? user = null, CancellationToken ct = default)
         {
             if (user == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(user), "User needs to be provided if API credentials not set");
@@ -149,15 +143,14 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             actionParameters.Add("nonce", DateTime.UtcNow);
             parameters.Add("action", actionParameters);
 
-            var result = await _baseClient.QueryInternalAsync(
+            return await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<object>(_baseClient, "post", "action", parameters, true), ct).ConfigureAwait(false);
-            return result.AsDataless();
         }
 
         #endregion
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToUserSymbolUpdatesAsync(string? address, string symbol, Action<DataEvent<HyperLiquidFuturesUserSymbolUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToUserSymbolUpdatesAsync(string? address, string symbol, Action<DataEvent<HyperLiquidFuturesUserSymbolUpdate>> onMessage, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -183,14 +176,14 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToUserFundingUpdatesAsync(string? address, Action<DataEvent<HyperLiquidUserFunding[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToUserFundingUpdatesAsync(string? address, Action<DataEvent<HyperLiquidUserFunding[]>> onMessage, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
 
             var result = await HyperLiquidUtils.UpdateSpotSymbolInfoAsync(_baseClient.BaseClient).ConfigureAwait(false);
-            if (!result)
-                return new CallResult<UpdateSubscription>(result.Error!);
+            if (!result.Success)
+                return WebSocketResult.Fail<UpdateSubscription>(_baseClient.Exchange, result.Error!);
 
             var internalHandler = new Action<DateTime, string?, int, HyperLiquidSocketUpdate<HyperLiquidUserFundingUpdate>>((receiveTime, originalData, invocation, data) =>
             {

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApiExchangeData.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApiExchangeData.cs
@@ -20,6 +20,12 @@ namespace HyperLiquid.Net.Clients.FuturesApi
     /// </summary>
     internal partial class HyperLiquidSocketClientFuturesApiExchangeData : HyperLiquidSocketClientApiExchangeData, IHyperLiquidSocketClientFuturesApiExchangeData
     {
+        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
+        {
+            Decimal = DecimalSerialization.String,
+            Sort = false
+        };
+
         #region constructor/destructor
 
         /// <summary>
@@ -34,7 +40,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         /// <inheritdoc />
         public async Task<CallResult<HyperLiquidPerpDex[]>> GetPerpDexesAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "perpDexs" }
             };
@@ -46,7 +52,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
         public async Task<CallResult<HyperLiquidFuturesDexInfo[]>> GetExchangeInfoAllDexesAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "allPerpMetas" }
             };
@@ -98,11 +104,11 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         /// <inheritdoc />
         public async Task<CallResult<HyperLiquidFuturesSymbol[]>> GetExchangeInfoAsync(string? dex = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "meta" }
             };
-            parameters.AddOptional("dex", dex);
+            parameters.Add("dex", dex);
 
             var result = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidFuturesExchangeInfo>(_baseClient, "post", "info", parameters, false), ct).ConfigureAwait(false);
@@ -141,7 +147,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         /// <inheritdoc />
         public async Task<CallResult<HyperLiquidFuturesExchangeInfoAndTickers>> GetExchangeInfoAndTickersAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "metaAndAssetCtxs" }
             };
@@ -167,14 +173,14 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         /// <inheritdoc />
         public async Task<CallResult<HyperLiquidFundingRate[]>> GetFundingRateHistoryAsync(string symbol, DateTime startTime, DateTime? endTime = null, CancellationToken ct = default)
         {
-            var innerParameters = new ParameterCollection();
-            var parameters = new ParameterCollection()
+            var innerParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "fundingHistory" },
             };
             parameters.Add("coin", symbol);
-            parameters.AddMilliseconds("startTime", startTime);
-            parameters.AddOptionalMilliseconds("endTime", endTime);
+            parameters.Add("startTime", startTime);
+            parameters.Add("endTime", endTime);
 
             var result = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidFundingRate[]>(_baseClient, "post", "info", parameters, false), ct).ConfigureAwait(false);
@@ -191,11 +197,11 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         /// <inheritdoc />
         public async Task<CallResult<string[]>> GetSymbolsAtMaxOpenInterestAsync(string? dex = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "perpsAtOpenInterestCap" },
             };
-            parameters.AddOptional("dex", dex);
+            parameters.Add("dex", dex);
             return await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<string[]>(_baseClient, "post", "info", parameters, false), ct).ConfigureAwait(false);
         }
@@ -207,11 +213,11 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         /// <inheritdoc />
         public async Task<CallResult<HyperLiquidPerpDexLimit>> GetPerpDexMarketLimitsAsync(string? dex = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "perpDexLimits" },
             };
-            parameters.AddOptional("dex", dex);
+            parameters.Add("dex", dex);
 
             return await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidPerpDexLimit>(_baseClient, "post", "info", parameters, false), ct).ConfigureAwait(false);
@@ -224,11 +230,11 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         /// <inheritdoc />
         public async Task<CallResult<HyperLiquidPerpDexStatus>> GetPerpDexMarketStatusAsync(string? dex = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "perpDexStatus" },
             };
-            parameters.AddOptional("dex", dex);
+            parameters.Add("dex", dex);
             return await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidPerpDexStatus>(_baseClient, "post", "info", parameters, false), ct).ConfigureAwait(false);
         }

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApiExchangeData.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApiExchangeData.cs
@@ -20,12 +20,6 @@ namespace HyperLiquid.Net.Clients.FuturesApi
     /// </summary>
     internal partial class HyperLiquidSocketClientFuturesApiExchangeData : HyperLiquidSocketClientApiExchangeData, IHyperLiquidSocketClientFuturesApiExchangeData
     {
-        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
-        {
-            Decimal = DecimalSerialization.String,
-            Sort = false
-        };
-
         #region constructor/destructor
 
         /// <summary>
@@ -38,7 +32,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #endregion
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidPerpDex[]>> GetPerpDexesAsync(CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidPerpDex[]>> GetPerpDexesAsync(CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
@@ -50,7 +44,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         }
 
 
-        public async Task<CallResult<HyperLiquidFuturesDexInfo[]>> GetExchangeInfoAllDexesAsync(CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidFuturesDexInfo[]>> GetExchangeInfoAllDexesAsync(CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
@@ -59,6 +53,8 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
             var result = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidFuturesExchangeInfo[]>(_baseClient, "post", "info", parameters, false), ct).ConfigureAwait(false);
+            if(!result.Success)
+                return QueryResult.Fail<HyperLiquidFuturesDexInfo[]>(result);
 
             for (var j = 0; j < result.Data.Length; j++)
             {
@@ -87,7 +83,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             }
 
             int index = 0;
-            return result.As(result.Data.Select(x =>
+            return QueryResult.Ok(result, result.Data.Select(x =>
             {
                 var symbolName = x.Symbols.FirstOrDefault()?.Name;
                 return new HyperLiquidFuturesDexInfo
@@ -102,7 +98,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Get Futures Exchange Info
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidFuturesSymbol[]>> GetExchangeInfoAsync(string? dex = null, CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidFuturesSymbol[]>> GetExchangeInfoAsync(string? dex = null, CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
@@ -112,8 +108,8 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
             var result = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidFuturesExchangeInfo>(_baseClient, "post", "info", parameters, false), ct).ConfigureAwait(false);
-            if (!result)
-                return result.As<HyperLiquidFuturesSymbol[]>(default);
+            if (!result.Success)
+                return QueryResult.Fail<HyperLiquidFuturesSymbol[]>(result);
 
             for (var i = 0; i < result.Data.Symbols.Count(); i++)
             {
@@ -137,7 +133,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 }
             }
 
-            return result.As<HyperLiquidFuturesSymbol[]>(result.Data?.Symbols);
+            return QueryResult.Ok(result, result.Data.Symbols);
         }
 
         #endregion
@@ -145,7 +141,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Get Futures Exchange Info And Tickers
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidFuturesExchangeInfoAndTickers>> GetExchangeInfoAndTickersAsync(CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidFuturesExchangeInfoAndTickers>> GetExchangeInfoAndTickersAsync(CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
@@ -154,7 +150,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
             var result = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidFuturesExchangeInfoAndTickers>(_baseClient, "post", "info", parameters, false), ct).ConfigureAwait(false);
-            if (!result)
+            if (!result.Success)
                 return result;
 
             for (var i = 0; i < result.Data.ExchangeInfo.Symbols.Count(); i++)
@@ -171,7 +167,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Get Funding Rate History
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidFundingRate[]>> GetFundingRateHistoryAsync(string symbol, DateTime startTime, DateTime? endTime = null, CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidFundingRate[]>> GetFundingRateHistoryAsync(string symbol, DateTime startTime, DateTime? endTime = null, CancellationToken ct = default)
         {
             var innerParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
@@ -195,7 +191,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Get Futures Symbols At Max Open Interest
 
         /// <inheritdoc />
-        public async Task<CallResult<string[]>> GetSymbolsAtMaxOpenInterestAsync(string? dex = null, CancellationToken ct = default)
+        public async Task<QueryResult<string[]>> GetSymbolsAtMaxOpenInterestAsync(string? dex = null, CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
@@ -211,7 +207,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Get Perp DEX Market Limits
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidPerpDexLimit>> GetPerpDexMarketLimitsAsync(string? dex = null, CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidPerpDexLimit>> GetPerpDexMarketLimitsAsync(string? dex = null, CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
@@ -228,7 +224,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Get Perp Market Status
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidPerpDexStatus>> GetPerpDexMarketStatusAsync(string? dex = null, CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidPerpDexStatus>> GetPerpDexMarketStatusAsync(string? dex = null, CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
@@ -242,7 +238,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #endregion
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToSymbolUpdatesAsync(string symbol, Action<DataEvent<HyperLiquidFuturesTicker>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToSymbolUpdatesAsync(string symbol, Action<DataEvent<HyperLiquidFuturesTicker>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, int, HyperLiquidSocketUpdate<HyperLiquidFuturesTickerUpdate>>((receiveTime, originalData, invocation, data) =>
             {

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApiShared.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApiShared.cs
@@ -14,20 +14,20 @@ namespace HyperLiquid.Net.Clients.FuturesApi
     {
         private const string _exchangeName = "HyperLiquid";
         private const string _topicId = "HyperLiquidFutures";
-        public string Exchange => "HyperLiquid";
 
         public TradingMode[] SupportedTradingModes => new[] { TradingMode.PerpetualLinear };
 
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
 
         #region Ticker client
         SubscribeTickerOptions ITickerSocketClient.SubscribeTickerOptions { get; } = new SubscribeTickerOptions(_exchangeName);
         async Task<WebSocketResult<UpdateSubscription>> ITickerSocketClient.SubscribeToTickerUpdatesAsync(SubscribeTickerRequest request, Action<DataEvent<SharedSpotTicker>> handler, CancellationToken ct)
         {
-            var validationError = ((ITickerSocketClient)this).SubscribeTickerOptions.ValidateRequest(request, this);
+            var validationError = SharedClient.SubscribeTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.SubscribeToSymbolUpdatesAsync(symbol, update =>
@@ -36,18 +36,18 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 QuoteVolume = update.Data.NotionalVolume
             })), ct).ConfigureAwait(false);
 
-            return new WebSocketResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Trade client
 
-        EndpointOptions<SubscribeTradeRequest, ITradeSocketClient> ITradeSocketClient.SubscribeTradeOptions { get; } = new EndpointOptions<SubscribeTradeRequest, ITradeSocketClient>(_exchangeName, false);
+        SubscribeTradeOptions ITradeSocketClient.SubscribeTradeOptions { get; } = new SubscribeTradeOptions(_exchangeName, false);
         async Task<WebSocketResult<UpdateSubscription>> ITradeSocketClient.SubscribeToTradeUpdatesAsync(SubscribeTradeRequest request, Action<DataEvent<SharedTrade[]>> handler, CancellationToken ct)
         {
-            var validationError = ((ITradeSocketClient)this).SubscribeTradeOptions.ValidateRequest(request, this);
+            var validationError = SharedClient.SubscribeTradeOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.SubscribeToTradeUpdatesAsync(symbol, update =>
@@ -63,7 +63,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 ));
             }, ct).ConfigureAwait(false);
 
-            return new WebSocketResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
 
         #endregion
@@ -86,12 +86,9 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         async Task<WebSocketResult<UpdateSubscription>> IKlineSocketClient.SubscribeToKlineUpdatesAsync(SubscribeKlineRequest request, Action<DataEvent<SharedKline>> handler, CancellationToken ct)
         {
             var interval = (Enums.KlineInterval)request.Interval;
-            if (!Enum.IsDefined(typeof(Enums.KlineInterval), interval))
-                return new WebSocketResult<UpdateSubscription>(Exchange, ArgumentError.Invalid(nameof(GetKlinesRequest.Interval), "Interval not supported"));
-
-            var validationError = ((IKlineSocketClient)this).SubscribeKlineOptions.ValidateRequest(request, this);
+            var validationError = SharedClient.SubscribeKlineOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.SubscribeToKlineUpdatesAsync(symbol, interval,
@@ -103,7 +100,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                     handler(update.ToType(new SharedKline(request.Symbol, symbol, update.Data.OpenTime, update.Data.ClosePrice, update.Data.HighPrice, update.Data.LowPrice, update.Data.OpenPrice, update.Data.Volume)));
                 }, ct).ConfigureAwait(false);
 
-            return new WebSocketResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
@@ -111,25 +108,25 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         SubscribeOrderBookOptions IOrderBookSocketClient.SubscribeOrderBookOptions { get; } = new SubscribeOrderBookOptions(_exchangeName, false, new[] { 20 });
         async Task<WebSocketResult<UpdateSubscription>> IOrderBookSocketClient.SubscribeToOrderBookUpdatesAsync(SubscribeOrderBookRequest request, Action<DataEvent<SharedOrderBook>> handler, CancellationToken ct)
         {
-            var validationError = ((IOrderBookSocketClient)this).SubscribeOrderBookOptions.ValidateRequest(request, this);
+            var validationError = SharedClient.SubscribeOrderBookOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.SubscribeToOrderBookUpdatesAsync(symbol, update => handler(update.ToType(new SharedOrderBook(update.Data.Levels.Asks, update.Data.Levels.Bids))), ct: ct).ConfigureAwait(false);
 
-            return new WebSocketResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region User Trade client
 
-        EndpointOptions<SubscribeUserTradeRequest, IUserTradeSocketClient> IUserTradeSocketClient.SubscribeUserTradeOptions { get; } = new EndpointOptions<SubscribeUserTradeRequest, IUserTradeSocketClient>(_exchangeName, true);
+        SubscribeUserTradeOptions IUserTradeSocketClient.SubscribeUserTradeOptions { get; } = new SubscribeUserTradeOptions(_exchangeName, true);
         async Task<WebSocketResult<UpdateSubscription>> IUserTradeSocketClient.SubscribeToUserTradeUpdatesAsync(SubscribeUserTradeRequest request, Action<DataEvent<SharedUserTrade[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IUserTradeSocketClient)this).SubscribeUserTradeOptions.ValidateRequest(request, this);
+            var validationError = SharedClient.SubscribeUserTradeOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var result = await Trading.SubscribeToUserTradeUpdatesAsync(null,
                 update =>
@@ -160,18 +157,18 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 },
                 ct: ct).ConfigureAwait(false);
 
-            return new WebSocketResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Futures Order client
 
-        EndpointOptions<SubscribeFuturesOrderRequest, IFuturesOrderSocketClient> IFuturesOrderSocketClient.SubscribeFuturesOrderOptions { get; } = new EndpointOptions<SubscribeFuturesOrderRequest, IFuturesOrderSocketClient>(_exchangeName, true);
+        SubscribeFuturesOrderOptions IFuturesOrderSocketClient.SubscribeFuturesOrderOptions { get; } = new SubscribeFuturesOrderOptions(_exchangeName, true);
         async Task<WebSocketResult<UpdateSubscription>> IFuturesOrderSocketClient.SubscribeToFuturesOrderUpdatesAsync(SubscribeFuturesOrderRequest request, Action<DataEvent<SharedFuturesOrder[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderSocketClient)this).SubscribeFuturesOrderOptions.ValidateRequest(request, this);
+            var validationError = SharedClient.SubscribeFuturesOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var result = await Trading.SubscribeToOrderUpdatesAsync(null,
                 update =>
@@ -206,7 +203,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 },
                 ct: ct).ConfigureAwait(false);
 
-            return new WebSocketResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
 
         private SharedOrderStatus ParseOrderStatus(Enums.OrderStatus status)
@@ -247,12 +244,12 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #endregion
 
         #region Balance client
-        EndpointOptions<SubscribeBalancesRequest, IBalanceSocketClient> IBalanceSocketClient.SubscribeBalanceOptions { get; } = new EndpointOptions<SubscribeBalancesRequest, IBalanceSocketClient>(_exchangeName, false);
+        SubscribeBalanceOptions IBalanceSocketClient.SubscribeBalanceOptions { get; } = new SubscribeBalanceOptions(_exchangeName, false);
         async Task<WebSocketResult<UpdateSubscription>> IBalanceSocketClient.SubscribeToBalanceUpdatesAsync(SubscribeBalancesRequest request, Action<DataEvent<SharedBalance[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IBalanceSocketClient)this).SubscribeBalanceOptions.ValidateRequest(request, this);
+            var validationError = SharedClient.SubscribeBalanceOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var result = await Account.SubscribeToUserUpdatesAsync(
                 null,
@@ -264,18 +261,18 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                         )])),
                 ct: ct).ConfigureAwait(false);
 
-            return new WebSocketResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
 
         #endregion
 
         #region Position client
-        EndpointOptions<SubscribePositionRequest, IPositionSocketClient> IPositionSocketClient.SubscribePositionOptions { get; } = new EndpointOptions<SubscribePositionRequest, IPositionSocketClient>(_exchangeName, false);
+        SubscribePositionOptions IPositionSocketClient.SubscribePositionOptions { get; } = new SubscribePositionOptions(_exchangeName, false);
         async Task<WebSocketResult<UpdateSubscription>> IPositionSocketClient.SubscribeToPositionUpdatesAsync(SubscribePositionRequest request, Action<DataEvent<SharedPosition[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IPositionSocketClient)this).SubscribePositionOptions.ValidateRequest(request, this);
+            var validationError = SharedClient.SubscribePositionOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var result = await Account.SubscribeToUserUpdatesAsync(
                 null,
@@ -290,19 +287,19 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 }).ToArray())),
                 ct: ct).ConfigureAwait(false);
 
-            return new WebSocketResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
 
         #endregion
 
         #region Book Ticker client
 
-        EndpointOptions<SubscribeBookTickerRequest, IBookTickerSocketClient> IBookTickerSocketClient.SubscribeBookTickerOptions { get; } = new EndpointOptions<SubscribeBookTickerRequest, IBookTickerSocketClient>(_exchangeName, false);
+        SubscribeBookTickerOptions IBookTickerSocketClient.SubscribeBookTickerOptions { get; } = new SubscribeBookTickerOptions(_exchangeName, false);
         async Task<WebSocketResult<UpdateSubscription>> IBookTickerSocketClient.SubscribeToBookTickerUpdatesAsync(SubscribeBookTickerRequest request, Action<DataEvent<SharedBookTicker>> handler, CancellationToken ct)
         {
-            var validationError = ((IBookTickerSocketClient)this).SubscribeBookTickerOptions.ValidateRequest(request, this);
+            var validationError = SharedClient.SubscribeBookTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.SubscribeToBookTickerUpdatesAsync(symbol, update =>
@@ -315,7 +312,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                     update.Data.BestBid.Price,
                     update.Data.BestBid.Quantity))), ct).ConfigureAwait(false);
 
-            return new WebSocketResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
 
         #endregion

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApiShared.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApiShared.cs
@@ -19,7 +19,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
-        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(HyperLiquidExchange.Metadata, this);
 
         #region Ticker client
         SubscribeTickerOptions ITickerSocketClient.SubscribeTickerOptions { get; } = new SubscribeTickerOptions(_exchangeName);
@@ -31,7 +31,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.SubscribeToSymbolUpdatesAsync(symbol, update =>
-            handler(update.ToType(new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, update.Data.Symbol), update.Data.Symbol!, update.Data.MidPrice, null, null, update.Data.NotionalVolume, update.Data.MidPrice == null ? null : Math.Round((update.Data.MidPrice.Value / update.Data.PreviousDayPrice * 100 - 100) / 10, 3) * 10)
+            handler(update.ToType(new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, update.Data.Symbol), update.Data.Symbol!, update.Data.MidPrice, null, null, update.Data.NotionalVolume, update.Data.MidPrice == null ? null : Math.Round((update.Data.MidPrice.Value / update.Data.PreviousDayPrice * 100 - 100) / 10, 3) * 10)
             {
                 QuoteVolume = update.Data.NotionalVolume
             })), ct).ConfigureAwait(false);
@@ -140,7 +140,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
                     handler(update.ToType<SharedUserTrade[]>(futuresOrders.Select(x =>
                         new SharedUserTrade(
-                            ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol),
+                            ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Symbol),
                             x.Symbol!,
                             x.OrderId.ToString(),
                             x.TradeId.ToString(),
@@ -182,7 +182,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
                     handler(update.ToType<SharedFuturesOrder[]>(futuresOrders.Select(x =>
                         new SharedFuturesOrder(
-                            ExchangeSymbolCache.ParseSymbol(_topicId, x.Order.Symbol!),
+                            ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Order.Symbol!),
                             x.Order.Symbol!,
                             x.Order.OrderId.ToString(),
                             x.Order.OrderType == Enums.OrderType.Limit || x.Order.OrderType == Enums.OrderType.Limit ? SharedOrderType.Limit : x.Order.OrderType == Enums.OrderType.Market ? SharedOrderType.Market : SharedOrderType.Other,
@@ -276,7 +276,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
             var result = await Account.SubscribeToUserUpdatesAsync(
                 null,
-                update => handler(update.ToType<SharedPosition[]>(update.Data.FuturesInfo.Positions.Select(x => new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicId, x.Position.Symbol), x.Position.Symbol, Math.Abs(x.Position.PositionQuantity ?? 0), update.DataTime ?? update.ReceiveTime)
+                update => handler(update.ToType<SharedPosition[]>(update.Data.FuturesInfo.Positions.Select(x => new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Position.Symbol), x.Position.Symbol, Math.Abs(x.Position.PositionQuantity ?? 0), update.DataTime ?? update.ReceiveTime)
                 {
                     AverageOpenPrice = x.Position.AverageEntryPrice,
                     Leverage = x.Position.Leverage!.Value,
@@ -305,7 +305,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             var result = await ExchangeData.SubscribeToBookTickerUpdatesAsync(symbol, update =>
             handler(update.ToType(
                 new SharedBookTicker(
-                    ExchangeSymbolCache.ParseSymbol(_topicId, update.Data.Symbol),
+                    ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, update.Data.Symbol),
                     update.Data.Symbol,
                     update.Data.BestAsk.Price,
                     update.Data.BestAsk.Quantity,

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApiShared.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApiShared.cs
@@ -12,6 +12,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 {
     internal partial class HyperLiquidSocketClientFuturesApi : IHyperLiquidSocketClientFuturesApiShared
     {
+        private const string _exchangeName = "HyperLiquid";
         private const string _topicId = "HyperLiquidFutures";
         public string Exchange => "HyperLiquid";
 
@@ -21,10 +22,10 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
 
         #region Ticker client
-        SubscribeTickerOptions ITickerSocketClient.SubscribeTickerOptions { get; } = new SubscribeTickerOptions();
+        SubscribeTickerOptions ITickerSocketClient.SubscribeTickerOptions { get; } = new SubscribeTickerOptions(_exchangeName);
         async Task<ExchangeResult<UpdateSubscription>> ITickerSocketClient.SubscribeToTickerUpdatesAsync(SubscribeTickerRequest request, Action<DataEvent<SharedSpotTicker>> handler, CancellationToken ct)
         {
-            var validationError = ((ITickerSocketClient)this).SubscribeTickerOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = ((ITickerSocketClient)this).SubscribeTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
                 return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
 
@@ -41,10 +42,10 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
         #region Trade client
 
-        EndpointOptions<SubscribeTradeRequest> ITradeSocketClient.SubscribeTradeOptions { get; } = new EndpointOptions<SubscribeTradeRequest>(false);
+        EndpointOptions<SubscribeTradeRequest, ITradeSocketClient> ITradeSocketClient.SubscribeTradeOptions { get; } = new EndpointOptions<SubscribeTradeRequest, ITradeSocketClient>(_exchangeName, false);
         async Task<ExchangeResult<UpdateSubscription>> ITradeSocketClient.SubscribeToTradeUpdatesAsync(SubscribeTradeRequest request, Action<DataEvent<SharedTrade[]>> handler, CancellationToken ct)
         {
-            var validationError = ((ITradeSocketClient)this).SubscribeTradeOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = ((ITradeSocketClient)this).SubscribeTradeOptions.ValidateRequest(request, this);
             if (validationError != null)
                 return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
 
@@ -68,7 +69,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #endregion
 
         #region Kline client
-        SubscribeKlineOptions IKlineSocketClient.SubscribeKlineOptions { get; } = new SubscribeKlineOptions(false,
+        SubscribeKlineOptions IKlineSocketClient.SubscribeKlineOptions { get; } = new SubscribeKlineOptions(_exchangeName, false,
             SharedKlineInterval.OneMinute,
             SharedKlineInterval.ThreeMinutes,
             SharedKlineInterval.FiveMinutes,
@@ -88,7 +89,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             if (!Enum.IsDefined(typeof(Enums.KlineInterval), interval))
                 return new ExchangeResult<UpdateSubscription>(Exchange, ArgumentError.Invalid(nameof(GetKlinesRequest.Interval), "Interval not supported"));
 
-            var validationError = ((IKlineSocketClient)this).SubscribeKlineOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = ((IKlineSocketClient)this).SubscribeKlineOptions.ValidateRequest(request, this);
             if (validationError != null)
                 return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
 
@@ -107,10 +108,10 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #endregion
 
         #region Order Book client
-        SubscribeOrderBookOptions IOrderBookSocketClient.SubscribeOrderBookOptions { get; } = new SubscribeOrderBookOptions(false, new[] { 20 });
+        SubscribeOrderBookOptions IOrderBookSocketClient.SubscribeOrderBookOptions { get; } = new SubscribeOrderBookOptions(_exchangeName, false, new[] { 20 });
         async Task<ExchangeResult<UpdateSubscription>> IOrderBookSocketClient.SubscribeToOrderBookUpdatesAsync(SubscribeOrderBookRequest request, Action<DataEvent<SharedOrderBook>> handler, CancellationToken ct)
         {
-            var validationError = ((IOrderBookSocketClient)this).SubscribeOrderBookOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = ((IOrderBookSocketClient)this).SubscribeOrderBookOptions.ValidateRequest(request, this);
             if (validationError != null)
                 return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
 
@@ -123,10 +124,10 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
         #region User Trade client
 
-        EndpointOptions<SubscribeUserTradeRequest> IUserTradeSocketClient.SubscribeUserTradeOptions { get; } = new EndpointOptions<SubscribeUserTradeRequest>(true);
+        EndpointOptions<SubscribeUserTradeRequest, IUserTradeSocketClient> IUserTradeSocketClient.SubscribeUserTradeOptions { get; } = new EndpointOptions<SubscribeUserTradeRequest, IUserTradeSocketClient>(_exchangeName, true);
         async Task<ExchangeResult<UpdateSubscription>> IUserTradeSocketClient.SubscribeToUserTradeUpdatesAsync(SubscribeUserTradeRequest request, Action<DataEvent<SharedUserTrade[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IUserTradeSocketClient)this).SubscribeUserTradeOptions.ValidateRequest(Exchange, request, null, SupportedTradingModes);
+            var validationError = ((IUserTradeSocketClient)this).SubscribeUserTradeOptions.ValidateRequest(request, this);
             if (validationError != null)
                 return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
 
@@ -165,10 +166,10 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
         #region Futures Order client
 
-        EndpointOptions<SubscribeFuturesOrderRequest> IFuturesOrderSocketClient.SubscribeFuturesOrderOptions { get; } = new EndpointOptions<SubscribeFuturesOrderRequest>(true);
+        EndpointOptions<SubscribeFuturesOrderRequest, IFuturesOrderSocketClient> IFuturesOrderSocketClient.SubscribeFuturesOrderOptions { get; } = new EndpointOptions<SubscribeFuturesOrderRequest, IFuturesOrderSocketClient>(_exchangeName, true);
         async Task<ExchangeResult<UpdateSubscription>> IFuturesOrderSocketClient.SubscribeToFuturesOrderUpdatesAsync(SubscribeFuturesOrderRequest request, Action<DataEvent<SharedFuturesOrder[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderSocketClient)this).SubscribeFuturesOrderOptions.ValidateRequest(Exchange, request, TradingMode.PerpetualLinear, SupportedTradingModes);
+            var validationError = ((IFuturesOrderSocketClient)this).SubscribeFuturesOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
                 return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
 
@@ -246,10 +247,10 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #endregion
 
         #region Balance client
-        EndpointOptions<SubscribeBalancesRequest> IBalanceSocketClient.SubscribeBalanceOptions { get; } = new EndpointOptions<SubscribeBalancesRequest>(false);
+        EndpointOptions<SubscribeBalancesRequest, IBalanceSocketClient> IBalanceSocketClient.SubscribeBalanceOptions { get; } = new EndpointOptions<SubscribeBalancesRequest, IBalanceSocketClient>(_exchangeName, false);
         async Task<ExchangeResult<UpdateSubscription>> IBalanceSocketClient.SubscribeToBalanceUpdatesAsync(SubscribeBalancesRequest request, Action<DataEvent<SharedBalance[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IBalanceSocketClient)this).SubscribeBalanceOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = ((IBalanceSocketClient)this).SubscribeBalanceOptions.ValidateRequest(request, this);
             if (validationError != null)
                 return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
 
@@ -269,10 +270,10 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #endregion
 
         #region Position client
-        EndpointOptions<SubscribePositionRequest> IPositionSocketClient.SubscribePositionOptions { get; } = new EndpointOptions<SubscribePositionRequest>(false);
+        EndpointOptions<SubscribePositionRequest, IPositionSocketClient> IPositionSocketClient.SubscribePositionOptions { get; } = new EndpointOptions<SubscribePositionRequest, IPositionSocketClient>(_exchangeName, false);
         async Task<ExchangeResult<UpdateSubscription>> IPositionSocketClient.SubscribeToPositionUpdatesAsync(SubscribePositionRequest request, Action<DataEvent<SharedPosition[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IPositionSocketClient)this).SubscribePositionOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = ((IPositionSocketClient)this).SubscribePositionOptions.ValidateRequest(request, this);
             if (validationError != null)
                 return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
 
@@ -296,10 +297,10 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
         #region Book Ticker client
 
-        EndpointOptions<SubscribeBookTickerRequest> IBookTickerSocketClient.SubscribeBookTickerOptions { get; } = new EndpointOptions<SubscribeBookTickerRequest>(false);
+        EndpointOptions<SubscribeBookTickerRequest, IBookTickerSocketClient> IBookTickerSocketClient.SubscribeBookTickerOptions { get; } = new EndpointOptions<SubscribeBookTickerRequest, IBookTickerSocketClient>(_exchangeName, false);
         async Task<ExchangeResult<UpdateSubscription>> IBookTickerSocketClient.SubscribeToBookTickerUpdatesAsync(SubscribeBookTickerRequest request, Action<DataEvent<SharedBookTicker>> handler, CancellationToken ct)
         {
-            var validationError = ((IBookTickerSocketClient)this).SubscribeBookTickerOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = ((IBookTickerSocketClient)this).SubscribeBookTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
                 return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
 

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApiShared.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApiShared.cs
@@ -255,6 +255,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 null,
                 update => handler(update.ToType<SharedBalance[]>([
                     new SharedBalance(
+                        SupportedTradingModes,
                         "USDC",
                         update.Data.FuturesInfo.MarginSummary.AccountValue - update.Data.FuturesInfo.MarginSummary.TotalMarginUsed,
                         update.Data.FuturesInfo.MarginSummary.AccountValue

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApiShared.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApiShared.cs
@@ -23,11 +23,11 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
         #region Ticker client
         SubscribeTickerOptions ITickerSocketClient.SubscribeTickerOptions { get; } = new SubscribeTickerOptions(_exchangeName);
-        async Task<ExchangeResult<UpdateSubscription>> ITickerSocketClient.SubscribeToTickerUpdatesAsync(SubscribeTickerRequest request, Action<DataEvent<SharedSpotTicker>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> ITickerSocketClient.SubscribeToTickerUpdatesAsync(SubscribeTickerRequest request, Action<DataEvent<SharedSpotTicker>> handler, CancellationToken ct)
         {
             var validationError = ((ITickerSocketClient)this).SubscribeTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.SubscribeToSymbolUpdatesAsync(symbol, update =>
@@ -36,18 +36,18 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 QuoteVolume = update.Data.NotionalVolume
             })), ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return new WebSocketResult<UpdateSubscription>(Exchange, result);
         }
         #endregion
 
         #region Trade client
 
         EndpointOptions<SubscribeTradeRequest, ITradeSocketClient> ITradeSocketClient.SubscribeTradeOptions { get; } = new EndpointOptions<SubscribeTradeRequest, ITradeSocketClient>(_exchangeName, false);
-        async Task<ExchangeResult<UpdateSubscription>> ITradeSocketClient.SubscribeToTradeUpdatesAsync(SubscribeTradeRequest request, Action<DataEvent<SharedTrade[]>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> ITradeSocketClient.SubscribeToTradeUpdatesAsync(SubscribeTradeRequest request, Action<DataEvent<SharedTrade[]>> handler, CancellationToken ct)
         {
             var validationError = ((ITradeSocketClient)this).SubscribeTradeOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.SubscribeToTradeUpdatesAsync(symbol, update =>
@@ -63,7 +63,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 ));
             }, ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return new WebSocketResult<UpdateSubscription>(Exchange, result);
         }
 
         #endregion
@@ -83,15 +83,15 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             SharedKlineInterval.OneDay,
             SharedKlineInterval.OneWeek,
             SharedKlineInterval.OneMonth);
-        async Task<ExchangeResult<UpdateSubscription>> IKlineSocketClient.SubscribeToKlineUpdatesAsync(SubscribeKlineRequest request, Action<DataEvent<SharedKline>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> IKlineSocketClient.SubscribeToKlineUpdatesAsync(SubscribeKlineRequest request, Action<DataEvent<SharedKline>> handler, CancellationToken ct)
         {
             var interval = (Enums.KlineInterval)request.Interval;
             if (!Enum.IsDefined(typeof(Enums.KlineInterval), interval))
-                return new ExchangeResult<UpdateSubscription>(Exchange, ArgumentError.Invalid(nameof(GetKlinesRequest.Interval), "Interval not supported"));
+                return new WebSocketResult<UpdateSubscription>(Exchange, ArgumentError.Invalid(nameof(GetKlinesRequest.Interval), "Interval not supported"));
 
             var validationError = ((IKlineSocketClient)this).SubscribeKlineOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.SubscribeToKlineUpdatesAsync(symbol, interval,
@@ -103,33 +103,33 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                     handler(update.ToType(new SharedKline(request.Symbol, symbol, update.Data.OpenTime, update.Data.ClosePrice, update.Data.HighPrice, update.Data.LowPrice, update.Data.OpenPrice, update.Data.Volume)));
                 }, ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return new WebSocketResult<UpdateSubscription>(Exchange, result);
         }
         #endregion
 
         #region Order Book client
         SubscribeOrderBookOptions IOrderBookSocketClient.SubscribeOrderBookOptions { get; } = new SubscribeOrderBookOptions(_exchangeName, false, new[] { 20 });
-        async Task<ExchangeResult<UpdateSubscription>> IOrderBookSocketClient.SubscribeToOrderBookUpdatesAsync(SubscribeOrderBookRequest request, Action<DataEvent<SharedOrderBook>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> IOrderBookSocketClient.SubscribeToOrderBookUpdatesAsync(SubscribeOrderBookRequest request, Action<DataEvent<SharedOrderBook>> handler, CancellationToken ct)
         {
             var validationError = ((IOrderBookSocketClient)this).SubscribeOrderBookOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.SubscribeToOrderBookUpdatesAsync(symbol, update => handler(update.ToType(new SharedOrderBook(update.Data.Levels.Asks, update.Data.Levels.Bids))), ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return new WebSocketResult<UpdateSubscription>(Exchange, result);
         }
         #endregion
 
         #region User Trade client
 
         EndpointOptions<SubscribeUserTradeRequest, IUserTradeSocketClient> IUserTradeSocketClient.SubscribeUserTradeOptions { get; } = new EndpointOptions<SubscribeUserTradeRequest, IUserTradeSocketClient>(_exchangeName, true);
-        async Task<ExchangeResult<UpdateSubscription>> IUserTradeSocketClient.SubscribeToUserTradeUpdatesAsync(SubscribeUserTradeRequest request, Action<DataEvent<SharedUserTrade[]>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> IUserTradeSocketClient.SubscribeToUserTradeUpdatesAsync(SubscribeUserTradeRequest request, Action<DataEvent<SharedUserTrade[]>> handler, CancellationToken ct)
         {
             var validationError = ((IUserTradeSocketClient)this).SubscribeUserTradeOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
 
             var result = await Trading.SubscribeToUserTradeUpdatesAsync(null,
                 update =>
@@ -160,18 +160,18 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 },
                 ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return new WebSocketResult<UpdateSubscription>(Exchange, result);
         }
         #endregion
 
         #region Futures Order client
 
         EndpointOptions<SubscribeFuturesOrderRequest, IFuturesOrderSocketClient> IFuturesOrderSocketClient.SubscribeFuturesOrderOptions { get; } = new EndpointOptions<SubscribeFuturesOrderRequest, IFuturesOrderSocketClient>(_exchangeName, true);
-        async Task<ExchangeResult<UpdateSubscription>> IFuturesOrderSocketClient.SubscribeToFuturesOrderUpdatesAsync(SubscribeFuturesOrderRequest request, Action<DataEvent<SharedFuturesOrder[]>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> IFuturesOrderSocketClient.SubscribeToFuturesOrderUpdatesAsync(SubscribeFuturesOrderRequest request, Action<DataEvent<SharedFuturesOrder[]>> handler, CancellationToken ct)
         {
             var validationError = ((IFuturesOrderSocketClient)this).SubscribeFuturesOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
 
             var result = await Trading.SubscribeToOrderUpdatesAsync(null,
                 update =>
@@ -206,7 +206,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 },
                 ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return new WebSocketResult<UpdateSubscription>(Exchange, result);
         }
 
         private SharedOrderStatus ParseOrderStatus(Enums.OrderStatus status)
@@ -248,11 +248,11 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
         #region Balance client
         EndpointOptions<SubscribeBalancesRequest, IBalanceSocketClient> IBalanceSocketClient.SubscribeBalanceOptions { get; } = new EndpointOptions<SubscribeBalancesRequest, IBalanceSocketClient>(_exchangeName, false);
-        async Task<ExchangeResult<UpdateSubscription>> IBalanceSocketClient.SubscribeToBalanceUpdatesAsync(SubscribeBalancesRequest request, Action<DataEvent<SharedBalance[]>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> IBalanceSocketClient.SubscribeToBalanceUpdatesAsync(SubscribeBalancesRequest request, Action<DataEvent<SharedBalance[]>> handler, CancellationToken ct)
         {
             var validationError = ((IBalanceSocketClient)this).SubscribeBalanceOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
 
             var result = await Account.SubscribeToUserUpdatesAsync(
                 null,
@@ -264,18 +264,18 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                         )])),
                 ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return new WebSocketResult<UpdateSubscription>(Exchange, result);
         }
 
         #endregion
 
         #region Position client
         EndpointOptions<SubscribePositionRequest, IPositionSocketClient> IPositionSocketClient.SubscribePositionOptions { get; } = new EndpointOptions<SubscribePositionRequest, IPositionSocketClient>(_exchangeName, false);
-        async Task<ExchangeResult<UpdateSubscription>> IPositionSocketClient.SubscribeToPositionUpdatesAsync(SubscribePositionRequest request, Action<DataEvent<SharedPosition[]>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> IPositionSocketClient.SubscribeToPositionUpdatesAsync(SubscribePositionRequest request, Action<DataEvent<SharedPosition[]>> handler, CancellationToken ct)
         {
             var validationError = ((IPositionSocketClient)this).SubscribePositionOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
 
             var result = await Account.SubscribeToUserUpdatesAsync(
                 null,
@@ -290,7 +290,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 }).ToArray())),
                 ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return new WebSocketResult<UpdateSubscription>(Exchange, result);
         }
 
         #endregion
@@ -298,11 +298,11 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Book Ticker client
 
         EndpointOptions<SubscribeBookTickerRequest, IBookTickerSocketClient> IBookTickerSocketClient.SubscribeBookTickerOptions { get; } = new EndpointOptions<SubscribeBookTickerRequest, IBookTickerSocketClient>(_exchangeName, false);
-        async Task<ExchangeResult<UpdateSubscription>> IBookTickerSocketClient.SubscribeToBookTickerUpdatesAsync(SubscribeBookTickerRequest request, Action<DataEvent<SharedBookTicker>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> IBookTickerSocketClient.SubscribeToBookTickerUpdatesAsync(SubscribeBookTickerRequest request, Action<DataEvent<SharedBookTicker>> handler, CancellationToken ct)
         {
             var validationError = ((IBookTickerSocketClient)this).SubscribeBookTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.SubscribeToBookTickerUpdatesAsync(symbol, update =>
@@ -315,7 +315,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                     update.Data.BestBid.Price,
                     update.Data.BestBid.Quantity))), ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return new WebSocketResult<UpdateSubscription>(Exchange, result);
         }
 
         #endregion

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApiTrading.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApiTrading.cs
@@ -127,7 +127,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             });
 
             var addressSub = address ?? _baseClient.AuthenticationProvider!.Key;
-            var subscription = new HyperLiquidSubscription<HyperLiquidPositionUpdate>(_logger, _baseClient, "clearinghouseState", null, new Dictionary<string, object>
+            var subscription = new HyperLiquidSubscription<HyperLiquidPositionUpdate>(_logger, _baseClient, "clearinghouseState", addressSub.ToLowerInvariant(), new Dictionary<string, object>
             {
                 { "user", addressSub.ToLowerInvariant() },
                 { "dex", dex ?? "" },
@@ -154,7 +154,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             });
 
             var addressSub = address ?? _baseClient.AuthenticationProvider!.Key;
-            var subscription = new HyperLiquidSubscription<HyperLiquidAllDexPositionUpdate>(_logger, _baseClient, "allDexsClearinghouseState", null, new Dictionary<string, object>
+            var subscription = new HyperLiquidSubscription<HyperLiquidAllDexPositionUpdate>(_logger, _baseClient, "allDexsClearinghouseState", addressSub.ToLowerInvariant(), new Dictionary<string, object>
             {
                 { "user", addressSub.ToLowerInvariant() }
             },

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApiTrading.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApiTrading.cs
@@ -22,6 +22,12 @@ namespace HyperLiquid.Net.Clients.FuturesApi
     /// </summary>
     internal partial class HyperLiquidSocketClientFuturesApiTrading : HyperLiquidSocketClientApiTrading, IHyperLiquidSocketClientFuturesApiTrading
     {
+        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
+        {
+            Decimal = DecimalSerialization.String,
+            Sort = false
+        };
+
         #region constructor/destructor
 
         /// <summary>
@@ -51,8 +57,8 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection();
-            var actionParameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "updateLeverage" },
                 { "asset", symbolId.Data }
@@ -88,8 +94,8 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection();
-            var actionParameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "updateIsolatedMargin" },
                 { "asset", symbolId.Data },

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApiTrading.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApiTrading.cs
@@ -22,12 +22,6 @@ namespace HyperLiquid.Net.Clients.FuturesApi
     /// </summary>
     internal partial class HyperLiquidSocketClientFuturesApiTrading : HyperLiquidSocketClientApiTrading, IHyperLiquidSocketClientFuturesApiTrading
     {
-        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
-        {
-            Decimal = DecimalSerialization.String,
-            Sort = false
-        };
-
         #region constructor/destructor
 
         /// <summary>
@@ -39,11 +33,10 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         }
         #endregion
 
-
         #region Set Leverage
 
         /// <inheritdoc />
-        public async Task<CallResult> SetLeverageAsync(
+        public async Task<QueryResult> SetLeverageAsync(
             string symbol,
             int leverage,
             MarginType marginType,
@@ -52,8 +45,8 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             CancellationToken ct = default)
         {
             var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
-            if (!symbolId)
-                return new HttpResult(symbolId.Error!);
+            if (!symbolId.Success)
+                return QueryResult.Fail(_baseClient.Exchange, symbolId.Error!);
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
@@ -71,9 +64,8 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
             _baseClient.AddExpiresAfter(parameters, expiresAfter);
 
-            var result = await _baseClient.QueryInternalAsync(
+            return await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<object>(_baseClient, "post", "action", parameters, true), ct).ConfigureAwait(false);
-            return result.AsDataless();
         }
 
         #endregion
@@ -81,7 +73,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #region Update Isolated Margin
 
         /// <inheritdoc />
-        public async Task<CallResult> UpdateIsolatedMarginAsync(
+        public async Task<QueryResult> UpdateIsolatedMarginAsync(
             string symbol,
             decimal updateValue,
             string? vaultAddress = null,
@@ -89,8 +81,8 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             CancellationToken ct = default)
         {
             var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
-            if (!symbolId)
-                return new HttpResult(symbolId.Error!);
+            if (!symbolId.Success)
+                return QueryResult.Fail(_baseClient.Exchange, symbolId.Error!);
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
@@ -108,15 +100,14 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
             _baseClient.AddExpiresAfter(parameters, expiresAfter);
 
-            var result = await _baseClient.QueryInternalAsync(
+            return await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<object>(_baseClient, "post", "action", parameters, true), ct).ConfigureAwait(false);
-            return result.AsDataless();
         }
 
         #endregion
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToBalanceAndPositionUpdatesAsync(string? address, string? dex, Action<DataEvent<HyperLiquidPositionUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToBalanceAndPositionUpdatesAsync(string? address, string? dex, Action<DataEvent<HyperLiquidPositionUpdate>> onMessage, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -146,7 +137,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToBalanceAndPositionUpdatesAllDexesAsync(string? address, Action<DataEvent<HyperLiquidAllDexPositionUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToBalanceAndPositionUpdatesAllDexesAsync(string? address, Action<DataEvent<HyperLiquidAllDexPositionUpdate>> onMessage, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApiTrading.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidSocketClientFuturesApiTrading.cs
@@ -53,7 +53,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         {
             var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
             if (!symbolId)
-                return new WebCallResult(symbolId.Error!);
+                return new HttpResult(symbolId.Error!);
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
@@ -90,7 +90,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         {
             var symbolId = await HyperLiquidUtils.GetSymbolIdFromNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
             if (!symbolId)
-                return new WebCallResult(symbolId.Error!);
+                return new HttpResult(symbolId.Error!);
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 

--- a/HyperLiquid.Net/Clients/HyperLiquidRestClient.cs
+++ b/HyperLiquid.Net/Clients/HyperLiquidRestClient.cs
@@ -49,8 +49,8 @@ namespace HyperLiquid.Net.Clients
         {
             Initialize(options.Value);
                         
-            SpotApi = AddApiClient(new HyperLiquidRestClientSpotApi(_logger, this, httpClient, options.Value));
-            FuturesApi = AddApiClient(new HyperLiquidRestClientFuturesApi(_logger, this, httpClient, options.Value));
+            SpotApi = AddApiClient(new HyperLiquidRestClientSpotApi(loggerFactory, this, httpClient, options.Value));
+            FuturesApi = AddApiClient(new HyperLiquidRestClientFuturesApi(loggerFactory, this, httpClient, options.Value));
         }
 
         #endregion

--- a/HyperLiquid.Net/Clients/HyperLiquidSocketClient.cs
+++ b/HyperLiquid.Net/Clients/HyperLiquidSocketClient.cs
@@ -48,8 +48,8 @@ namespace HyperLiquid.Net.Clients
         {
             Initialize(options.Value);
 
-            SpotApi = AddApiClient(new HyperLiquidSocketClientSpotApi(_logger, this, options.Value));
-            FuturesApi = AddApiClient(new HyperLiquidSocketClientFuturesApi(_logger, this, options.Value));
+            SpotApi = AddApiClient(new HyperLiquidSocketClientSpotApi(loggerFactory, this, options.Value));
+            FuturesApi = AddApiClient(new HyperLiquidSocketClientFuturesApi(loggerFactory, this, options.Value));
         }
         #endregion
 

--- a/HyperLiquid.Net/Clients/HyperLiquidUserClientProvider.cs
+++ b/HyperLiquid.Net/Clients/HyperLiquidUserClientProvider.cs
@@ -1,4 +1,5 @@
 ﻿using CryptoExchange.Net.Authentication;
+using CryptoExchange.Net.Clients;
 using HyperLiquid.Net.Interfaces.Clients;
 using HyperLiquid.Net.Objects.Options;
 using Microsoft.Extensions.Logging;
@@ -10,18 +11,17 @@ using System.Net.Http;
 namespace HyperLiquid.Net.Clients
 {
     /// <inheritdoc />
-    public class HyperLiquidUserClientProvider : IHyperLiquidUserClientProvider
+    public class HyperLiquidUserClientProvider : UserClientProvider<
+        IHyperLiquidRestClient,
+        IHyperLiquidSocketClient,
+        HyperLiquidRestOptions,
+        HyperLiquidSocketOptions,
+        HyperLiquidCredentials,
+        HyperLiquidEnvironment
+        >, IHyperLiquidUserClientProvider
     {
-        private ConcurrentDictionary<string, IHyperLiquidRestClient> _restClients = new ConcurrentDictionary<string, IHyperLiquidRestClient>();
-        private ConcurrentDictionary<string, IHyperLiquidSocketClient> _socketClients = new ConcurrentDictionary<string, IHyperLiquidSocketClient>();
-
-        private readonly IOptions<HyperLiquidRestOptions> _restOptions;
-        private readonly IOptions<HyperLiquidSocketOptions> _socketOptions;
-        private readonly HttpClient _httpClient;
-        private readonly ILoggerFactory? _loggerFactory;
-
         /// <inheritdoc />
-        public string ExchangeName => HyperLiquidExchange.ExchangeName;
+        public override string ExchangeName => HyperLiquidExchange.ExchangeName;
 
         /// <summary>
         /// ctor
@@ -40,97 +40,15 @@ namespace HyperLiquid.Net.Clients
             ILoggerFactory? loggerFactory,
             IOptions<HyperLiquidRestOptions> restOptions,
             IOptions<HyperLiquidSocketOptions> socketOptions)
+            : base(httpClient, loggerFactory, restOptions, socketOptions)
         {
-            _httpClient = httpClient ?? new HttpClient();
-            _httpClient.Timeout = restOptions.Value.RequestTimeout;
-            _loggerFactory = loggerFactory;
-            _restOptions = restOptions;
-            _socketOptions = socketOptions;
         }
 
         /// <inheritdoc />
-        public void InitializeUserClient(string userIdentifier, HyperLiquidCredentials credentials, HyperLiquidEnvironment? environment = null)
-        {
-            CreateRestClient(userIdentifier, credentials, environment);
-            CreateSocketClient(userIdentifier, credentials, environment);
-        }
-
+        protected override IHyperLiquidRestClient ConstructRestClient(HttpClient client, ILoggerFactory? loggerFactory, IOptions<HyperLiquidRestOptions> options) 
+            => new HyperLiquidRestClient(client, loggerFactory, options);
         /// <inheritdoc />
-        public void ClearUserClients(string userIdentifier)
-        {
-            _restClients.TryRemove(userIdentifier, out _);
-            _socketClients.TryRemove(userIdentifier, out _);
-        }
-
-        /// <inheritdoc />
-        public IHyperLiquidRestClient GetRestClient(string userIdentifier, HyperLiquidCredentials? credentials = null, HyperLiquidEnvironment? environment = null)
-        {
-            if (!_restClients.TryGetValue(userIdentifier, out var client) || client.Disposed)
-                client = CreateRestClient(userIdentifier, credentials, environment);
-
-            return client;
-        }
-
-        /// <inheritdoc />
-        public IHyperLiquidSocketClient GetSocketClient(string userIdentifier, HyperLiquidCredentials? credentials = null, HyperLiquidEnvironment? environment = null)
-        {
-            if (!_socketClients.TryGetValue(userIdentifier, out var client) || client.Disposed)
-                client = CreateSocketClient(userIdentifier, credentials, environment);
-
-            return client;
-        }
-
-        private IHyperLiquidRestClient CreateRestClient(string userIdentifier, HyperLiquidCredentials? credentials, HyperLiquidEnvironment? environment)
-        {
-            var clientRestOptions = SetRestEnvironment(environment);
-            var client = new HyperLiquidRestClient(_httpClient, _loggerFactory, clientRestOptions);
-            if (credentials != null)
-            {
-                client.SetApiCredentials(credentials);
-                _restClients[userIdentifier] = client;
-            }
-            return client;
-        }
-
-        private IHyperLiquidSocketClient CreateSocketClient(string userIdentifier, HyperLiquidCredentials? credentials, HyperLiquidEnvironment? environment)
-        {
-            var clientSocketOptions = SetSocketEnvironment(environment);
-            var client = new HyperLiquidSocketClient(clientSocketOptions!, _loggerFactory);
-            if (credentials != null)
-            {
-                client.SetApiCredentials(credentials);
-                _socketClients[userIdentifier] = client;
-            }
-            return client;
-        }
-
-        private IOptions<HyperLiquidRestOptions> SetRestEnvironment(HyperLiquidEnvironment? environment)
-        {
-            if (environment == null)
-                return _restOptions;
-
-            var newRestClientOptions = new HyperLiquidRestOptions();
-            var restOptions = _restOptions.Value.Set(newRestClientOptions);
-            newRestClientOptions.Environment = environment;
-            return Options.Create(newRestClientOptions);
-        }
-
-        private IOptions<HyperLiquidSocketOptions> SetSocketEnvironment(HyperLiquidEnvironment? environment)
-        {
-            if (environment == null)
-                return _socketOptions;
-
-            var newSocketClientOptions = new HyperLiquidSocketOptions();
-            var restOptions = _socketOptions.Value.Set(newSocketClientOptions);
-            newSocketClientOptions.Environment = environment;
-            return Options.Create(newSocketClientOptions);
-        }
-
-        private static T ApplyOptionsDelegate<T>(Action<T>? del) where T : new()
-        {
-            var opts = new T();
-            del?.Invoke(opts);
-            return opts;
-        }
+        protected override IHyperLiquidSocketClient ConstructSocketClient(ILoggerFactory? loggerFactory, IOptions<HyperLiquidSocketOptions> options)
+            => new HyperLiquidSocketClient(options, loggerFactory);
     }
 }

--- a/HyperLiquid.Net/Clients/MessageHandlers/HyperLiquidSocketMessageHandler.cs
+++ b/HyperLiquid.Net/Clients/MessageHandlers/HyperLiquidSocketMessageHandler.cs
@@ -71,6 +71,14 @@ namespace HyperLiquid.Net.Clients.MessageHandlers
             AddTopicMapping<HyperLiquidSocketUpdate<HyperLiquidFuturesUserSymbolUpdate>>(x => x.Data.Symbol);
             AddTopicMapping<HyperLiquidSocketUpdate<HyperLiquidTickerUpdate>>(x => x.Data.Symbol);
             AddTopicMapping<HyperLiquidSocketUpdate<HyperLiquidBookTicker>>(x => x.Data.Symbol);
+
+            AddTopicMapping<HyperLiquidSocketUpdate<HyperLiquidTwapOrderUpdate>>(x => x.Data.User.ToLowerInvariant());
+            AddTopicMapping<HyperLiquidSocketUpdate<HyperLiquidTwapTradeUpdate>>(x => x.Data.User.ToLowerInvariant());
+            AddTopicMapping<HyperLiquidSocketUpdate<HyperLiquidUserTradeUpdate>>(x => x.Data.User.ToLowerInvariant());
+            AddTopicMapping<HyperLiquidSocketUpdate<HyperLiquidOpenOrderUpdate>>(x => x.Data.User.ToLowerInvariant());
+            AddTopicMapping<HyperLiquidSocketUpdate<HyperLiquidAllDexPositionUpdate>>(x => x.Data.User.ToLowerInvariant());
+            AddTopicMapping<HyperLiquidSocketUpdate<HyperLiquidPositionUpdate>>(x => x.Data.User.ToLowerInvariant());
+
         }
 
         protected override MessageTypeDefinition[] TypeEvaluators { get; } = [

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApi.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApi.cs
@@ -37,7 +37,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #endregion
 
         /// <inheritdoc />
-        protected override Task<WebCallResult<DateTime>> GetServerTimestampAsync() => throw new NotImplementedException();
+        protected override Task<HttpResult<DateTime>> GetServerTimestampAsync() => throw new NotImplementedException();
 
         /// <inheritdoc />
         public IHyperLiquidRestClientSpotApiShared SharedClient => this;

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApi.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApi.cs
@@ -27,12 +27,12 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #endregion
 
         #region constructor/destructor
-        internal HyperLiquidRestClientSpotApi(ILogger logger, HyperLiquidRestClient baseClient, HttpClient? httpClient, HyperLiquidRestOptions options)
-            : base(logger, baseClient, httpClient, options, options.SpotOptions)
+        internal HyperLiquidRestClientSpotApi(ILoggerFactory? loggerFactory, HyperLiquidRestClient baseClient, HttpClient? httpClient, HyperLiquidRestOptions options)
+            : base(loggerFactory, baseClient, httpClient, options, options.SpotOptions)
         {
             Account = new HyperLiquidRestClientSpotApiAccount(this);
-            ExchangeData = new HyperLiquidRestClientSpotApiExchangeData(logger, this);
-            Trading = new HyperLiquidRestClientSpotApiTrading(logger, this);
+            ExchangeData = new HyperLiquidRestClientSpotApiExchangeData(_logger, this);
+            Trading = new HyperLiquidRestClientSpotApiTrading(_logger, this);
         }
         #endregion
 

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiAccount.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiAccount.cs
@@ -29,7 +29,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #region Get Spot Balances
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidBalance[]>> GetBalancesAsync(string? address = null, CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidBalance[]>> GetBalancesAsync(string? address = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -41,7 +41,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
                 { "type", "spotClearinghouseState" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
             var result = await _baseClient.SendAsync<HyperLiquidBalances>(request, parameters, ct).ConfigureAwait(false);
             return result.As<HyperLiquidBalance[]>(result.Data?.Balances);
         }
@@ -51,15 +51,15 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #region Spot Transfer
 
         /// <inheritdoc />
-        public async Task<WebCallResult> TransferSpotAsync(
+        public async Task<HttpResult> TransferSpotAsync(
             string destinationAddress,
             string asset,
             decimal quantity,
             CancellationToken ct = default)
         {
             var assetId = await HyperLiquidUtils.GetAssetNameAndIdAsync(_baseClient.BaseClient, asset).ConfigureAwait(false);
-            if (!assetId)
-                return new WebCallResult(assetId.Error!);
+            if (!assetId.Success)
+                return HttpResult.Fail(_baseClient.Exchange, assetId.Error!);
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
@@ -76,9 +76,8 @@ namespace HyperLiquid.Net.Clients.SpotApi
             actionParameters.Add("time", DateTime.UtcNow);
             parameters.Add("action", actionParameters);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
-            var result = await _baseClient.SendAuthAsync<HyperLiquidDefault>(request, parameters, ct).ConfigureAwait(false);
-            return result.AsDataless();
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
+            return await _baseClient.SendAuthAsync<HyperLiquidDefault>(request, parameters, ct).ConfigureAwait(false);
         }
 
         #endregion

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiAccount.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiAccount.cs
@@ -13,11 +13,6 @@ namespace HyperLiquid.Net.Clients.SpotApi
     /// <inheritdoc />
     internal class HyperLiquidRestClientSpotApiAccount : HyperLiquidRestClientApiAccount, IHyperLiquidRestClientSpotApiAccount
     {
-        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
-        {
-            Decimal = DecimalSerialization.String,
-            Sort = false
-        };
         private static readonly RequestDefinitionCache _definitions = new RequestDefinitionCache();
         private readonly new HyperLiquidRestClientSpotApi _baseClient;
 
@@ -43,7 +38,10 @@ namespace HyperLiquid.Net.Clients.SpotApi
             };
             var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 2, false);
             var result = await _baseClient.SendAsync<HyperLiquidBalances>(request, parameters, ct).ConfigureAwait(false);
-            return result.As<HyperLiquidBalance[]>(result.Data?.Balances);
+            if (!result.Success)
+                return HttpResult.Fail<HyperLiquidBalance[]>(result);
+
+            return HttpResult.Ok(result, result.Data.Balances);
         }
 
         #endregion

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiAccount.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiAccount.cs
@@ -13,6 +13,11 @@ namespace HyperLiquid.Net.Clients.SpotApi
     /// <inheritdoc />
     internal class HyperLiquidRestClientSpotApiAccount : HyperLiquidRestClientApiAccount, IHyperLiquidRestClientSpotApiAccount
     {
+        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
+        {
+            Decimal = DecimalSerialization.String,
+            Sort = false
+        };
         private static readonly RequestDefinitionCache _definitions = new RequestDefinitionCache();
         private readonly new HyperLiquidRestClientSpotApi _baseClient;
 
@@ -31,7 +36,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "spotClearinghouseState" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
@@ -58,8 +63,8 @@ namespace HyperLiquid.Net.Clients.SpotApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection();
-            var actionParameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "spotSend" },
                 { "hyperliquidChain", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? "Testnet" : "Mainnet" },
@@ -67,8 +72,8 @@ namespace HyperLiquid.Net.Clients.SpotApi
                 { "destination", destinationAddress },
                 { "token", assetId.Data }
             };
-            actionParameters.AddString("amount", quantity);
-            actionParameters.AddMilliseconds("time", DateTime.UtcNow);
+            actionParameters.Add("amount", quantity);
+            actionParameters.Add("time", DateTime.UtcNow);
             parameters.Add("action", actionParameters);
 
             var request = _definitions.GetOrCreate(HttpMethod.Post, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiExchangeData.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiExchangeData.cs
@@ -13,6 +13,11 @@ namespace HyperLiquid.Net.Clients.SpotApi
     /// <inheritdoc />
     internal class HyperLiquidRestClientSpotApiExchangeData : HyperLiquidRestClientApiExchangeData, IHyperLiquidRestClientSpotApiExchangeData
     {
+        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
+        {
+            Decimal = DecimalSerialization.String,
+            Sort = false
+        };
         private readonly HyperLiquidRestClientSpotApi _baseClient;
         private static readonly RequestDefinitionCache _definitions = new RequestDefinitionCache();
 
@@ -26,7 +31,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         /// <inheritdoc />
         public async Task<WebCallResult<HyperLiquidSpotExchangeInfo>> GetExchangeInfoAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "spotMeta" }
             };
@@ -41,7 +46,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         /// <inheritdoc />
         public async Task<WebCallResult<HyperLiquidExchangeInfoAndTickers>> GetExchangeInfoAndTickersAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "spotMetaAndAssetCtxs" }
             };
@@ -67,7 +72,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         /// <inheritdoc />
         public async Task<WebCallResult<HyperLiquidAssetInfo>> GetAssetInfoAsync(string assetId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "tokenDetails" },
                 { "tokenId", assetId }
@@ -83,7 +88,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         /// <inheritdoc />
         public async Task<WebCallResult<HyperLiquidQuestionsAndOutcomesInfo>> GetQuestionsAndOutcomesInfoAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "outcomeMeta" }
             };
@@ -99,7 +104,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         /// <inheritdoc />
         public async Task<WebCallResult<HyperLiquidSettledOutcome>> GetSettledOutcomeAsync(long outcomeId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "settledOutcome" },
                 { "outcome", outcomeId }

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiExchangeData.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiExchangeData.cs
@@ -29,13 +29,13 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #region Get Spot Exchange Info
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidSpotExchangeInfo>> GetExchangeInfoAsync(CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidSpotExchangeInfo>> GetExchangeInfoAsync(CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "spotMeta" }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             return await _baseClient.SendAsync<HyperLiquidSpotExchangeInfo>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -44,21 +44,21 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #region Get Spot Exchange Info And Tickers
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidExchangeInfoAndTickers>> GetExchangeInfoAndTickersAsync(CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidExchangeInfoAndTickers>> GetExchangeInfoAndTickersAsync(CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "spotMetaAndAssetCtxs" }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             var result = await _baseClient.SendAsync<HyperLiquidExchangeInfoAndTickers>(request, parameters, ct).ConfigureAwait(false);
-            if (!result)
+            if (!result.Success)
                 return result;
 
             foreach (var ticker in result.Data.Tickers)
             {
                 var nameResult = await HyperLiquidUtils.GetSymbolNameFromExchangeNameAsync(_baseClient.BaseClient, ticker.Symbol!).ConfigureAwait(false);
-                if (nameResult)
+                if (nameResult.Success)
                     ticker.Symbol = nameResult.Data;
             }
 
@@ -70,14 +70,14 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #region Get Asset Info
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidAssetInfo>> GetAssetInfoAsync(string assetId, CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidAssetInfo>> GetAssetInfoAsync(string assetId, CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "tokenDetails" },
                 { "tokenId", assetId }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             return await _baseClient.SendAsync<HyperLiquidAssetInfo>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -86,13 +86,13 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #region Get Outcomes Info
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidQuestionsAndOutcomesInfo>> GetQuestionsAndOutcomesInfoAsync(CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidQuestionsAndOutcomesInfo>> GetQuestionsAndOutcomesInfoAsync(CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "outcomeMeta" }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             var result = await _baseClient.SendAsync<HyperLiquidQuestionsAndOutcomesInfo>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
@@ -102,14 +102,14 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #region Get Settled Outcome
 
         /// <inheritdoc />
-        public async Task<WebCallResult<HyperLiquidSettledOutcome>> GetSettledOutcomeAsync(long outcomeId, CancellationToken ct = default)
+        public async Task<HttpResult<HyperLiquidSettledOutcome>> GetSettledOutcomeAsync(long outcomeId, CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "settledOutcome" },
                 { "outcome", outcomeId }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
             var result = await _baseClient.SendAsync<HyperLiquidSettledOutcome>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiExchangeData.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiExchangeData.cs
@@ -13,11 +13,6 @@ namespace HyperLiquid.Net.Clients.SpotApi
     /// <inheritdoc />
     internal class HyperLiquidRestClientSpotApiExchangeData : HyperLiquidRestClientApiExchangeData, IHyperLiquidRestClientSpotApiExchangeData
     {
-        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
-        {
-            Decimal = DecimalSerialization.String,
-            Sort = false
-        };
         private readonly HyperLiquidRestClientSpotApi _baseClient;
         private static readonly RequestDefinitionCache _definitions = new RequestDefinitionCache();
 

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiShared.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiShared.cs
@@ -14,6 +14,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
 {
     internal partial class HyperLiquidRestClientSpotApi : IHyperLiquidRestClientSpotApiShared
     {
+        private const string _exchangeName = "HyperLiquid";
         private const string _topicId = "HyperLiquidSpot";
         public string Exchange => "HyperLiquid";
 
@@ -22,27 +23,32 @@ namespace HyperLiquid.Net.Clients.SpotApi
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
 
+
         #region Balance Client
-        GetBalancesOptions IBalanceRestClient.GetBalancesOptions { get; } = new GetBalancesOptions(AccountTypeFilter.Spot);
+        GetBalancesOptions IBalanceRestClient.GetBalancesOptions { get; } = new GetBalancesOptions(_exchangeName, AccountTypeFilter.Spot);
 
-        async Task<ExchangeWebResult<SharedBalance[]>> IBalanceRestClient.GetBalancesAsync(GetBalancesRequest request, CancellationToken ct)
+        Task<ExchangeWebResult<SharedBalance[]>> IBalanceRestClient.GetBalancesAsync(GetBalancesRequest request, CancellationToken ct)
         {
-            var validationError = ((IBalanceRestClient)this).GetBalancesOptions.ValidateRequest(Exchange, request, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedBalance[]>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<IBalanceRestClient, GetBalancesRequest, SharedBalance[]>(
+                this,
+                client => client.GetBalancesOptions,
+                request,
+                async () =>
+                {
 
-            var result = await Account.GetBalancesAsync(ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedBalance[]>(Exchange, null, default);
+                    var result = await Account.GetBalancesAsync(ct: ct).ConfigureAwait(false);
+                    if (!result)
+                        return SharedExecutionResult<SharedBalance[]>.Error(result);
 
-            return result.AsExchangeResult<SharedBalance[]>(Exchange, TradingMode.Spot, result.Data.Select(x => new SharedBalance(HyperLiquidExchange.AssetAliases.ExchangeToCommonName(x.Asset), x.Total - x.Hold, x.Total)).ToArray());
+                    return SharedExecutionResult<SharedBalance[]>.Ok(result, result.Data.Select(x => new SharedBalance(HyperLiquidExchange.AssetAliases.ExchangeToCommonName(x.Asset), x.Total - x.Hold, x.Total)).ToArray());
+                });
         }
 
         #endregion
 
         #region Klines Client
 
-        GetKlinesOptions IKlineRestClient.GetKlinesOptions { get; } = new GetKlinesOptions(false, true, true, 1000, false,
+        GetKlinesOptions IKlineRestClient.GetKlinesOptions { get; } = new GetKlinesOptions(_exchangeName, false, true, true, 1000, false,
             SharedKlineInterval.OneMinute,
             SharedKlineInterval.FiveMinutes,
             SharedKlineInterval.FifteenMinutes,
@@ -59,176 +65,196 @@ namespace HyperLiquid.Net.Clients.SpotApi
             MaxTotalDataPoints = 5000
         };
 
-        async Task<ExchangeWebResult<SharedKline[]>> IKlineRestClient.GetKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        Task<ExchangeWebResult<SharedKline[]>> IKlineRestClient.GetKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var interval = (Enums.KlineInterval)request.Interval;
-            if (!Enum.IsDefined(typeof(Enums.KlineInterval), interval))
-                return new ExchangeWebResult<SharedKline[]>(Exchange, ArgumentError.Invalid(nameof(GetKlinesRequest.Interval), "Interval not supported"));
+            return SharedUtils.ExecuteSharedAsync<IKlineRestClient, GetKlinesRequest, SharedKline[]>(
+                this,
+                client => client.GetKlinesOptions,
+                request,
+                async () =>
+                {
+                    var interval = (Enums.KlineInterval)request.Interval;
+                    if (!Enum.IsDefined(typeof(Enums.KlineInterval), interval))
+                        return SharedExecutionResult<SharedKline[]>.Error(ArgumentError.Invalid(nameof(GetKlinesRequest.Interval), "Interval not supported"));
 
-            var validationError = ((IKlineRestClient)this).GetKlinesOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedKline[]>(Exchange, validationError);
+                    var symbol = request.Symbol!.GetSymbol(FormatSymbol);
+                    int limit = request.Limit ?? 1000;
+                    var direction = DataDirection.Descending;
+                    var pageParams = Pagination.GetPaginationParameters(direction, limit, request.StartTime, request.EndTime ?? DateTime.UtcNow, pageRequest);
 
-            var symbol = request.Symbol!.GetSymbol(FormatSymbol);
-            int limit = request.Limit ?? 1000;
-            var direction = DataDirection.Descending;
-            var pageParams = Pagination.GetPaginationParameters(direction, limit, request.StartTime, request.EndTime ?? DateTime.UtcNow, pageRequest);
+                    // Get data
+                    var result = await ExchangeData.GetKlinesAsync(
+                        symbol,
+                        interval,
+                        startTime: pageParams.StartTime ?? DateTime.UtcNow.Add(TimeSpan.FromSeconds(-((int)interval * 99))),
+                        endTime: pageParams.EndTime ?? DateTime.UtcNow,
+                        ct: ct
+                        ).ConfigureAwait(false);
+                    if (!result)
+                        return SharedExecutionResult<SharedKline[]>.Error(result);
 
-            // Get data
-            var result = await ExchangeData.GetKlinesAsync(
-                symbol,
-                interval,
-                startTime: pageParams.StartTime ?? DateTime.UtcNow.Add(TimeSpan.FromSeconds(-((int)interval * 99))),
-                endTime: pageParams.EndTime ?? DateTime.UtcNow,
-                ct: ct
-                ).ConfigureAwait(false);
-            if (!result)
-                return new ExchangeWebResult<SharedKline[]>(Exchange, TradingMode.Spot, result.As<SharedKline[]>(default));
+                    var nextPageRequest = Pagination.GetNextPageRequest(
+                             () => Pagination.NextPageFromTime(pageParams, result.Data.Min(x => x.OpenTime)),
+                             result.Data.Length,
+                             result.Data.Select(x => x.OpenTime),
+                             request.StartTime,
+                             request.EndTime ?? DateTime.UtcNow,
+                             pageParams);
 
-            var nextPageRequest = Pagination.GetNextPageRequest(
-                     () => Pagination.NextPageFromTime(pageParams, result.Data.Min(x => x.OpenTime)),
-                     result.Data.Length,
-                     result.Data.Select(x => x.OpenTime),
-                     request.StartTime,
-                     request.EndTime ?? DateTime.UtcNow,
-                     pageParams);
-
-            return result.AsExchangeResult(
-                    Exchange,
-                    request.Symbol.TradingMode,
-                    ExchangeHelpers.ApplyFilter(result.Data, x => x.OpenTime, request.StartTime, request.EndTime, direction)
-                    .Select(x => 
-                        new SharedKline(
-                            request.Symbol,
-                            symbol,
-                            x.OpenTime,
-                            x.ClosePrice,
-                            x.HighPrice,
-                            x.LowPrice,
-                            x.OpenPrice,
-                            x.Volume))
-                    .ToArray(), nextPageRequest);
+                    return SharedExecutionResult<SharedKline[]>.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.OpenTime, request.StartTime, request.EndTime, direction)
+                            .Select(x =>
+                                new SharedKline(
+                                    request.Symbol,
+                                    symbol,
+                                    x.OpenTime,
+                                    x.ClosePrice,
+                                    x.HighPrice,
+                                    x.LowPrice,
+                                    x.OpenPrice,
+                                    x.Volume))
+                            .ToArray(), nextPageRequest);
+                });
         }
 
         #endregion
 
         #region Order Book client
-        GetOrderBookOptions IOrderBookRestClient.GetOrderBookOptions { get; } = new GetOrderBookOptions([20], false);
-        async Task<ExchangeWebResult<SharedOrderBook>> IOrderBookRestClient.GetOrderBookAsync(GetOrderBookRequest request, CancellationToken ct)
+        GetOrderBookOptions IOrderBookRestClient.GetOrderBookOptions { get; } = new GetOrderBookOptions(_exchangeName, [20], false);
+        Task<ExchangeWebResult<SharedOrderBook>> IOrderBookRestClient.GetOrderBookAsync(GetOrderBookRequest request, CancellationToken ct)
         {
-            var validationError = ((IOrderBookRestClient)this).GetOrderBookOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedOrderBook>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<IOrderBookRestClient, GetOrderBookRequest, SharedOrderBook>(
+                this,
+                client => client.GetOrderBookOptions,
+                request,
+                async () =>
+                {
 
-            var result = await ExchangeData.GetOrderBookAsync(
-                request.Symbol!.GetSymbol(FormatSymbol),
-                ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedOrderBook>(Exchange, null, default);
+                    var result = await ExchangeData.GetOrderBookAsync(
+                        request.Symbol!.GetSymbol(FormatSymbol),
+                        ct: ct).ConfigureAwait(false);
+                    if (!result)
+                        return SharedExecutionResult<SharedOrderBook>.Error(result);
 
-            if (result.Data == null)
-                return result.AsExchangeError<SharedOrderBook>(Exchange, new ServerError(ErrorInfo.Unknown with { Message = "No response" }));
+                    if (result.Data == null)
+                        return SharedExecutionResult<SharedOrderBook>.Error(result.AsError<SharedOrderBook>(new ServerError(ErrorInfo.Unknown with { Message = "No response" })));
 
-            return result.AsExchangeResult(Exchange, TradingMode.Spot, new SharedOrderBook(result.Data.Levels.Asks, result.Data.Levels.Bids));
+                    return SharedExecutionResult<SharedOrderBook>.Ok(result, new SharedOrderBook(result.Data.Levels.Asks, result.Data.Levels.Bids));
+                });
         }
 
         #endregion
 
         #region Ticker client
 
-        GetTickerOptions ISpotTickerRestClient.GetSpotTickerOptions { get; } = new GetTickerOptions();
-        async Task<ExchangeWebResult<SharedSpotTicker>> ISpotTickerRestClient.GetSpotTickerAsync(GetTickerRequest request, CancellationToken ct)
+        GetSpotTickerOptions ISpotTickerRestClient.GetSpotTickerOptions { get; } = new GetSpotTickerOptions(_exchangeName);
+        Task<ExchangeWebResult<SharedSpotTicker>> ISpotTickerRestClient.GetSpotTickerAsync(GetTickerRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotTickerRestClient)this).GetSpotTickerOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedSpotTicker>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<ISpotTickerRestClient, GetTickerRequest, SharedSpotTicker>(
+                this,
+                client => client.GetSpotTickerOptions,
+                request,
+                async () =>
+                {
 
-            var symbolName = request.Symbol!.GetSymbol(FormatSymbol);
-            var result = await ExchangeData.GetExchangeInfoAndTickersAsync(ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedSpotTicker>(Exchange, null, default);
-            
-            var symbol = result.Data.Tickers.SingleOrDefault(x => x.Symbol == symbolName);
-            if (symbol == null)
-                return result.AsExchangeError<SharedSpotTicker>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
+                    var symbolName = request.Symbol!.GetSymbol(FormatSymbol);
+                    var result = await ExchangeData.GetExchangeInfoAndTickersAsync(ct: ct).ConfigureAwait(false);
+                    if (!result)
+                        return SharedExecutionResult<SharedSpotTicker>.Error(result);
 
-            return result.AsExchangeResult(Exchange, TradingMode.Spot, new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, symbol.Symbol!), symbol.Symbol!, symbol.MidPrice, null, null, symbol.BaseVolume, (symbol.MidPrice == null || symbol.PreviousDayPrice == 0) ? null : Math.Round((symbol.MidPrice.Value / symbol.PreviousDayPrice * 100 - 100) / 10, 3) * 10)
-            {
-                QuoteVolume = symbol.QuoteVolume
-            });
+                    var symbol = result.Data.Tickers.SingleOrDefault(x => x.Symbol == symbolName);
+                    if (symbol == null)
+                        return SharedExecutionResult<SharedSpotTicker>.Error(result.AsError<SharedSpotTicker>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found"))));
+
+                    return SharedExecutionResult<SharedSpotTicker>.Ok(result, new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, symbol.Symbol!), symbol.Symbol!, symbol.MidPrice, null, null, symbol.BaseVolume, (symbol.MidPrice == null || symbol.PreviousDayPrice == 0) ? null : Math.Round((symbol.MidPrice.Value / symbol.PreviousDayPrice * 100 - 100) / 10, 3) * 10)
+                    {
+                        QuoteVolume = symbol.QuoteVolume
+                    });
+                });
         }
 
-        GetTickersOptions ISpotTickerRestClient.GetSpotTickersOptions { get; } = new GetTickersOptions();
-        async Task<ExchangeWebResult<SharedSpotTicker[]>> ISpotTickerRestClient.GetSpotTickersAsync(GetTickersRequest request, CancellationToken ct)
+        GetSpotTickersOptions ISpotTickerRestClient.GetSpotTickersOptions { get; } = new GetSpotTickersOptions(_exchangeName);
+        Task<ExchangeWebResult<SharedSpotTicker[]>> ISpotTickerRestClient.GetSpotTickersAsync(GetTickersRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotTickerRestClient)this).GetSpotTickersOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedSpotTicker[]>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<ISpotTickerRestClient, GetTickersRequest, SharedSpotTicker[]>(
+                this,
+                client => client.GetSpotTickersOptions,
+                request,
+                async () =>
+                {
 
-            var result = await ExchangeData.GetExchangeInfoAndTickersAsync(ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedSpotTicker[]>(Exchange, null, default);
+                    var result = await ExchangeData.GetExchangeInfoAndTickersAsync(ct: ct).ConfigureAwait(false);
+                    if (!result)
+                        return SharedExecutionResult<SharedSpotTicker[]>.Error(result);
 
-            return result.AsExchangeResult<SharedSpotTicker[]>(Exchange, TradingMode.Spot, result.Data.Tickers.Select(x => new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol!), x.Symbol!, x.MidPrice, null, null, x.BaseVolume, (x.MidPrice == null || x.PreviousDayPrice == 0) ? null : Math.Round((x.MidPrice.Value / x.PreviousDayPrice * 100 - 100) / 10, 3) * 10)
-            {
-                QuoteVolume = x.QuoteVolume
-            }).ToArray());
+                    return SharedExecutionResult<SharedSpotTicker[]>.Ok(result, result.Data.Tickers.Select(x => new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol!), x.Symbol!, x.MidPrice, null, null, x.BaseVolume, (x.MidPrice == null || x.PreviousDayPrice == 0) ? null : Math.Round((x.MidPrice.Value / x.PreviousDayPrice * 100 - 100) / 10, 3) * 10)
+                    {
+                        QuoteVolume = x.QuoteVolume
+                    }).ToArray());
+                });
         }
 
         #endregion
 
         #region Book Ticker client
 
-        EndpointOptions<GetBookTickerRequest> IBookTickerRestClient.GetBookTickerOptions { get; } = new EndpointOptions<GetBookTickerRequest>(false);
-        async Task<ExchangeWebResult<SharedBookTicker>> IBookTickerRestClient.GetBookTickerAsync(GetBookTickerRequest request, CancellationToken ct)
+        EndpointOptions<GetBookTickerRequest, IBookTickerRestClient> IBookTickerRestClient.GetBookTickerOptions { get; } = new EndpointOptions<GetBookTickerRequest, IBookTickerRestClient>(_exchangeName, false);
+        Task<ExchangeWebResult<SharedBookTicker>> IBookTickerRestClient.GetBookTickerAsync(GetBookTickerRequest request, CancellationToken ct)
         {
-            var validationError = ((IBookTickerRestClient)this).GetBookTickerOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedBookTicker>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<IBookTickerRestClient, GetBookTickerRequest, SharedBookTicker>(
+                this,
+                client => client.GetBookTickerOptions,
+                request,
+                async () =>
+                {
 
-            var symbol = request.Symbol!.GetSymbol(FormatSymbol);
-            var resultTicker = await ExchangeData.GetOrderBookAsync(symbol, ct: ct).ConfigureAwait(false);
-            if (!resultTicker)
-                return resultTicker.AsExchangeResult<SharedBookTicker>(Exchange, null, default);
+                    var symbol = request.Symbol!.GetSymbol(FormatSymbol);
+                    var resultTicker = await ExchangeData.GetOrderBookAsync(symbol, ct: ct).ConfigureAwait(false);
+                    if (!resultTicker)
+                        return SharedExecutionResult<SharedBookTicker>.Error(resultTicker);
 
-            if (resultTicker.Data == null)
-                return resultTicker.AsExchangeError<SharedBookTicker>(Exchange, new ServerError(new ErrorInfo(ErrorType.Unknown, "No response")));
+                    if (resultTicker.Data == null)
+                        return SharedExecutionResult<SharedBookTicker>.Error(resultTicker.AsError<SharedBookTicker>(new ServerError(new ErrorInfo(ErrorType.Unknown, "No response"))));
 
-            return resultTicker.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedBookTicker(
-                ExchangeSymbolCache.ParseSymbol(_topicId, symbol),
-                symbol,
-                resultTicker.Data.Levels.Asks[0].Price,
-                resultTicker.Data.Levels.Asks[0].Quantity,
-                resultTicker.Data.Levels.Bids[0].Price,
-                resultTicker.Data.Levels.Bids[0].Quantity));
+                    return SharedExecutionResult<SharedBookTicker>.Ok(resultTicker, new SharedBookTicker(
+                        ExchangeSymbolCache.ParseSymbol(_topicId, symbol),
+                        symbol,
+                        resultTicker.Data.Levels.Asks[0].Price,
+                        resultTicker.Data.Levels.Asks[0].Quantity,
+                        resultTicker.Data.Levels.Bids[0].Price,
+                        resultTicker.Data.Levels.Bids[0].Quantity));
+                });
         }
 
         #endregion
 
         #region Spot Symbol client
-        EndpointOptions<GetSymbolsRequest> ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new EndpointOptions<GetSymbolsRequest>(false);
+        EndpointOptions<GetSymbolsRequest, ISpotSymbolRestClient> ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new EndpointOptions<GetSymbolsRequest, ISpotSymbolRestClient>(_exchangeName, false);
 
-        async Task<ExchangeWebResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
+        Task<ExchangeWebResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotSymbolRestClient)this).GetSpotSymbolsOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedSpotSymbol[]>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<ISpotSymbolRestClient, GetSymbolsRequest, SharedSpotSymbol[]>(
+                this,
+                client => client.GetSpotSymbolsOptions,
+                request,
+                async () =>
+                {
 
-            var result = await ExchangeData.GetExchangeInfoAsync(ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedSpotSymbol[]>(Exchange, null, default);
+                    var result = await ExchangeData.GetExchangeInfoAsync(ct: ct).ConfigureAwait(false);
+                    if (!result)
+                        return SharedExecutionResult<SharedSpotSymbol[]>.Error(result);
 
-            var resultData = result.AsExchangeResult<SharedSpotSymbol[]>(Exchange, TradingMode.Spot, result.Data.Symbols.Select(s => new SharedSpotSymbol(HyperLiquidExchange.AssetAliases.ExchangeToCommonName(s.BaseAsset.Name), HyperLiquidExchange.AssetAliases.ExchangeToCommonName(s.QuoteAsset.Name), s.Name, true)
-            {
-                MinTradeQuantity = 1m / (decimal)(Math.Pow(10, s.BaseAsset.QuantityDecimals)),
-                MinNotionalValue = 10, // Order API returns error mentioning at least 10$ order value, but value isn't returned by symbol API
-                QuantityDecimals = s.BaseAsset.QuantityDecimals,
-                PriceSignificantFigures = 5,
-                PriceDecimals = 8 - s.BaseAsset.QuantityDecimals
-            }).ToArray());
+                    var resultData = result.Data.Symbols.Select(s => new SharedSpotSymbol(HyperLiquidExchange.AssetAliases.ExchangeToCommonName(s.BaseAsset.Name), HyperLiquidExchange.AssetAliases.ExchangeToCommonName(s.QuoteAsset.Name), s.Name, true)
+                    {
+                        MinTradeQuantity = 1m / (decimal)(Math.Pow(10, s.BaseAsset.QuantityDecimals)),
+                        MinNotionalValue = 10, // Order API returns error mentioning at least 10$ order value, but value isn't returned by symbol API
+                        QuantityDecimals = s.BaseAsset.QuantityDecimals,
+                        PriceSignificantFigures = 5,
+                        PriceDecimals = 8 - s.BaseAsset.QuantityDecimals
+                    }).ToArray();
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, resultData.Data);
-            return resultData;
+                    ExchangeSymbolCache.UpdateSymbolInfo(_topicId, resultData);
+                    return SharedExecutionResult<SharedSpotSymbol[]>.Ok(result, resultData);
+                });
         }
 
         async Task<ExchangeResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)
@@ -285,7 +311,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
 
         string ISpotOrderRestClient.GenerateClientOrderId() => ExchangeHelpers.RandomHexString(16)!.ToLowerInvariant();
 
-        PlaceSpotOrderOptions ISpotOrderRestClient.PlaceSpotOrderOptions { get; } = new PlaceSpotOrderOptions()
+        PlaceSpotOrderOptions ISpotOrderRestClient.PlaceSpotOrderOptions { get; } = new PlaceSpotOrderOptions(_exchangeName)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
@@ -293,229 +319,187 @@ namespace HyperLiquid.Net.Clients.SpotApi
             }
         };
 
-        async Task<ExchangeWebResult<SharedId>> ISpotOrderRestClient.PlaceSpotOrderAsync(PlaceSpotOrderRequest request, CancellationToken ct)
+        Task<ExchangeWebResult<SharedId>> ISpotOrderRestClient.PlaceSpotOrderAsync(PlaceSpotOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).PlaceSpotOrderOptions.ValidateRequest(
-                Exchange,
+            return SharedUtils.ExecuteSharedAsync<ISpotOrderRestClient, PlaceSpotOrderRequest, SharedId>(
+                this,
+                client => client.PlaceSpotOrderOptions,
                 request,
-                request.TradingMode,
-                SupportedTradingModes,
-                ((ISpotOrderRestClient)this).SpotSupportedOrderTypes,
-                ((ISpotOrderRestClient)this).SpotSupportedTimeInForce,
-                ((ISpotOrderRestClient)this).SpotSupportedOrderQuantity);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                async () =>
+                {
 
-            var result = await Trading.PlaceOrderAsync(
-                request.Symbol!.GetSymbol(FormatSymbol),
-                request.Side == SharedOrderSide.Buy ? Enums.OrderSide.Buy : Enums.OrderSide.Sell,
-                request.OrderType == SharedOrderType.Limit || request.OrderType == SharedOrderType.LimitMaker ? Enums.OrderType.Limit : Enums.OrderType.Market,
-                quantity: request.Quantity?.QuantityInBaseAsset ?? 0,
-                price: request.Price!.Value,
-                timeInForce: GetTimeInForce(request.TimeInForce, request.OrderType),
-                clientOrderId: request.ClientOrderId,
-                ct: ct).ConfigureAwait(false);
+                    var result = await Trading.PlaceOrderAsync(
+                        request.Symbol!.GetSymbol(FormatSymbol),
+                        request.Side == SharedOrderSide.Buy ? Enums.OrderSide.Buy : Enums.OrderSide.Sell,
+                        request.OrderType == SharedOrderType.Limit || request.OrderType == SharedOrderType.LimitMaker ? Enums.OrderType.Limit : Enums.OrderType.Market,
+                        quantity: request.Quantity?.QuantityInBaseAsset ?? 0,
+                        price: request.Price!.Value,
+                        timeInForce: GetTimeInForce(request.TimeInForce, request.OrderType),
+                        clientOrderId: request.ClientOrderId,
+                        rawParameter: request.ExchangeParameters?.GetCollection(Exchange),
+                        ct: ct).ConfigureAwait(false);
 
-            if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+                    if (!result)
+                        return SharedExecutionResult<SharedId>.Error(result);
 
-            return result.AsExchangeResult(Exchange, TradingMode.Spot, new SharedId(result.Data.OrderId.ToString()));
+                    return SharedExecutionResult<SharedId>.Ok(result, new SharedId(result.Data.OrderId.ToString()));
+                });
         }
 
-        EndpointOptions<GetOrderRequest> ISpotOrderRestClient.GetSpotOrderOptions { get; } = new EndpointOptions<GetOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedSpotOrder>> ISpotOrderRestClient.GetSpotOrderAsync(GetOrderRequest request, CancellationToken ct)
+        EndpointOptions<GetOrderRequest, ISpotOrderRestClient> ISpotOrderRestClient.GetSpotOrderOptions { get; } = new EndpointOptions<GetOrderRequest, ISpotOrderRestClient>(_exchangeName, true);
+        Task<ExchangeWebResult<SharedSpotOrder>> ISpotOrderRestClient.GetSpotOrderAsync(GetOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetSpotOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedSpotOrder>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<ISpotOrderRestClient, GetOrderRequest, SharedSpotOrder>(
+                this,
+                client => client.GetSpotOrderOptions,
+                request,
+                async () =>
+                {
 
-            if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedSpotOrder>(Exchange, ArgumentError.Invalid(nameof(GetOrderRequest.OrderId), "Invalid order id"));
+                    if (!long.TryParse(request.OrderId, out var orderId))
+                        return SharedExecutionResult<SharedSpotOrder>.Error(ArgumentError.Invalid(nameof(GetOrderRequest.OrderId), "Invalid order id"));
 
-            var order = await Trading.GetOrderAsync(orderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedSpotOrder>(Exchange, null, default);
+                    var order = await Trading.GetOrderAsync(orderId, ct: ct).ConfigureAwait(false);
+                    if (!order)
+                        return SharedExecutionResult<SharedSpotOrder>.Error(order);
 
-            return order.AsExchangeResult(Exchange, TradingMode.Spot, new SharedSpotOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicId, order.Data.Order.Symbol!),
-                order.Data.Order.Symbol!,
-                order.Data.Order.OrderId.ToString(),
-                ParseOrderType(order.Data.Order.OrderType),
-                order.Data.Order.OrderSide == Enums.OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell,
-                ParseOrderStatus(order.Data.Status),
-                order.Data.Order.Timestamp)
-            {
-                TimeInForce = ParseTimeInForce(order.Data.Order.TimeInForce),
-                ClientOrderId = order.Data.Order.ClientOrderId,
-                OrderPrice = order.Data.Order.Price,
-                OrderQuantity = new SharedOrderQuantity(order.Data.Order.Quantity),
-                QuantityFilled = new SharedOrderQuantity(order.Data.Order.Quantity - order.Data.Order.QuantityRemaining),
-                UpdateTime = order.Data.Timestamp,
-                TriggerPrice = order.Data.Order.TriggerPrice,
-                IsTriggerOrder = order.Data.Order.TriggerPrice > 0
-            });
+                    return SharedExecutionResult<SharedSpotOrder>.Ok(order, new SharedSpotOrder(
+                        ExchangeSymbolCache.ParseSymbol(_topicId, order.Data.Order.Symbol!),
+                        order.Data.Order.Symbol!,
+                        order.Data.Order.OrderId.ToString(),
+                        ParseOrderType(order.Data.Order.OrderType),
+                        order.Data.Order.OrderSide == Enums.OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell,
+                        ParseOrderStatus(order.Data.Status),
+                        order.Data.Order.Timestamp)
+                    {
+                        TimeInForce = ParseTimeInForce(order.Data.Order.TimeInForce),
+                        ClientOrderId = order.Data.Order.ClientOrderId,
+                        OrderPrice = order.Data.Order.Price,
+                        OrderQuantity = new SharedOrderQuantity(order.Data.Order.Quantity),
+                        QuantityFilled = new SharedOrderQuantity(order.Data.Order.Quantity - order.Data.Order.QuantityRemaining),
+                        UpdateTime = order.Data.Timestamp,
+                        TriggerPrice = order.Data.Order.TriggerPrice,
+                        IsTriggerOrder = order.Data.Order.TriggerPrice > 0
+                    });
+                });
         }
 
-        EndpointOptions<GetOpenOrdersRequest> ISpotOrderRestClient.GetOpenSpotOrdersOptions { get; } = new EndpointOptions<GetOpenOrdersRequest>(true);
-        async Task<ExchangeWebResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetOpenSpotOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
+        EndpointOptions<GetOpenOrdersRequest, ISpotOrderRestClient> ISpotOrderRestClient.GetOpenSpotOrdersOptions { get; } = new EndpointOptions<GetOpenOrdersRequest, ISpotOrderRestClient>(_exchangeName, true);
+        Task<ExchangeWebResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetOpenSpotOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetOpenSpotOrdersOptions.ValidateRequest(Exchange, request, request.Symbol?.TradingMode ?? request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedSpotOrder[]>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<ISpotOrderRestClient, GetOpenOrdersRequest, SharedSpotOrder[]>(
+                this,
+                client => client.GetOpenSpotOrdersOptions,
+                request,
+                async () =>
+                {
 
-            var symbol = request.Symbol?.GetSymbol(FormatSymbol);
-            var orders = await Trading.GetOpenOrdersExtendedAsync(ct: ct).ConfigureAwait(false);
-            if (!orders)
-                return orders.AsExchangeResult<SharedSpotOrder[]>(Exchange, null, default);
+                    var symbol = request.Symbol?.GetSymbol(FormatSymbol);
+                    var orders = await Trading.GetOpenOrdersExtendedAsync(ct: ct).ConfigureAwait(false);
+                    if (!orders)
+                        return SharedExecutionResult<SharedSpotOrder[]>.Error(orders);
 
-            var data = orders.Data.Where(x => x.SymbolType == Enums.SymbolType.Spot);
-            if (symbol != null)
-                data = data.Where(x => x.Symbol == symbol);
+                    var data = orders.Data.Where(x => x.SymbolType == Enums.SymbolType.Spot);
+                    if (symbol != null)
+                        data = data.Where(x => x.Symbol == symbol);
 
-            return orders.AsExchangeResult<SharedSpotOrder[]>(Exchange, TradingMode.Spot, data.Select(x => new SharedSpotOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol),
-                x.Symbol!,
-                x.OrderId.ToString(),
-                ParseOrderType(x.OrderType),
-                x.OrderSide == Enums.OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell,
-                SharedOrderStatus.Open,
-                x.Timestamp)
-            {
-                TimeInForce = ParseTimeInForce(x.TimeInForce),
-                ClientOrderId = x.ClientOrderId,
-                OrderPrice = x.Price,
-                OrderQuantity = new SharedOrderQuantity(x.Quantity),
-                QuantityFilled = new SharedOrderQuantity(x.Quantity - x.QuantityRemaining),
-                UpdateTime = x.Timestamp,
-                TriggerPrice = x.TriggerPrice,
-                IsTriggerOrder = x.TriggerPrice > 0
-            }).ToArray());
+                    return SharedExecutionResult<SharedSpotOrder[]>.Ok(orders, data.Select(x => new SharedSpotOrder(
+                        ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol),
+                        x.Symbol!,
+                        x.OrderId.ToString(),
+                        ParseOrderType(x.OrderType),
+                        x.OrderSide == Enums.OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell,
+                        SharedOrderStatus.Open,
+                        x.Timestamp)
+                    {
+                        TimeInForce = ParseTimeInForce(x.TimeInForce),
+                        ClientOrderId = x.ClientOrderId,
+                        OrderPrice = x.Price,
+                        OrderQuantity = new SharedOrderQuantity(x.Quantity),
+                        QuantityFilled = new SharedOrderQuantity(x.Quantity - x.QuantityRemaining),
+                        UpdateTime = x.Timestamp,
+                        TriggerPrice = x.TriggerPrice,
+                        IsTriggerOrder = x.TriggerPrice > 0
+                    }).ToArray());
+                });
         }
 
-        GetClosedOrdersOptions ISpotOrderRestClient.GetClosedSpotOrdersOptions { get; } = new GetClosedOrdersOptions(true, true, false, 2000)
+        GetSpotClosedOrdersOptions ISpotOrderRestClient.GetClosedSpotOrdersOptions { get; } = new GetSpotClosedOrdersOptions(_exchangeName, true, true, false, 2000)
         {
             RequestNotes = "API request doesn't allow filtering, so filtering is done client side. This might result in missing historical data as only up to 2000 results are returned from the API"
         };
-        async Task<ExchangeWebResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetClosedSpotOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageToken, CancellationToken ct)
+        Task<ExchangeWebResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetClosedSpotOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageToken, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetClosedSpotOrdersOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedSpotOrder[]>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<ISpotOrderRestClient, GetClosedOrdersRequest, SharedSpotOrder[]>(
+                this,
+                client => client.GetClosedSpotOrdersOptions,
+                request,
+                async () =>
+                {
 
-            // Get data
-            var orders = await Trading.GetOrderHistoryAsync(ct: ct).ConfigureAwait(false);
-            if (!orders)
-                return orders.AsExchangeResult<SharedSpotOrder[]>(Exchange, null, default);
+                    // Get data
+                    var orders = await Trading.GetOrderHistoryAsync(ct: ct).ConfigureAwait(false);
+                    if (!orders)
+                        return SharedExecutionResult<SharedSpotOrder[]>.Error(orders);
 
-            var direction = request.Direction ?? DataDirection.Ascending;
-            var symbol = request.Symbol!.GetSymbol(FormatSymbol);
-            var data = orders.Data.Where(x => 
-                x.Order.SymbolType == Enums.SymbolType.Spot 
-                && x.Order.Symbol == symbol
-                && x.Status != Enums.OrderStatus.Open);
+                    var direction = request.Direction ?? DataDirection.Ascending;
+                    var symbol = request.Symbol!.GetSymbol(FormatSymbol);
+                    var data = orders.Data.Where(x =>
+                        x.Order.SymbolType == Enums.SymbolType.Spot
+                        && x.Order.Symbol == symbol
+                        && x.Status != Enums.OrderStatus.Open);
 
-            if (direction == DataDirection.Ascending)
-                data.OrderBy(x => x.Timestamp);
-            if (direction == DataDirection.Descending)
-                data.OrderByDescending(x => x.Timestamp);
-            if (request.Limit != null)
-                data = data.Take(request.Limit.Value);
+                    if (direction == DataDirection.Ascending)
+                        data.OrderBy(x => x.Timestamp);
+                    if (direction == DataDirection.Descending)
+                        data.OrderByDescending(x => x.Timestamp);
+                    if (request.Limit != null)
+                        data = data.Take(request.Limit.Value);
 
-            return orders.AsExchangeResult(
-                        Exchange,
-                        request.Symbol.TradingMode,
-                        ExchangeHelpers.ApplyFilter(data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
-                        .Select(x =>
-                            new SharedSpotOrder(
-                                ExchangeSymbolCache.ParseSymbol(_topicId, x.Order.Symbol), 
-                                x.Order.Symbol!,
-                                x.Order.OrderId.ToString(),
-                                ParseOrderType(x.Order.OrderType),
-                                x.Order.OrderSide == Enums.OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell,
-                                ParseOrderStatus(x.Status),
-                                x.Order.Timestamp)
-                            {
-                                TimeInForce = ParseTimeInForce(x.Order.TimeInForce),
-                                ClientOrderId = x.Order.ClientOrderId,
-                                OrderPrice = x.Order.Price,
-                                OrderQuantity = new SharedOrderQuantity(x.Order.Quantity),
-                                QuantityFilled = new SharedOrderQuantity(x.Order.Quantity - x.Order.QuantityRemaining),
-                                UpdateTime = x.Timestamp,
-                                TriggerPrice = x.Order.TriggerPrice,
-                                IsTriggerOrder = x.Order.TriggerPrice > 0
-                            })
-                        .ToArray());
+                    return SharedExecutionResult<SharedSpotOrder[]>.Ok(orders, ExchangeHelpers.ApplyFilter(data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
+                                .Select(x =>
+                                    new SharedSpotOrder(
+                                        ExchangeSymbolCache.ParseSymbol(_topicId, x.Order.Symbol),
+                                        x.Order.Symbol!,
+                                        x.Order.OrderId.ToString(),
+                                        ParseOrderType(x.Order.OrderType),
+                                        x.Order.OrderSide == Enums.OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell,
+                                        ParseOrderStatus(x.Status),
+                                        x.Order.Timestamp)
+                                    {
+                                        TimeInForce = ParseTimeInForce(x.Order.TimeInForce),
+                                        ClientOrderId = x.Order.ClientOrderId,
+                                        OrderPrice = x.Order.Price,
+                                        OrderQuantity = new SharedOrderQuantity(x.Order.Quantity),
+                                        QuantityFilled = new SharedOrderQuantity(x.Order.Quantity - x.Order.QuantityRemaining),
+                                        UpdateTime = x.Timestamp,
+                                        TriggerPrice = x.Order.TriggerPrice,
+                                        IsTriggerOrder = x.Order.TriggerPrice > 0
+                                    })
+                                .ToArray());
+                });
         }
 
-        EndpointOptions<GetOrderTradesRequest> ISpotOrderRestClient.GetSpotOrderTradesOptions { get; } = new EndpointOptions<GetOrderTradesRequest>(true);
-        async Task<ExchangeWebResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
+        EndpointOptions<GetOrderTradesRequest, ISpotOrderRestClient> ISpotOrderRestClient.GetSpotOrderTradesOptions { get; } = new EndpointOptions<GetOrderTradesRequest, ISpotOrderRestClient>(_exchangeName, true);
+        Task<ExchangeWebResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetSpotOrderTradesOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<ISpotOrderRestClient, GetOrderTradesRequest, SharedUserTrade[]>(
+                this,
+                client => client.GetSpotOrderTradesOptions,
+                request,
+                async () =>
+                {
 
-            if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, ArgumentError.Invalid(nameof(GetOrderTradesRequest.OrderId), "Invalid order id"));
+                    if (!long.TryParse(request.OrderId, out var orderId))
+                        return SharedExecutionResult<SharedUserTrade[]>.Error(ArgumentError.Invalid(nameof(GetOrderTradesRequest.OrderId), "Invalid order id"));
 
-            var orders = await Trading.GetUserTradesAsync(ct: ct).ConfigureAwait(false);
-            if (!orders)
-                return orders.AsExchangeResult<SharedUserTrade[]>(Exchange, null, default);
+                    var orders = await Trading.GetUserTradesAsync(ct: ct).ConfigureAwait(false);
+                    if (!orders)
+                        return SharedExecutionResult<SharedUserTrade[]>.Error(orders);
 
-            var data = orders.Data.Where(x => x.OrderId == orderId);
-            return orders.AsExchangeResult<SharedUserTrade[]>(Exchange, TradingMode.Spot, data.Select(x => new SharedUserTrade(
-                ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), 
-                x.Symbol,
-                x.OrderId.ToString(),
-                x.TradeId.ToString(),
-                x.OrderSide == Enums.OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell,
-                x.Quantity,
-                x.Price,
-                x.Timestamp)
-            {
-                Fee = x.Fee,
-                FeeAsset = HyperLiquidExchange.AssetAliases.ExchangeToCommonName(x.FeeToken),
-                Role = x.Crossed ? SharedRole.Taker : SharedRole.Maker
-            }).ToArray());
-        }
-
-        GetUserTradesOptions ISpotOrderRestClient.GetSpotUserTradesOptions { get; } = new GetUserTradesOptions(true, false, true, 2000)
-        {
-            RequestNotes = "API request doesn't allow filtering, so filtering is done client side. This might result in missing historical data as only up to 2000 per request / 10000 results in total are returned from the API"
-        };
-        async Task<ExchangeWebResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
-        {
-            var validationError = ((ISpotOrderRestClient)this).GetSpotUserTradesOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, validationError);
-            
-            int limit = request.Limit ?? 2000;
-            var direction = DataDirection.Ascending;
-            var pageParams = Pagination.GetPaginationParameters(direction, limit, request.StartTime, request.EndTime ?? DateTime.UtcNow, pageRequest, false);
-
-            // Get data
-            var result = await Trading.GetUserTradesByTimeAsync(
-                startTime: pageParams.StartTime ?? DateTime.UtcNow.AddDays(-7),
-                ct: ct
-                ).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedUserTrade[]>(Exchange, null, default);
-
-            var data = result.Data.Where(x => x.Symbol == request.Symbol!.GetSymbol(FormatSymbol));
-            var nextPageRequest = Pagination.GetNextPageRequest(
-                     () => Pagination.NextPageFromTime(pageParams, result.Data.Max(x => x.Timestamp)),
-                     result.Data.Length,
-                     result.Data.Select(x => x.Timestamp),
-                     request.StartTime,
-                     request.EndTime ?? DateTime.UtcNow,
-                     pageParams);
-
-            return result.AsExchangeResult(
-                    Exchange,
-                    request.Symbol!.TradingMode,
-                    ExchangeHelpers.ApplyFilter(data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
-                    .Select(x => 
-                        new SharedUserTrade(
-                        ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), 
+                    var data = orders.Data.Where(x => x.OrderId == orderId);
+                    return SharedExecutionResult<SharedUserTrade[]>.Ok(orders, data.Select(x => new SharedUserTrade(
+                        ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol),
                         x.Symbol,
                         x.OrderId.ToString(),
                         x.TradeId.ToString(),
@@ -527,24 +511,82 @@ namespace HyperLiquid.Net.Clients.SpotApi
                         Fee = x.Fee,
                         FeeAsset = HyperLiquidExchange.AssetAliases.ExchangeToCommonName(x.FeeToken),
                         Role = x.Crossed ? SharedRole.Taker : SharedRole.Maker
-                    }).ToArray(), nextPageRequest);
+                    }).ToArray());
+                });
         }
 
-        EndpointOptions<CancelOrderRequest> ISpotOrderRestClient.CancelSpotOrderOptions { get; } = new EndpointOptions<CancelOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedId>> ISpotOrderRestClient.CancelSpotOrderAsync(CancelOrderRequest request, CancellationToken ct)
+        GetSpotUserTradesOptions ISpotOrderRestClient.GetSpotUserTradesOptions { get; } = new GetSpotUserTradesOptions(_exchangeName, true, false, true, 2000)
         {
-            var validationError = ((ISpotOrderRestClient)this).CancelSpotOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+            RequestNotes = "API request doesn't allow filtering, so filtering is done client side. This might result in missing historical data as only up to 2000 per request / 10000 results in total are returned from the API"
+        };
+        Task<ExchangeWebResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        {
+            return SharedUtils.ExecuteSharedAsync<ISpotOrderRestClient, GetUserTradesRequest, SharedUserTrade[]>(
+                this,
+                client => client.GetSpotUserTradesOptions,
+                request,
+                async () =>
+                {
 
-            if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedId>(Exchange, ArgumentError.Invalid(nameof(CancelOrderRequest.OrderId), "Invalid order id"));
+                    int limit = request.Limit ?? 2000;
+                    var direction = DataDirection.Ascending;
+                    var pageParams = Pagination.GetPaginationParameters(direction, limit, request.StartTime, request.EndTime ?? DateTime.UtcNow, pageRequest, false);
 
-            var order = await Trading.CancelOrderAsync(request.Symbol!.GetSymbol(FormatSymbol), orderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedId>(Exchange, null, default);
+                    // Get data
+                    var result = await Trading.GetUserTradesByTimeAsync(
+                        startTime: pageParams.StartTime ?? DateTime.UtcNow.AddDays(-7),
+                        ct: ct
+                        ).ConfigureAwait(false);
+                    if (!result)
+                        return SharedExecutionResult<SharedUserTrade[]>.Error(result);
 
-            return order.AsExchangeResult(Exchange, TradingMode.Spot, new SharedId(request.OrderId));
+                    var data = result.Data.Where(x => x.Symbol == request.Symbol!.GetSymbol(FormatSymbol));
+                    var nextPageRequest = Pagination.GetNextPageRequest(
+                             () => Pagination.NextPageFromTime(pageParams, result.Data.Max(x => x.Timestamp)),
+                             result.Data.Length,
+                             result.Data.Select(x => x.Timestamp),
+                             request.StartTime,
+                             request.EndTime ?? DateTime.UtcNow,
+                             pageParams);
+
+                    return SharedExecutionResult<SharedUserTrade[]>.Ok(result, ExchangeHelpers.ApplyFilter(data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
+                            .Select(x =>
+                                new SharedUserTrade(
+                                ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol),
+                                x.Symbol,
+                                x.OrderId.ToString(),
+                                x.TradeId.ToString(),
+                                x.OrderSide == Enums.OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell,
+                                x.Quantity,
+                                x.Price,
+                                x.Timestamp)
+                                {
+                                    Fee = x.Fee,
+                                    FeeAsset = HyperLiquidExchange.AssetAliases.ExchangeToCommonName(x.FeeToken),
+                                    Role = x.Crossed ? SharedRole.Taker : SharedRole.Maker
+                                }).ToArray(), nextPageRequest);
+                });
+        }
+
+        EndpointOptions<CancelOrderRequest, ISpotOrderRestClient> ISpotOrderRestClient.CancelSpotOrderOptions { get; } = new EndpointOptions<CancelOrderRequest, ISpotOrderRestClient>(_exchangeName, true);
+        Task<ExchangeWebResult<SharedId>> ISpotOrderRestClient.CancelSpotOrderAsync(CancelOrderRequest request, CancellationToken ct)
+        {
+            return SharedUtils.ExecuteSharedAsync<ISpotOrderRestClient, CancelOrderRequest, SharedId>(
+                this,
+                client => client.CancelSpotOrderOptions,
+                request,
+                async () =>
+                {
+
+                    if (!long.TryParse(request.OrderId, out var orderId))
+                        return SharedExecutionResult<SharedId>.Error(ArgumentError.Invalid(nameof(CancelOrderRequest.OrderId), "Invalid order id"));
+
+                    var order = await Trading.CancelOrderAsync(request.Symbol!.GetSymbol(FormatSymbol), orderId, ct: ct).ConfigureAwait(false);
+                    if (!order)
+                        return SharedExecutionResult<SharedId>.Error(order);
+
+                    return SharedExecutionResult<SharedId>.Ok(order, new SharedId(request.OrderId));
+                });
         }
 
         private SharedTimeInForce? ParseTimeInForce(TimeInForce? timeInForce)
@@ -612,176 +654,204 @@ namespace HyperLiquid.Net.Clients.SpotApi
 
         #region Spot Client Id Order Client
 
-        EndpointOptions<GetOrderRequest> ISpotOrderClientIdRestClient.GetSpotOrderByClientOrderIdOptions { get; } = new EndpointOptions<GetOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedSpotOrder>> ISpotOrderClientIdRestClient.GetSpotOrderByClientOrderIdAsync(GetOrderRequest request, CancellationToken ct)
+        EndpointOptions<GetOrderRequest, ISpotOrderClientIdRestClient> ISpotOrderClientIdRestClient.GetSpotOrderByClientOrderIdOptions { get; } = new EndpointOptions<GetOrderRequest, ISpotOrderClientIdRestClient>(_exchangeName, true);
+        Task<ExchangeWebResult<SharedSpotOrder>> ISpotOrderClientIdRestClient.GetSpotOrderByClientOrderIdAsync(GetOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetSpotOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedSpotOrder>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<ISpotOrderClientIdRestClient, GetOrderRequest, SharedSpotOrder>(
+                this,
+                client => client.GetSpotOrderByClientOrderIdOptions,
+                request,
+                async () =>
+                {
 
-            var order = await Trading.GetOrderAsync(clientOrderId: request.OrderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedSpotOrder>(Exchange, null, default);
+                    var order = await Trading.GetOrderAsync(clientOrderId: request.OrderId, ct: ct).ConfigureAwait(false);
+                    if (!order)
+                        return SharedExecutionResult<SharedSpotOrder>.Error(order);
 
-            return order.AsExchangeResult(Exchange, TradingMode.Spot, new SharedSpotOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicId, order.Data.Order.Symbol!),
-                order.Data.Order.Symbol!,
-                order.Data.Order.OrderId.ToString(),
-                ParseOrderType(order.Data.Order.OrderType),
-                order.Data.Order.OrderSide == Enums.OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell,
-                ParseOrderStatus(order.Data.Status),
-                order.Data.Order.Timestamp)
-            {
-                TimeInForce = ParseTimeInForce(order.Data.Order.TimeInForce),
-                ClientOrderId = order.Data.Order.ClientOrderId,
-                OrderPrice = order.Data.Order.Price,
-                OrderQuantity = new SharedOrderQuantity(order.Data.Order.Quantity),
-                QuantityFilled = new SharedOrderQuantity(order.Data.Order.Quantity - order.Data.Order.QuantityRemaining),
-                UpdateTime = order.Data.Timestamp,
-                TriggerPrice = order.Data.Order.TriggerPrice,
-                IsTriggerOrder = order.Data.Order.TriggerPrice > 0
-            });
+                    return SharedExecutionResult<SharedSpotOrder>.Ok(order, new SharedSpotOrder(
+                        ExchangeSymbolCache.ParseSymbol(_topicId, order.Data.Order.Symbol!),
+                        order.Data.Order.Symbol!,
+                        order.Data.Order.OrderId.ToString(),
+                        ParseOrderType(order.Data.Order.OrderType),
+                        order.Data.Order.OrderSide == Enums.OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell,
+                        ParseOrderStatus(order.Data.Status),
+                        order.Data.Order.Timestamp)
+                    {
+                        TimeInForce = ParseTimeInForce(order.Data.Order.TimeInForce),
+                        ClientOrderId = order.Data.Order.ClientOrderId,
+                        OrderPrice = order.Data.Order.Price,
+                        OrderQuantity = new SharedOrderQuantity(order.Data.Order.Quantity),
+                        QuantityFilled = new SharedOrderQuantity(order.Data.Order.Quantity - order.Data.Order.QuantityRemaining),
+                        UpdateTime = order.Data.Timestamp,
+                        TriggerPrice = order.Data.Order.TriggerPrice,
+                        IsTriggerOrder = order.Data.Order.TriggerPrice > 0
+                    });
+                });
         }
 
-        EndpointOptions<CancelOrderRequest> ISpotOrderClientIdRestClient.CancelSpotOrderByClientOrderIdOptions { get; } = new EndpointOptions<CancelOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedId>> ISpotOrderClientIdRestClient.CancelSpotOrderByClientOrderIdAsync(CancelOrderRequest request, CancellationToken ct)
+        EndpointOptions<CancelOrderRequest, ISpotOrderClientIdRestClient> ISpotOrderClientIdRestClient.CancelSpotOrderByClientOrderIdOptions { get; } = new EndpointOptions<CancelOrderRequest, ISpotOrderClientIdRestClient>(_exchangeName, true);
+        Task<ExchangeWebResult<SharedId>> ISpotOrderClientIdRestClient.CancelSpotOrderByClientOrderIdAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).CancelSpotOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<ISpotOrderClientIdRestClient, CancelOrderRequest, SharedId>(
+                this,
+                client => client.CancelSpotOrderByClientOrderIdOptions,
+                request,
+                async () =>
+                {
 
-            var order = await Trading.CancelOrderByClientOrderIdAsync(request.Symbol!.GetSymbol(FormatSymbol), clientOrderId: request.OrderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedId>(Exchange, null, default);
+                    var order = await Trading.CancelOrderByClientOrderIdAsync(request.Symbol!.GetSymbol(FormatSymbol), clientOrderId: request.OrderId, ct: ct).ConfigureAwait(false);
+                    if (!order)
+                        return SharedExecutionResult<SharedId>.Error(order);
 
-            return order.AsExchangeResult(Exchange, TradingMode.Spot, new SharedId(request.OrderId));
+                    return SharedExecutionResult<SharedId>.Ok(order, new SharedId(request.OrderId));
+                });
         }
         #endregion
 
         #region Asset client
-        EndpointOptions<GetAssetsRequest> IAssetsRestClient.GetAssetsOptions { get; } = new EndpointOptions<GetAssetsRequest>(true);
+        EndpointOptions<GetAssetsRequest, IAssetsRestClient> IAssetsRestClient.GetAssetsOptions { get; } = new EndpointOptions<GetAssetsRequest, IAssetsRestClient>(_exchangeName, true);
 
-        async Task<ExchangeWebResult<SharedAsset[]>> IAssetsRestClient.GetAssetsAsync(GetAssetsRequest request, CancellationToken ct)
+        Task<ExchangeWebResult<SharedAsset[]>> IAssetsRestClient.GetAssetsAsync(GetAssetsRequest request, CancellationToken ct)
         {
-            var validationError = ((IAssetsRestClient)this).GetAssetsOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedAsset[]>(Exchange, validationError);
-            
-            var assets = await ExchangeData.GetExchangeInfoAsync(ct: ct).ConfigureAwait(false);
-            if (!assets)
-                return assets.AsExchangeResult<SharedAsset[]>(Exchange, null, default);
+            return SharedUtils.ExecuteSharedAsync<IAssetsRestClient, GetAssetsRequest, SharedAsset[]>(
+                this,
+                client => client.GetAssetsOptions,
+                request,
+                async () =>
+                {
 
-            return assets.AsExchangeResult<SharedAsset[]>(Exchange, TradingMode.Spot, assets.Data.Assets.Select(x => new SharedAsset(HyperLiquidExchange.AssetAliases.ExchangeToCommonName(x.Name))
-            {
-                FullName = x.FullName,
-                Networks = [new SharedAssetNetwork("HyperLiquid") {
+                    var assets = await ExchangeData.GetExchangeInfoAsync(ct: ct).ConfigureAwait(false);
+                    if (!assets)
+                        return SharedExecutionResult<SharedAsset[]>.Error(assets);
+
+                    return SharedExecutionResult<SharedAsset[]>.Ok(assets, assets.Data.Assets.Select(x => new SharedAsset(HyperLiquidExchange.AssetAliases.ExchangeToCommonName(x.Name))
+                    {
+                        FullName = x.FullName,
+                        Networks = [new SharedAssetNetwork("HyperLiquid") {
                     ContractAddress = x.AssetId
                 }]
-            }).ToArray());
+                    }).ToArray());
+                });
         }
 
-        EndpointOptions<GetAssetRequest> IAssetsRestClient.GetAssetOptions { get; } = new EndpointOptions<GetAssetRequest>(false);
-        async Task<ExchangeWebResult<SharedAsset>> IAssetsRestClient.GetAssetAsync(GetAssetRequest request, CancellationToken ct)
+        EndpointOptions<GetAssetRequest, IAssetsRestClient> IAssetsRestClient.GetAssetOptions { get; } = new EndpointOptions<GetAssetRequest, IAssetsRestClient>(_exchangeName, false);
+        Task<ExchangeWebResult<SharedAsset>> IAssetsRestClient.GetAssetAsync(GetAssetRequest request, CancellationToken ct)
         {
-            var validationError = ((IAssetsRestClient)this).GetAssetOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedAsset>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<IAssetsRestClient, GetAssetRequest, SharedAsset>(
+                this,
+                client => client.GetAssetOptions,
+                request,
+                async () =>
+                {
 
-            var assets = await ExchangeData.GetExchangeInfoAsync(ct: ct).ConfigureAwait(false);
-            if (!assets)
-                return assets.AsExchangeResult<SharedAsset>(Exchange, null, default);
+                    var assets = await ExchangeData.GetExchangeInfoAsync(ct: ct).ConfigureAwait(false);
+                    if (!assets)
+                        return SharedExecutionResult<SharedAsset>.Error(assets);
 
-            var asset = assets.Data.Assets.SingleOrDefault(x => x.Name.Equals(HyperLiquidExchange.AssetAliases.CommonToExchangeName(request.Asset), StringComparison.InvariantCultureIgnoreCase));
-            if (asset == null)
-                return assets.AsExchangeError<SharedAsset>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownAsset, "Asset not found")));
+                    var asset = assets.Data.Assets.SingleOrDefault(x => x.Name.Equals(HyperLiquidExchange.AssetAliases.CommonToExchangeName(request.Asset), StringComparison.InvariantCultureIgnoreCase));
+                    if (asset == null)
+                        return SharedExecutionResult<SharedAsset>.Error(assets.AsError<SharedAsset>(new ServerError(new ErrorInfo(ErrorType.UnknownAsset, "Asset not found"))));
 
-            return assets.AsExchangeResult(Exchange, TradingMode.Spot, new SharedAsset(HyperLiquidExchange.AssetAliases.ExchangeToCommonName(asset.Name))
-            {
-                FullName = asset.FullName,
-                Networks = [new SharedAssetNetwork("HyperLiquid") {
+                    return SharedExecutionResult<SharedAsset>.Ok(assets, new SharedAsset(HyperLiquidExchange.AssetAliases.ExchangeToCommonName(asset.Name))
+                    {
+                        FullName = asset.FullName,
+                        Networks = [new SharedAssetNetwork("HyperLiquid") {
                     ContractAddress = asset.AssetId
                 }]
-            });
+                    });
+                });
         }
 
         #endregion
 
         #region Fee Client
-        EndpointOptions<GetFeeRequest> IFeeRestClient.GetFeeOptions { get; } = new EndpointOptions<GetFeeRequest>(true);
+        EndpointOptions<GetFeeRequest, IFeeRestClient> IFeeRestClient.GetFeeOptions { get; } = new EndpointOptions<GetFeeRequest, IFeeRestClient>(_exchangeName, true);
 
-        async Task<ExchangeWebResult<SharedFee>> IFeeRestClient.GetFeesAsync(GetFeeRequest request, CancellationToken ct)
+        Task<ExchangeWebResult<SharedFee>> IFeeRestClient.GetFeesAsync(GetFeeRequest request, CancellationToken ct)
         {
-            var validationError = ((IFeeRestClient)this).GetFeeOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedFee>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<IFeeRestClient, GetFeeRequest, SharedFee>(
+                this,
+                client => client.GetFeeOptions,
+                request,
+                async () =>
+                {
 
-            // Get data
-            var result = await Account.GetFeeInfoAsync(ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedFee>(Exchange, null, default);
+                    // Get data
+                    var result = await Account.GetFeeInfoAsync(ct: ct).ConfigureAwait(false);
+                    if (!result)
+                        return SharedExecutionResult<SharedFee>.Error(result);
 
-            // Return
-            return result.AsExchangeResult(Exchange, TradingMode.Spot, new SharedFee(result.Data.MakerFeeRateSpot * 100, result.Data.TakerFeeRateSpot * 100));
+                    // Return
+                    return SharedExecutionResult<SharedFee>.Ok(result, new SharedFee(result.Data.MakerFeeRateSpot * 100, result.Data.TakerFeeRateSpot * 100));
+                });
         }
         #endregion
 
         #region Withdraw client
 
-        WithdrawOptions IWithdrawRestClient.WithdrawOptions { get; } = new WithdrawOptions();
-        async Task<ExchangeWebResult<SharedId>> IWithdrawRestClient.WithdrawAsync(WithdrawRequest request, CancellationToken ct)
+        WithdrawOptions IWithdrawRestClient.WithdrawOptions { get; } = new WithdrawOptions(_exchangeName);
+        Task<ExchangeWebResult<SharedId>> IWithdrawRestClient.WithdrawAsync(WithdrawRequest request, CancellationToken ct)
         {
-            var validationError = ((IWithdrawRestClient)this).WithdrawOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<IWithdrawRestClient, WithdrawRequest, SharedId>(
+                this,
+                client => client.WithdrawOptions,
+                request,
+                async () =>
+                {
 
-            // Get data
-            var withdrawal = await Account.TransferSpotAsync(
-                request.Address,
-                HyperLiquidExchange.AssetAliases.CommonToExchangeName(request.Asset),
-                request.Quantity,
-                ct: ct).ConfigureAwait(false);
-            if (!withdrawal)
-                return withdrawal.AsExchangeResult<SharedId>(Exchange, null, default);
+                    // Get data
+                    var withdrawal = await Account.TransferSpotAsync(
+                        request.Address,
+                        HyperLiquidExchange.AssetAliases.CommonToExchangeName(request.Asset),
+                        request.Quantity,
+                        ct: ct).ConfigureAwait(false);
+                    if (!withdrawal)
+                        return SharedExecutionResult<SharedId>.Error(withdrawal);
 
-            return withdrawal.AsExchangeResult(Exchange, TradingMode.Spot, new SharedId(string.Empty));
+                    return SharedExecutionResult<SharedId>.Ok(withdrawal, new SharedId(string.Empty));
+                });
         }
 
         #endregion
 
         #region Transfer client
 
-        TransferOptions ITransferRestClient.TransferOptions { get; } = new TransferOptions([
+        TransferOptions ITransferRestClient.TransferOptions { get; } = new TransferOptions(_exchangeName, [
             SharedAccountType.PerpetualLinearFutures,
             SharedAccountType.PerpetualInverseFutures,
             SharedAccountType.DeliveryLinearFutures,
             SharedAccountType.DeliveryInverseFutures,
             SharedAccountType.Spot
             ]);
-        async Task<ExchangeWebResult<SharedId>> ITransferRestClient.TransferAsync(TransferRequest request, CancellationToken ct)
+        Task<ExchangeWebResult<SharedId>> ITransferRestClient.TransferAsync(TransferRequest request, CancellationToken ct)
         {
-            var validationError = ((ITransferRestClient)this).TransferOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
-            if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+            return SharedUtils.ExecuteSharedAsync<ITransferRestClient, TransferRequest, SharedId>(
+                this,
+                client => client.TransferOptions,
+                request,
+                async () =>
+                {
 
-            if (!request.Asset.Equals("USDC", StringComparison.InvariantCultureIgnoreCase)
-                && !request.Asset.Equals("USD", StringComparison.InvariantCultureIgnoreCase))
-            {
-                return new ExchangeWebResult<SharedId>(Exchange, ArgumentError.Invalid("Asset", "invalid asset, only USD is supported"));
-            }
+                    if (!request.Asset.Equals("USDC", StringComparison.InvariantCultureIgnoreCase)
+                        && !request.Asset.Equals("USD", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        return SharedExecutionResult<SharedId>.Error(ArgumentError.Invalid("Asset", "invalid asset, only USD is supported"));
+                    }
 
-            var type = GetTransferType(request);
-            if (type == null)
-                return new ExchangeWebResult<SharedId>(Exchange, ArgumentError.Invalid("To/From AccountType", "invalid to/from account combination"));
+                    var type = GetTransferType(request);
+                    if (type == null)
+                        return SharedExecutionResult<SharedId>.Error(ArgumentError.Invalid("To/From AccountType", "invalid to/from account combination"));
 
-            // Get data
-            var transfer = await Account.TransferInternalAsync(
-                type.Value,
-                request.Quantity,
-                ct: ct).ConfigureAwait(false);
-            if (!transfer)
-                return transfer.AsExchangeResult<SharedId>(Exchange, null, default);
+                    // Get data
+                    var transfer = await Account.TransferInternalAsync(
+                        type.Value,
+                        request.Quantity,
+                        ct: ct).ConfigureAwait(false);
+                    if (!transfer)
+                        return SharedExecutionResult<SharedId>.Error(transfer);
 
-            return transfer.AsExchangeResult(Exchange, TradingMode.Spot, new SharedId(""));
+                    return SharedExecutionResult<SharedId>.Ok(transfer, new SharedId(""));
+                });
         }
 
         private TransferDirection? GetTransferType(TransferRequest request)

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiShared.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiShared.cs
@@ -20,7 +20,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
 
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
-        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(HyperLiquidExchange.Metadata, this);
 
 
         #region Balance Client
@@ -149,7 +149,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
                     if (symbol == null)
                         return HttpResult.Fail<SharedSpotTicker>(result, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
-                    return HttpResult.Ok(result, new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, symbol.Symbol!), symbol.Symbol!, symbol.MidPrice, null, null, symbol.BaseVolume, (symbol.MidPrice == null || symbol.PreviousDayPrice == 0) ? null : Math.Round((symbol.MidPrice.Value / symbol.PreviousDayPrice * 100 - 100) / 10, 3) * 10)
+                    return HttpResult.Ok(result, new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, symbol.Symbol!), symbol.Symbol!, symbol.MidPrice, null, null, symbol.BaseVolume, (symbol.MidPrice == null || symbol.PreviousDayPrice == 0) ? null : Math.Round((symbol.MidPrice.Value / symbol.PreviousDayPrice * 100 - 100) / 10, 3) * 10)
                     {
                         QuoteVolume = symbol.QuoteVolume
                     });
@@ -167,7 +167,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
                     if (!result.Success)
                         return HttpResult.Fail<SharedSpotTicker[]>(result);
 
-                    return HttpResult.Ok(result, result.Data.Tickers.Select(x => new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol!), x.Symbol!, x.MidPrice, null, null, x.BaseVolume, (x.MidPrice == null || x.PreviousDayPrice == 0) ? null : Math.Round((x.MidPrice.Value / x.PreviousDayPrice * 100 - 100) / 10, 3) * 10)
+                    return HttpResult.Ok(result, result.Data.Tickers.Select(x => new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Symbol!), x.Symbol!, x.MidPrice, null, null, x.BaseVolume, (x.MidPrice == null || x.PreviousDayPrice == 0) ? null : Math.Round((x.MidPrice.Value / x.PreviousDayPrice * 100 - 100) / 10, 3) * 10)
                     {
                         QuoteVolume = x.QuoteVolume
                     }).ToArray());
@@ -194,7 +194,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
                         return HttpResult.Fail<SharedBookTicker>(resultTicker, new ServerError(new ErrorInfo(ErrorType.Unknown, "No response")));
 
                     return HttpResult.Ok(resultTicker, new SharedBookTicker(
-                        ExchangeSymbolCache.ParseSymbol(_topicId, symbol),
+                        ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, symbol),
                         symbol,
                         resultTicker.Data.Levels.Asks[0].Price,
                         resultTicker.Data.Levels.Asks[0].Quantity,
@@ -227,21 +227,21 @@ namespace HyperLiquid.Net.Clients.SpotApi
                         PriceDecimals = 8 - s.BaseAsset.QuantityDecimals
                     }).ToArray();
 
-                    ExchangeSymbolCache.UpdateSymbolInfo(_topicId, resultData);
+                    ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData);
                     return HttpResult.Ok(result, resultData);
                 
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)
         {
-            if (!ExchangeSymbolCache.HasCached(_topicId))
+            if (!ExchangeSymbolCache.HasCached(_topicId, EnvironmentName, null))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<SharedSymbol[]>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicId, baseAsset));
+            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicId, EnvironmentName, null, baseAsset));
         }
 
         async Task<ExchangeCallResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(SharedSymbol symbol)
@@ -249,26 +249,26 @@ namespace HyperLiquid.Net.Clients.SpotApi
             if (symbol.TradingMode != TradingMode.Spot)
                 throw new ArgumentException(nameof(symbol), "Only Spot symbols allowed");
 
-            if (!ExchangeSymbolCache.HasCached(_topicId))
+            if (!ExchangeSymbolCache.HasCached(_topicId, EnvironmentName, null))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbol));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, EnvironmentName, null, symbol));
         }
 
         async Task<ExchangeCallResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(string symbolName)
         {
-            if (!ExchangeSymbolCache.HasCached(_topicId))
+            if (!ExchangeSymbolCache.HasCached(_topicId, EnvironmentName, null))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbolName));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, EnvironmentName, null, symbolName));
         }
         #endregion
 
@@ -337,7 +337,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
                         return HttpResult.Fail<SharedSpotOrder>(order);
 
                     return HttpResult.Ok(order, new SharedSpotOrder(
-                        ExchangeSymbolCache.ParseSymbol(_topicId, order.Data.Order.Symbol!),
+                        ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, order.Data.Order.Symbol!),
                         order.Data.Order.Symbol!,
                         order.Data.Order.OrderId.ToString(),
                         ParseOrderType(order.Data.Order.OrderType),
@@ -374,7 +374,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
                         data = data.Where(x => x.Symbol == symbol);
 
                     return HttpResult.Ok(orders, data.Select(x => new SharedSpotOrder(
-                        ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol),
+                        ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Symbol),
                         x.Symbol!,
                         x.OrderId.ToString(),
                         ParseOrderType(x.OrderType),
@@ -426,7 +426,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
                     return HttpResult.Ok(orders, ExchangeHelpers.ApplyFilter(data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
                                 .Select(x =>
                                     new SharedSpotOrder(
-                                        ExchangeSymbolCache.ParseSymbol(_topicId, x.Order.Symbol),
+                                        ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Order.Symbol),
                                         x.Order.Symbol!,
                                         x.Order.OrderId.ToString(),
                                         ParseOrderType(x.Order.OrderType),
@@ -463,7 +463,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
 
                     var data = orders.Data.Where(x => x.OrderId == orderId);
                     return HttpResult.Ok(orders, data.Select(x => new SharedUserTrade(
-                        ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol),
+                        ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Symbol),
                         x.Symbol,
                         x.OrderId.ToString(),
                         x.TradeId.ToString(),
@@ -513,7 +513,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
                     return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
                             .Select(x =>
                                 new SharedUserTrade(
-                                ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol),
+                                ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Symbol),
                                 x.Symbol,
                                 x.OrderId.ToString(),
                                 x.TradeId.ToString(),
@@ -634,7 +634,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
                         return HttpResult.Fail<SharedSpotOrder>(order);
 
                     return HttpResult.Ok(order, new SharedSpotOrder(
-                        ExchangeSymbolCache.ParseSymbol(_topicId, order.Data.Order.Symbol!),
+                        ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, order.Data.Order.Symbol!),
                         order.Data.Order.Symbol!,
                         order.Data.Order.OrderId.ToString(),
                         ParseOrderType(order.Data.Order.OrderType),

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiShared.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiShared.cs
@@ -32,12 +32,11 @@ namespace HyperLiquid.Net.Clients.SpotApi
             if (validationError != null)
                 return HttpResult.Fail<SharedBalance[]>(Exchange, validationError);
 
-                    var result = await Account.GetBalancesAsync(ct: ct).ConfigureAwait(false);
-                    if (!result.Success)
-                        return HttpResult.Fail<SharedBalance[]>(result);
+            var result = await Account.GetBalancesAsync(ct: ct).ConfigureAwait(false);
+            if (!result.Success)
+                return HttpResult.Fail<SharedBalance[]>(result);
 
-                    return HttpResult.Ok(result, result.Data.Select(x => new SharedBalance(HyperLiquidExchange.AssetAliases.ExchangeToCommonName(x.Asset), x.Total - x.Hold, x.Total)).ToArray());
-                
+            return HttpResult.Ok(result, result.Data.Select(x => new SharedBalance(HyperLiquidExchange.AssetAliases.ExchangeToCommonName(x.Asset), x.Total - x.Hold, x.Total)).ToArray());
         }
 
         #endregion
@@ -292,6 +291,10 @@ namespace HyperLiquid.Net.Clients.SpotApi
             RequiredOptionalParameters = new List<ParameterDescription>
             {
                 new ParameterDescription(nameof(PlaceSpotOrderRequest.Price), typeof(decimal), "Price for the order. For market orders this should be the current symbol price", 21.5m)
+            },
+            OptionalExchangeParameters = new List<ParameterDescription>
+            {
+                new ParameterDescription("vaultAddress", typeof(string), "Vault address to use for the order", "0x123...")
             }
         };
 
@@ -301,20 +304,21 @@ namespace HyperLiquid.Net.Clients.SpotApi
             if (validationError != null)
                 return HttpResult.Fail<SharedId>(Exchange, validationError);
 
-                    var result = await Trading.PlaceOrderAsync(
-                        request.Symbol!.GetSymbol(FormatSymbol),
-                        request.Side == SharedOrderSide.Buy ? Enums.OrderSide.Buy : Enums.OrderSide.Sell,
-                        request.OrderType == SharedOrderType.Limit || request.OrderType == SharedOrderType.LimitMaker ? Enums.OrderType.Limit : Enums.OrderType.Market,
-                        quantity: request.Quantity?.QuantityInBaseAsset ?? 0,
-                        price: request.Price!.Value,
-                        timeInForce: GetTimeInForce(request.TimeInForce, request.OrderType),
-                        clientOrderId: request.ClientOrderId,
-                        ct: ct).ConfigureAwait(false);
+            var result = await Trading.PlaceOrderAsync(
+                request.Symbol!.GetSymbol(FormatSymbol),
+                request.Side == SharedOrderSide.Buy ? Enums.OrderSide.Buy : Enums.OrderSide.Sell,
+                request.OrderType == SharedOrderType.Limit || request.OrderType == SharedOrderType.LimitMaker ? Enums.OrderType.Limit : Enums.OrderType.Market,
+                quantity: request.Quantity?.QuantityInBaseAsset ?? 0,
+                price: request.Price!.Value,
+                timeInForce: GetTimeInForce(request.TimeInForce, request.OrderType),
+                clientOrderId: request.ClientOrderId,
+                vaultAddress: request.GetParamValue<string?>(Exchange, "vaultAddress"),
+                ct: ct).ConfigureAwait(false);
 
-                    if (!result.Success)
-                        return HttpResult.Fail<SharedId>(result);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
-                    return HttpResult.Ok(result, new SharedId(result.Data.OrderId.ToString()));
+            return HttpResult.Ok(result, new SharedId(result.Data.OrderId.ToString()));
                 
         }
 
@@ -525,21 +529,31 @@ namespace HyperLiquid.Net.Clients.SpotApi
                 
         }
 
-        CancelSpotOrderOptions ISpotOrderRestClient.CancelSpotOrderOptions { get; } = new CancelSpotOrderOptions(_exchangeName, true);
+        CancelSpotOrderOptions ISpotOrderRestClient.CancelSpotOrderOptions { get; } = new CancelSpotOrderOptions(_exchangeName, true)
+        {
+            OptionalExchangeParameters = new List<ParameterDescription>
+            {
+                new ParameterDescription("vaultAddress", typeof(string), "Vault address to use for the order", "0x123...")
+            }
+        };
         async Task<HttpResult<SharedId>> ISpotOrderRestClient.CancelSpotOrderAsync(CancelOrderRequest request, CancellationToken ct)
         {
             var validationError = SharedClient.CancelSpotOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
                 return HttpResult.Fail<SharedId>(Exchange, validationError);
 
-                    if (!long.TryParse(request.OrderId, out var orderId))
-                        return HttpResult.Fail<SharedId>(Exchange, ArgumentError.Invalid(nameof(CancelOrderRequest.OrderId), "Invalid order id"));
+            if (!long.TryParse(request.OrderId, out var orderId))
+                return HttpResult.Fail<SharedId>(Exchange, ArgumentError.Invalid(nameof(CancelOrderRequest.OrderId), "Invalid order id"));
 
-                    var order = await Trading.CancelOrderAsync(request.Symbol!.GetSymbol(FormatSymbol), orderId, ct: ct).ConfigureAwait(false);
-                    if (!order.Success)
-                        return HttpResult.Fail<SharedId>(order);
+            var order = await Trading.CancelOrderAsync(
+                request.Symbol!.GetSymbol(FormatSymbol),
+                orderId, 
+                vaultAddress: request.GetParamValue<string?>(Exchange, "vaultAddress"),
+                ct: ct).ConfigureAwait(false);
+            if (!order.Success)
+                return HttpResult.Fail<SharedId>(order);
 
-                    return HttpResult.Ok(order, new SharedId(request.OrderId));
+            return HttpResult.Ok(order, new SharedId(request.OrderId));
                 
         }
 
@@ -640,18 +654,28 @@ namespace HyperLiquid.Net.Clients.SpotApi
                 
         }
 
-        CancelSpotOrderByClientOrderIdOptions ISpotOrderClientIdRestClient.CancelSpotOrderByClientOrderIdOptions { get; } = new CancelSpotOrderByClientOrderIdOptions(_exchangeName, true);
+        CancelSpotOrderByClientOrderIdOptions ISpotOrderClientIdRestClient.CancelSpotOrderByClientOrderIdOptions { get; } = new CancelSpotOrderByClientOrderIdOptions(_exchangeName, true)
+        {
+            OptionalExchangeParameters = new List<ParameterDescription>
+            {
+                new ParameterDescription("vaultAddress", typeof(string), "Vault address to use for the order", "0x123...")
+            }
+        };
         async Task<HttpResult<SharedId>> ISpotOrderClientIdRestClient.CancelSpotOrderByClientOrderIdAsync(CancelOrderRequest request, CancellationToken ct)
         {
             var validationError = SharedClient.CancelSpotOrderByClientOrderIdOptions.ValidateRequest(request, this);
             if (validationError != null)
                 return HttpResult.Fail<SharedId>(Exchange, validationError);
 
-                    var order = await Trading.CancelOrderByClientOrderIdAsync(request.Symbol!.GetSymbol(FormatSymbol), clientOrderId: request.OrderId, ct: ct).ConfigureAwait(false);
-                    if (!order.Success)
-                        return HttpResult.Fail<SharedId>(order);
+            var order = await Trading.CancelOrderByClientOrderIdAsync(
+                request.Symbol!.GetSymbol(FormatSymbol),
+                clientOrderId: request.OrderId,
+                vaultAddress: request.GetParamValue<string?>(Exchange, "vaultAddress"), 
+                ct: ct).ConfigureAwait(false);
+            if (!order.Success)
+                return HttpResult.Fail<SharedId>(order);
 
-                    return HttpResult.Ok(order, new SharedId(request.OrderId));
+            return HttpResult.Ok(order, new SharedId(request.OrderId));
                 
         }
         #endregion

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiShared.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiShared.cs
@@ -27,7 +27,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #region Balance Client
         GetBalancesOptions IBalanceRestClient.GetBalancesOptions { get; } = new GetBalancesOptions(_exchangeName, AccountTypeFilter.Spot);
 
-        Task<ExchangeWebResult<SharedBalance[]>> IBalanceRestClient.GetBalancesAsync(GetBalancesRequest request, CancellationToken ct)
+        Task<HttpResult<SharedBalance[]>> IBalanceRestClient.GetBalancesAsync(GetBalancesRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IBalanceRestClient, GetBalancesRequest, SharedBalance[]>(
                 this,
@@ -65,7 +65,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
             MaxTotalDataPoints = 5000
         };
 
-        Task<ExchangeWebResult<SharedKline[]>> IKlineRestClient.GetKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        Task<HttpResult<SharedKline[]>> IKlineRestClient.GetKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IKlineRestClient, GetKlinesRequest, SharedKline[]>(
                 this,
@@ -120,7 +120,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
 
         #region Order Book client
         GetOrderBookOptions IOrderBookRestClient.GetOrderBookOptions { get; } = new GetOrderBookOptions(_exchangeName, [20], false);
-        Task<ExchangeWebResult<SharedOrderBook>> IOrderBookRestClient.GetOrderBookAsync(GetOrderBookRequest request, CancellationToken ct)
+        Task<HttpResult<SharedOrderBook>> IOrderBookRestClient.GetOrderBookAsync(GetOrderBookRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IOrderBookRestClient, GetOrderBookRequest, SharedOrderBook>(
                 this,
@@ -147,7 +147,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #region Ticker client
 
         GetSpotTickerOptions ISpotTickerRestClient.GetSpotTickerOptions { get; } = new GetSpotTickerOptions(_exchangeName);
-        Task<ExchangeWebResult<SharedSpotTicker>> ISpotTickerRestClient.GetSpotTickerAsync(GetTickerRequest request, CancellationToken ct)
+        Task<HttpResult<SharedSpotTicker>> ISpotTickerRestClient.GetSpotTickerAsync(GetTickerRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<ISpotTickerRestClient, GetTickerRequest, SharedSpotTicker>(
                 this,
@@ -173,7 +173,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         }
 
         GetSpotTickersOptions ISpotTickerRestClient.GetSpotTickersOptions { get; } = new GetSpotTickersOptions(_exchangeName);
-        Task<ExchangeWebResult<SharedSpotTicker[]>> ISpotTickerRestClient.GetSpotTickersAsync(GetTickersRequest request, CancellationToken ct)
+        Task<HttpResult<SharedSpotTicker[]>> ISpotTickerRestClient.GetSpotTickersAsync(GetTickersRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<ISpotTickerRestClient, GetTickersRequest, SharedSpotTicker[]>(
                 this,
@@ -198,7 +198,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #region Book Ticker client
 
         EndpointOptions<GetBookTickerRequest, IBookTickerRestClient> IBookTickerRestClient.GetBookTickerOptions { get; } = new EndpointOptions<GetBookTickerRequest, IBookTickerRestClient>(_exchangeName, false);
-        Task<ExchangeWebResult<SharedBookTicker>> IBookTickerRestClient.GetBookTickerAsync(GetBookTickerRequest request, CancellationToken ct)
+        Task<HttpResult<SharedBookTicker>> IBookTickerRestClient.GetBookTickerAsync(GetBookTickerRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IBookTickerRestClient, GetBookTickerRequest, SharedBookTicker>(
                 this,
@@ -230,7 +230,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #region Spot Symbol client
         EndpointOptions<GetSymbolsRequest, ISpotSymbolRestClient> ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new EndpointOptions<GetSymbolsRequest, ISpotSymbolRestClient>(_exchangeName, false);
 
-        Task<ExchangeWebResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
+        Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<ISpotSymbolRestClient, GetSymbolsRequest, SharedSpotSymbol[]>(
                 this,
@@ -257,19 +257,19 @@ namespace HyperLiquid.Net.Clients.SpotApi
                 });
         }
 
-        async Task<ExchangeResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)
+        async Task<WebSocketResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)
         {
             if (!ExchangeSymbolCache.HasCached(_topicId))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols)
-                    return new ExchangeResult<SharedSymbol[]>(Exchange, symbols.Error!);
+                    return new WebSocketResult<SharedSymbol[]>(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<SharedSymbol[]>(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicId, baseAsset));
+            return new WebSocketResult<SharedSymbol[]>(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicId, baseAsset));
         }
 
-        async Task<ExchangeResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(SharedSymbol symbol)
+        async Task<WebSocketResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(SharedSymbol symbol)
         {
             if (symbol.TradingMode != TradingMode.Spot)
                 throw new ArgumentException(nameof(symbol), "Only Spot symbols allowed");
@@ -278,22 +278,22 @@ namespace HyperLiquid.Net.Clients.SpotApi
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols)
-                    return new ExchangeResult<bool>(Exchange, symbols.Error!);
+                    return new WebSocketResult<bool>(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbol));
+            return new WebSocketResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbol));
         }
 
-        async Task<ExchangeResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(string symbolName)
+        async Task<WebSocketResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(string symbolName)
         {
             if (!ExchangeSymbolCache.HasCached(_topicId))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols)
-                    return new ExchangeResult<bool>(Exchange, symbols.Error!);
+                    return new WebSocketResult<bool>(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbolName));
+            return new WebSocketResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbolName));
         }
         #endregion
 
@@ -319,7 +319,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
             }
         };
 
-        Task<ExchangeWebResult<SharedId>> ISpotOrderRestClient.PlaceSpotOrderAsync(PlaceSpotOrderRequest request, CancellationToken ct)
+        Task<HttpResult<SharedId>> ISpotOrderRestClient.PlaceSpotOrderAsync(PlaceSpotOrderRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<ISpotOrderRestClient, PlaceSpotOrderRequest, SharedId>(
                 this,
@@ -347,7 +347,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         }
 
         EndpointOptions<GetOrderRequest, ISpotOrderRestClient> ISpotOrderRestClient.GetSpotOrderOptions { get; } = new EndpointOptions<GetOrderRequest, ISpotOrderRestClient>(_exchangeName, true);
-        Task<ExchangeWebResult<SharedSpotOrder>> ISpotOrderRestClient.GetSpotOrderAsync(GetOrderRequest request, CancellationToken ct)
+        Task<HttpResult<SharedSpotOrder>> ISpotOrderRestClient.GetSpotOrderAsync(GetOrderRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<ISpotOrderRestClient, GetOrderRequest, SharedSpotOrder>(
                 this,
@@ -385,7 +385,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         }
 
         EndpointOptions<GetOpenOrdersRequest, ISpotOrderRestClient> ISpotOrderRestClient.GetOpenSpotOrdersOptions { get; } = new EndpointOptions<GetOpenOrdersRequest, ISpotOrderRestClient>(_exchangeName, true);
-        Task<ExchangeWebResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetOpenSpotOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
+        Task<HttpResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetOpenSpotOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<ISpotOrderRestClient, GetOpenOrdersRequest, SharedSpotOrder[]>(
                 this,
@@ -428,7 +428,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         {
             RequestNotes = "API request doesn't allow filtering, so filtering is done client side. This might result in missing historical data as only up to 2000 results are returned from the API"
         };
-        Task<ExchangeWebResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetClosedSpotOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageToken, CancellationToken ct)
+        Task<HttpResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetClosedSpotOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageToken, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<ISpotOrderRestClient, GetClosedOrdersRequest, SharedSpotOrder[]>(
                 this,
@@ -481,7 +481,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         }
 
         EndpointOptions<GetOrderTradesRequest, ISpotOrderRestClient> ISpotOrderRestClient.GetSpotOrderTradesOptions { get; } = new EndpointOptions<GetOrderTradesRequest, ISpotOrderRestClient>(_exchangeName, true);
-        Task<ExchangeWebResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
+        Task<HttpResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<ISpotOrderRestClient, GetOrderTradesRequest, SharedUserTrade[]>(
                 this,
@@ -519,7 +519,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         {
             RequestNotes = "API request doesn't allow filtering, so filtering is done client side. This might result in missing historical data as only up to 2000 per request / 10000 results in total are returned from the API"
         };
-        Task<ExchangeWebResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        Task<HttpResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<ISpotOrderRestClient, GetUserTradesRequest, SharedUserTrade[]>(
                 this,
@@ -569,7 +569,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         }
 
         EndpointOptions<CancelOrderRequest, ISpotOrderRestClient> ISpotOrderRestClient.CancelSpotOrderOptions { get; } = new EndpointOptions<CancelOrderRequest, ISpotOrderRestClient>(_exchangeName, true);
-        Task<ExchangeWebResult<SharedId>> ISpotOrderRestClient.CancelSpotOrderAsync(CancelOrderRequest request, CancellationToken ct)
+        Task<HttpResult<SharedId>> ISpotOrderRestClient.CancelSpotOrderAsync(CancelOrderRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<ISpotOrderRestClient, CancelOrderRequest, SharedId>(
                 this,
@@ -655,7 +655,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #region Spot Client Id Order Client
 
         EndpointOptions<GetOrderRequest, ISpotOrderClientIdRestClient> ISpotOrderClientIdRestClient.GetSpotOrderByClientOrderIdOptions { get; } = new EndpointOptions<GetOrderRequest, ISpotOrderClientIdRestClient>(_exchangeName, true);
-        Task<ExchangeWebResult<SharedSpotOrder>> ISpotOrderClientIdRestClient.GetSpotOrderByClientOrderIdAsync(GetOrderRequest request, CancellationToken ct)
+        Task<HttpResult<SharedSpotOrder>> ISpotOrderClientIdRestClient.GetSpotOrderByClientOrderIdAsync(GetOrderRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<ISpotOrderClientIdRestClient, GetOrderRequest, SharedSpotOrder>(
                 this,
@@ -690,7 +690,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         }
 
         EndpointOptions<CancelOrderRequest, ISpotOrderClientIdRestClient> ISpotOrderClientIdRestClient.CancelSpotOrderByClientOrderIdOptions { get; } = new EndpointOptions<CancelOrderRequest, ISpotOrderClientIdRestClient>(_exchangeName, true);
-        Task<ExchangeWebResult<SharedId>> ISpotOrderClientIdRestClient.CancelSpotOrderByClientOrderIdAsync(CancelOrderRequest request, CancellationToken ct)
+        Task<HttpResult<SharedId>> ISpotOrderClientIdRestClient.CancelSpotOrderByClientOrderIdAsync(CancelOrderRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<ISpotOrderClientIdRestClient, CancelOrderRequest, SharedId>(
                 this,
@@ -711,7 +711,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #region Asset client
         EndpointOptions<GetAssetsRequest, IAssetsRestClient> IAssetsRestClient.GetAssetsOptions { get; } = new EndpointOptions<GetAssetsRequest, IAssetsRestClient>(_exchangeName, true);
 
-        Task<ExchangeWebResult<SharedAsset[]>> IAssetsRestClient.GetAssetsAsync(GetAssetsRequest request, CancellationToken ct)
+        Task<HttpResult<SharedAsset[]>> IAssetsRestClient.GetAssetsAsync(GetAssetsRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IAssetsRestClient, GetAssetsRequest, SharedAsset[]>(
                 this,
@@ -735,7 +735,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         }
 
         EndpointOptions<GetAssetRequest, IAssetsRestClient> IAssetsRestClient.GetAssetOptions { get; } = new EndpointOptions<GetAssetRequest, IAssetsRestClient>(_exchangeName, false);
-        Task<ExchangeWebResult<SharedAsset>> IAssetsRestClient.GetAssetAsync(GetAssetRequest request, CancellationToken ct)
+        Task<HttpResult<SharedAsset>> IAssetsRestClient.GetAssetAsync(GetAssetRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IAssetsRestClient, GetAssetRequest, SharedAsset>(
                 this,
@@ -767,7 +767,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #region Fee Client
         EndpointOptions<GetFeeRequest, IFeeRestClient> IFeeRestClient.GetFeeOptions { get; } = new EndpointOptions<GetFeeRequest, IFeeRestClient>(_exchangeName, true);
 
-        Task<ExchangeWebResult<SharedFee>> IFeeRestClient.GetFeesAsync(GetFeeRequest request, CancellationToken ct)
+        Task<HttpResult<SharedFee>> IFeeRestClient.GetFeesAsync(GetFeeRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IFeeRestClient, GetFeeRequest, SharedFee>(
                 this,
@@ -790,7 +790,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #region Withdraw client
 
         WithdrawOptions IWithdrawRestClient.WithdrawOptions { get; } = new WithdrawOptions(_exchangeName);
-        Task<ExchangeWebResult<SharedId>> IWithdrawRestClient.WithdrawAsync(WithdrawRequest request, CancellationToken ct)
+        Task<HttpResult<SharedId>> IWithdrawRestClient.WithdrawAsync(WithdrawRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<IWithdrawRestClient, WithdrawRequest, SharedId>(
                 this,
@@ -823,7 +823,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
             SharedAccountType.DeliveryInverseFutures,
             SharedAccountType.Spot
             ]);
-        Task<ExchangeWebResult<SharedId>> ITransferRestClient.TransferAsync(TransferRequest request, CancellationToken ct)
+        Task<HttpResult<SharedId>> ITransferRestClient.TransferAsync(TransferRequest request, CancellationToken ct)
         {
             return SharedUtils.ExecuteSharedAsync<ITransferRestClient, TransferRequest, SharedId>(
                 this,

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiShared.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiShared.cs
@@ -16,32 +16,28 @@ namespace HyperLiquid.Net.Clients.SpotApi
     {
         private const string _exchangeName = "HyperLiquid";
         private const string _topicId = "HyperLiquidSpot";
-        public string Exchange => "HyperLiquid";
-
         public TradingMode[] SupportedTradingModes => new[] { TradingMode.Spot };
 
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
 
 
         #region Balance Client
         GetBalancesOptions IBalanceRestClient.GetBalancesOptions { get; } = new GetBalancesOptions(_exchangeName, AccountTypeFilter.Spot);
 
-        Task<HttpResult<SharedBalance[]>> IBalanceRestClient.GetBalancesAsync(GetBalancesRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedBalance[]>> IBalanceRestClient.GetBalancesAsync(GetBalancesRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IBalanceRestClient, GetBalancesRequest, SharedBalance[]>(
-                this,
-                client => client.GetBalancesOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetBalancesOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedBalance[]>(Exchange, validationError);
 
                     var result = await Account.GetBalancesAsync(ct: ct).ConfigureAwait(false);
-                    if (!result)
-                        return SharedExecutionResult<SharedBalance[]>.Error(result);
+                    if (!result.Success)
+                        return HttpResult.Fail<SharedBalance[]>(result);
 
-                    return SharedExecutionResult<SharedBalance[]>.Ok(result, result.Data.Select(x => new SharedBalance(HyperLiquidExchange.AssetAliases.ExchangeToCommonName(x.Asset), x.Total - x.Hold, x.Total)).ToArray());
-                });
+                    return HttpResult.Ok(result, result.Data.Select(x => new SharedBalance(HyperLiquidExchange.AssetAliases.ExchangeToCommonName(x.Asset), x.Total - x.Hold, x.Total)).ToArray());
+                
         }
 
         #endregion
@@ -65,17 +61,12 @@ namespace HyperLiquid.Net.Clients.SpotApi
             MaxTotalDataPoints = 5000
         };
 
-        Task<HttpResult<SharedKline[]>> IKlineRestClient.GetKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        async Task<HttpResult<SharedKline[]>> IKlineRestClient.GetKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IKlineRestClient, GetKlinesRequest, SharedKline[]>(
-                this,
-                client => client.GetKlinesOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetKlinesOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedKline[]>(Exchange, validationError);
                     var interval = (Enums.KlineInterval)request.Interval;
-                    if (!Enum.IsDefined(typeof(Enums.KlineInterval), interval))
-                        return SharedExecutionResult<SharedKline[]>.Error(ArgumentError.Invalid(nameof(GetKlinesRequest.Interval), "Interval not supported"));
 
                     var symbol = request.Symbol!.GetSymbol(FormatSymbol);
                     int limit = request.Limit ?? 1000;
@@ -90,8 +81,8 @@ namespace HyperLiquid.Net.Clients.SpotApi
                         endTime: pageParams.EndTime ?? DateTime.UtcNow,
                         ct: ct
                         ).ConfigureAwait(false);
-                    if (!result)
-                        return SharedExecutionResult<SharedKline[]>.Error(result);
+                    if (!result.Success)
+                        return HttpResult.Fail<SharedKline[]>(result);
 
                     var nextPageRequest = Pagination.GetNextPageRequest(
                              () => Pagination.NextPageFromTime(pageParams, result.Data.Min(x => x.OpenTime)),
@@ -101,7 +92,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
                              request.EndTime ?? DateTime.UtcNow,
                              pageParams);
 
-                    return SharedExecutionResult<SharedKline[]>.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.OpenTime, request.StartTime, request.EndTime, direction)
+                    return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.OpenTime, request.StartTime, request.EndTime, direction)
                             .Select(x =>
                                 new SharedKline(
                                     request.Symbol,
@@ -113,33 +104,30 @@ namespace HyperLiquid.Net.Clients.SpotApi
                                     x.OpenPrice,
                                     x.Volume))
                             .ToArray(), nextPageRequest);
-                });
+                
         }
 
         #endregion
 
         #region Order Book client
         GetOrderBookOptions IOrderBookRestClient.GetOrderBookOptions { get; } = new GetOrderBookOptions(_exchangeName, [20], false);
-        Task<HttpResult<SharedOrderBook>> IOrderBookRestClient.GetOrderBookAsync(GetOrderBookRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedOrderBook>> IOrderBookRestClient.GetOrderBookAsync(GetOrderBookRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IOrderBookRestClient, GetOrderBookRequest, SharedOrderBook>(
-                this,
-                client => client.GetOrderBookOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetOrderBookOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedOrderBook>(Exchange, validationError);
 
                     var result = await ExchangeData.GetOrderBookAsync(
                         request.Symbol!.GetSymbol(FormatSymbol),
                         ct: ct).ConfigureAwait(false);
-                    if (!result)
-                        return SharedExecutionResult<SharedOrderBook>.Error(result);
+                    if (!result.Success)
+                        return HttpResult.Fail<SharedOrderBook>(result);
 
                     if (result.Data == null)
-                        return SharedExecutionResult<SharedOrderBook>.Error(result.AsError<SharedOrderBook>(new ServerError(ErrorInfo.Unknown with { Message = "No response" })));
+                        return HttpResult.Fail<SharedOrderBook>(result, new ServerError(ErrorInfo.Unknown with { Message = "No response" }));
 
-                    return SharedExecutionResult<SharedOrderBook>.Ok(result, new SharedOrderBook(result.Data.Levels.Asks, result.Data.Levels.Bids));
-                });
+                    return HttpResult.Ok(result, new SharedOrderBook(result.Data.Levels.Asks, result.Data.Levels.Bids));
+                
         }
 
         #endregion
@@ -147,101 +135,89 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #region Ticker client
 
         GetSpotTickerOptions ISpotTickerRestClient.GetSpotTickerOptions { get; } = new GetSpotTickerOptions(_exchangeName);
-        Task<HttpResult<SharedSpotTicker>> ISpotTickerRestClient.GetSpotTickerAsync(GetTickerRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedSpotTicker>> ISpotTickerRestClient.GetSpotTickerAsync(GetTickerRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<ISpotTickerRestClient, GetTickerRequest, SharedSpotTicker>(
-                this,
-                client => client.GetSpotTickerOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetSpotTickerOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedSpotTicker>(Exchange, validationError);
 
                     var symbolName = request.Symbol!.GetSymbol(FormatSymbol);
                     var result = await ExchangeData.GetExchangeInfoAndTickersAsync(ct: ct).ConfigureAwait(false);
-                    if (!result)
-                        return SharedExecutionResult<SharedSpotTicker>.Error(result);
+                    if (!result.Success)
+                        return HttpResult.Fail<SharedSpotTicker>(result);
 
                     var symbol = result.Data.Tickers.SingleOrDefault(x => x.Symbol == symbolName);
                     if (symbol == null)
-                        return SharedExecutionResult<SharedSpotTicker>.Error(result.AsError<SharedSpotTicker>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found"))));
+                        return HttpResult.Fail<SharedSpotTicker>(result, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
-                    return SharedExecutionResult<SharedSpotTicker>.Ok(result, new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, symbol.Symbol!), symbol.Symbol!, symbol.MidPrice, null, null, symbol.BaseVolume, (symbol.MidPrice == null || symbol.PreviousDayPrice == 0) ? null : Math.Round((symbol.MidPrice.Value / symbol.PreviousDayPrice * 100 - 100) / 10, 3) * 10)
+                    return HttpResult.Ok(result, new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, symbol.Symbol!), symbol.Symbol!, symbol.MidPrice, null, null, symbol.BaseVolume, (symbol.MidPrice == null || symbol.PreviousDayPrice == 0) ? null : Math.Round((symbol.MidPrice.Value / symbol.PreviousDayPrice * 100 - 100) / 10, 3) * 10)
                     {
                         QuoteVolume = symbol.QuoteVolume
                     });
-                });
+                
         }
 
         GetSpotTickersOptions ISpotTickerRestClient.GetSpotTickersOptions { get; } = new GetSpotTickersOptions(_exchangeName);
-        Task<HttpResult<SharedSpotTicker[]>> ISpotTickerRestClient.GetSpotTickersAsync(GetTickersRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedSpotTicker[]>> ISpotTickerRestClient.GetSpotTickersAsync(GetTickersRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<ISpotTickerRestClient, GetTickersRequest, SharedSpotTicker[]>(
-                this,
-                client => client.GetSpotTickersOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetSpotTickersOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedSpotTicker[]>(Exchange, validationError);
 
                     var result = await ExchangeData.GetExchangeInfoAndTickersAsync(ct: ct).ConfigureAwait(false);
-                    if (!result)
-                        return SharedExecutionResult<SharedSpotTicker[]>.Error(result);
+                    if (!result.Success)
+                        return HttpResult.Fail<SharedSpotTicker[]>(result);
 
-                    return SharedExecutionResult<SharedSpotTicker[]>.Ok(result, result.Data.Tickers.Select(x => new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol!), x.Symbol!, x.MidPrice, null, null, x.BaseVolume, (x.MidPrice == null || x.PreviousDayPrice == 0) ? null : Math.Round((x.MidPrice.Value / x.PreviousDayPrice * 100 - 100) / 10, 3) * 10)
+                    return HttpResult.Ok(result, result.Data.Tickers.Select(x => new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol!), x.Symbol!, x.MidPrice, null, null, x.BaseVolume, (x.MidPrice == null || x.PreviousDayPrice == 0) ? null : Math.Round((x.MidPrice.Value / x.PreviousDayPrice * 100 - 100) / 10, 3) * 10)
                     {
                         QuoteVolume = x.QuoteVolume
                     }).ToArray());
-                });
+                
         }
 
         #endregion
 
         #region Book Ticker client
 
-        EndpointOptions<GetBookTickerRequest, IBookTickerRestClient> IBookTickerRestClient.GetBookTickerOptions { get; } = new EndpointOptions<GetBookTickerRequest, IBookTickerRestClient>(_exchangeName, false);
-        Task<HttpResult<SharedBookTicker>> IBookTickerRestClient.GetBookTickerAsync(GetBookTickerRequest request, CancellationToken ct)
+        GetBookTickerOptions IBookTickerRestClient.GetBookTickerOptions { get; } = new GetBookTickerOptions(_exchangeName, false);
+        async Task<HttpResult<SharedBookTicker>> IBookTickerRestClient.GetBookTickerAsync(GetBookTickerRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IBookTickerRestClient, GetBookTickerRequest, SharedBookTicker>(
-                this,
-                client => client.GetBookTickerOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetBookTickerOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedBookTicker>(Exchange, validationError);
 
                     var symbol = request.Symbol!.GetSymbol(FormatSymbol);
                     var resultTicker = await ExchangeData.GetOrderBookAsync(symbol, ct: ct).ConfigureAwait(false);
-                    if (!resultTicker)
-                        return SharedExecutionResult<SharedBookTicker>.Error(resultTicker);
+                    if (!resultTicker.Success)
+                        return HttpResult.Fail<SharedBookTicker>(resultTicker);
 
                     if (resultTicker.Data == null)
-                        return SharedExecutionResult<SharedBookTicker>.Error(resultTicker.AsError<SharedBookTicker>(new ServerError(new ErrorInfo(ErrorType.Unknown, "No response"))));
+                        return HttpResult.Fail<SharedBookTicker>(resultTicker, new ServerError(new ErrorInfo(ErrorType.Unknown, "No response")));
 
-                    return SharedExecutionResult<SharedBookTicker>.Ok(resultTicker, new SharedBookTicker(
+                    return HttpResult.Ok(resultTicker, new SharedBookTicker(
                         ExchangeSymbolCache.ParseSymbol(_topicId, symbol),
                         symbol,
                         resultTicker.Data.Levels.Asks[0].Price,
                         resultTicker.Data.Levels.Asks[0].Quantity,
                         resultTicker.Data.Levels.Bids[0].Price,
                         resultTicker.Data.Levels.Bids[0].Quantity));
-                });
+                
         }
 
         #endregion
 
         #region Spot Symbol client
-        EndpointOptions<GetSymbolsRequest, ISpotSymbolRestClient> ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new EndpointOptions<GetSymbolsRequest, ISpotSymbolRestClient>(_exchangeName, false);
+        GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false);
 
-        Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<ISpotSymbolRestClient, GetSymbolsRequest, SharedSpotSymbol[]>(
-                this,
-                client => client.GetSpotSymbolsOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetSpotSymbolsOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedSpotSymbol[]>(Exchange, validationError);
 
                     var result = await ExchangeData.GetExchangeInfoAsync(ct: ct).ConfigureAwait(false);
-                    if (!result)
-                        return SharedExecutionResult<SharedSpotSymbol[]>.Error(result);
+                    if (!result.Success)
+                        return HttpResult.Fail<SharedSpotSymbol[]>(result);
 
                     var resultData = result.Data.Symbols.Select(s => new SharedSpotSymbol(HyperLiquidExchange.AssetAliases.ExchangeToCommonName(s.BaseAsset.Name), HyperLiquidExchange.AssetAliases.ExchangeToCommonName(s.QuoteAsset.Name), s.Name, true)
                     {
@@ -253,23 +229,23 @@ namespace HyperLiquid.Net.Clients.SpotApi
                     }).ToArray();
 
                     ExchangeSymbolCache.UpdateSymbolInfo(_topicId, resultData);
-                    return SharedExecutionResult<SharedSpotSymbol[]>.Ok(result, resultData);
-                });
+                    return HttpResult.Ok(result, resultData);
+                
         }
 
-        async Task<WebSocketResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)
+        async Task<ExchangeCallResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)
         {
             if (!ExchangeSymbolCache.HasCached(_topicId))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new WebSocketResult<SharedSymbol[]>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<SharedSymbol[]>.Fail(Exchange, symbols.Error!);
             }
 
-            return new WebSocketResult<SharedSymbol[]>(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicId, baseAsset));
+            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicId, baseAsset));
         }
 
-        async Task<WebSocketResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(SharedSymbol symbol)
+        async Task<ExchangeCallResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(SharedSymbol symbol)
         {
             if (symbol.TradingMode != TradingMode.Spot)
                 throw new ArgumentException(nameof(symbol), "Only Spot symbols allowed");
@@ -277,23 +253,23 @@ namespace HyperLiquid.Net.Clients.SpotApi
             if (!ExchangeSymbolCache.HasCached(_topicId))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new WebSocketResult<bool>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return new WebSocketResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbol));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbol));
         }
 
-        async Task<WebSocketResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(string symbolName)
+        async Task<ExchangeCallResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(string symbolName)
         {
             if (!ExchangeSymbolCache.HasCached(_topicId))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new WebSocketResult<bool>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return new WebSocketResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbolName));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbolName));
         }
         #endregion
 
@@ -319,14 +295,11 @@ namespace HyperLiquid.Net.Clients.SpotApi
             }
         };
 
-        Task<HttpResult<SharedId>> ISpotOrderRestClient.PlaceSpotOrderAsync(PlaceSpotOrderRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> ISpotOrderRestClient.PlaceSpotOrderAsync(PlaceSpotOrderRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<ISpotOrderRestClient, PlaceSpotOrderRequest, SharedId>(
-                this,
-                client => client.PlaceSpotOrderOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.PlaceSpotOrderOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
                     var result = await Trading.PlaceOrderAsync(
                         request.Symbol!.GetSymbol(FormatSymbol),
@@ -336,34 +309,30 @@ namespace HyperLiquid.Net.Clients.SpotApi
                         price: request.Price!.Value,
                         timeInForce: GetTimeInForce(request.TimeInForce, request.OrderType),
                         clientOrderId: request.ClientOrderId,
-                        rawParameter: request.ExchangeParameters?.GetRawParameters(Exchange),
                         ct: ct).ConfigureAwait(false);
 
-                    if (!result)
-                        return SharedExecutionResult<SharedId>.Error(result);
+                    if (!result.Success)
+                        return HttpResult.Fail<SharedId>(result);
 
-                    return SharedExecutionResult<SharedId>.Ok(result, new SharedId(result.Data.OrderId.ToString()));
-                });
+                    return HttpResult.Ok(result, new SharedId(result.Data.OrderId.ToString()));
+                
         }
 
-        EndpointOptions<GetOrderRequest, ISpotOrderRestClient> ISpotOrderRestClient.GetSpotOrderOptions { get; } = new EndpointOptions<GetOrderRequest, ISpotOrderRestClient>(_exchangeName, true);
-        Task<HttpResult<SharedSpotOrder>> ISpotOrderRestClient.GetSpotOrderAsync(GetOrderRequest request, CancellationToken ct)
+        GetSpotOrderOptions ISpotOrderRestClient.GetSpotOrderOptions { get; } = new GetSpotOrderOptions(_exchangeName, true);
+        async Task<HttpResult<SharedSpotOrder>> ISpotOrderRestClient.GetSpotOrderAsync(GetOrderRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<ISpotOrderRestClient, GetOrderRequest, SharedSpotOrder>(
-                this,
-                client => client.GetSpotOrderOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetSpotOrderOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedSpotOrder>(Exchange, validationError);
 
                     if (!long.TryParse(request.OrderId, out var orderId))
-                        return SharedExecutionResult<SharedSpotOrder>.Error(ArgumentError.Invalid(nameof(GetOrderRequest.OrderId), "Invalid order id"));
+                        return HttpResult.Fail<SharedSpotOrder>(Exchange, ArgumentError.Invalid(nameof(GetOrderRequest.OrderId), "Invalid order id"));
 
                     var order = await Trading.GetOrderAsync(orderId, ct: ct).ConfigureAwait(false);
-                    if (!order)
-                        return SharedExecutionResult<SharedSpotOrder>.Error(order);
+                    if (!order.Success)
+                        return HttpResult.Fail<SharedSpotOrder>(order);
 
-                    return SharedExecutionResult<SharedSpotOrder>.Ok(order, new SharedSpotOrder(
+                    return HttpResult.Ok(order, new SharedSpotOrder(
                         ExchangeSymbolCache.ParseSymbol(_topicId, order.Data.Order.Symbol!),
                         order.Data.Order.Symbol!,
                         order.Data.Order.OrderId.ToString(),
@@ -381,29 +350,26 @@ namespace HyperLiquid.Net.Clients.SpotApi
                         TriggerPrice = order.Data.Order.TriggerPrice,
                         IsTriggerOrder = order.Data.Order.TriggerPrice > 0
                     });
-                });
+                
         }
 
-        EndpointOptions<GetOpenOrdersRequest, ISpotOrderRestClient> ISpotOrderRestClient.GetOpenSpotOrdersOptions { get; } = new EndpointOptions<GetOpenOrdersRequest, ISpotOrderRestClient>(_exchangeName, true);
-        Task<HttpResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetOpenSpotOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
+        GetOpenSpotOrdersOptions ISpotOrderRestClient.GetOpenSpotOrdersOptions { get; } = new GetOpenSpotOrdersOptions(_exchangeName, true);
+        async Task<HttpResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetOpenSpotOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<ISpotOrderRestClient, GetOpenOrdersRequest, SharedSpotOrder[]>(
-                this,
-                client => client.GetOpenSpotOrdersOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetOpenSpotOrdersOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedSpotOrder[]>(Exchange, validationError);
 
                     var symbol = request.Symbol?.GetSymbol(FormatSymbol);
                     var orders = await Trading.GetOpenOrdersExtendedAsync(ct: ct).ConfigureAwait(false);
-                    if (!orders)
-                        return SharedExecutionResult<SharedSpotOrder[]>.Error(orders);
+                    if (!orders.Success)
+                        return HttpResult.Fail<SharedSpotOrder[]>(orders);
 
                     var data = orders.Data.Where(x => x.SymbolType == Enums.SymbolType.Spot);
                     if (symbol != null)
                         data = data.Where(x => x.Symbol == symbol);
 
-                    return SharedExecutionResult<SharedSpotOrder[]>.Ok(orders, data.Select(x => new SharedSpotOrder(
+                    return HttpResult.Ok(orders, data.Select(x => new SharedSpotOrder(
                         ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol),
                         x.Symbol!,
                         x.OrderId.ToString(),
@@ -421,26 +387,23 @@ namespace HyperLiquid.Net.Clients.SpotApi
                         TriggerPrice = x.TriggerPrice,
                         IsTriggerOrder = x.TriggerPrice > 0
                     }).ToArray());
-                });
+                
         }
 
         GetSpotClosedOrdersOptions ISpotOrderRestClient.GetClosedSpotOrdersOptions { get; } = new GetSpotClosedOrdersOptions(_exchangeName, true, true, false, 2000)
         {
             RequestNotes = "API request doesn't allow filtering, so filtering is done client side. This might result in missing historical data as only up to 2000 results are returned from the API"
         };
-        Task<HttpResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetClosedSpotOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageToken, CancellationToken ct)
+        async Task<HttpResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetClosedSpotOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageToken, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<ISpotOrderRestClient, GetClosedOrdersRequest, SharedSpotOrder[]>(
-                this,
-                client => client.GetClosedSpotOrdersOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetClosedSpotOrdersOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedSpotOrder[]>(Exchange, validationError);
 
                     // Get data
                     var orders = await Trading.GetOrderHistoryAsync(ct: ct).ConfigureAwait(false);
-                    if (!orders)
-                        return SharedExecutionResult<SharedSpotOrder[]>.Error(orders);
+                    if (!orders.Success)
+                        return HttpResult.Fail<SharedSpotOrder[]>(orders);
 
                     var direction = request.Direction ?? DataDirection.Ascending;
                     var symbol = request.Symbol!.GetSymbol(FormatSymbol);
@@ -456,7 +419,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
                     if (request.Limit != null)
                         data = data.Take(request.Limit.Value);
 
-                    return SharedExecutionResult<SharedSpotOrder[]>.Ok(orders, ExchangeHelpers.ApplyFilter(data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
+                    return HttpResult.Ok(orders, ExchangeHelpers.ApplyFilter(data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
                                 .Select(x =>
                                     new SharedSpotOrder(
                                         ExchangeSymbolCache.ParseSymbol(_topicId, x.Order.Symbol),
@@ -477,28 +440,25 @@ namespace HyperLiquid.Net.Clients.SpotApi
                                         IsTriggerOrder = x.Order.TriggerPrice > 0
                                     })
                                 .ToArray());
-                });
+                
         }
 
-        EndpointOptions<GetOrderTradesRequest, ISpotOrderRestClient> ISpotOrderRestClient.GetSpotOrderTradesOptions { get; } = new EndpointOptions<GetOrderTradesRequest, ISpotOrderRestClient>(_exchangeName, true);
-        Task<HttpResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
+        GetSpotOrderTradesOptions ISpotOrderRestClient.GetSpotOrderTradesOptions { get; } = new GetSpotOrderTradesOptions(_exchangeName, true);
+        async Task<HttpResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<ISpotOrderRestClient, GetOrderTradesRequest, SharedUserTrade[]>(
-                this,
-                client => client.GetSpotOrderTradesOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetSpotOrderTradesOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, validationError);
 
                     if (!long.TryParse(request.OrderId, out var orderId))
-                        return SharedExecutionResult<SharedUserTrade[]>.Error(ArgumentError.Invalid(nameof(GetOrderTradesRequest.OrderId), "Invalid order id"));
+                        return HttpResult.Fail<SharedUserTrade[]>(Exchange, ArgumentError.Invalid(nameof(GetOrderTradesRequest.OrderId), "Invalid order id"));
 
                     var orders = await Trading.GetUserTradesAsync(ct: ct).ConfigureAwait(false);
-                    if (!orders)
-                        return SharedExecutionResult<SharedUserTrade[]>.Error(orders);
+                    if (!orders.Success)
+                        return HttpResult.Fail<SharedUserTrade[]>(orders);
 
                     var data = orders.Data.Where(x => x.OrderId == orderId);
-                    return SharedExecutionResult<SharedUserTrade[]>.Ok(orders, data.Select(x => new SharedUserTrade(
+                    return HttpResult.Ok(orders, data.Select(x => new SharedUserTrade(
                         ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol),
                         x.Symbol,
                         x.OrderId.ToString(),
@@ -512,21 +472,18 @@ namespace HyperLiquid.Net.Clients.SpotApi
                         FeeAsset = HyperLiquidExchange.AssetAliases.ExchangeToCommonName(x.FeeToken),
                         Role = x.Crossed ? SharedRole.Taker : SharedRole.Maker
                     }).ToArray());
-                });
+                
         }
 
         GetSpotUserTradesOptions ISpotOrderRestClient.GetSpotUserTradesOptions { get; } = new GetSpotUserTradesOptions(_exchangeName, true, false, true, 2000)
         {
             RequestNotes = "API request doesn't allow filtering, so filtering is done client side. This might result in missing historical data as only up to 2000 per request / 10000 results in total are returned from the API"
         };
-        Task<HttpResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        async Task<HttpResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<ISpotOrderRestClient, GetUserTradesRequest, SharedUserTrade[]>(
-                this,
-                client => client.GetSpotUserTradesOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetSpotUserTradesOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, validationError);
 
                     int limit = request.Limit ?? 2000;
                     var direction = DataDirection.Ascending;
@@ -537,8 +494,8 @@ namespace HyperLiquid.Net.Clients.SpotApi
                         startTime: pageParams.StartTime ?? DateTime.UtcNow.AddDays(-7),
                         ct: ct
                         ).ConfigureAwait(false);
-                    if (!result)
-                        return SharedExecutionResult<SharedUserTrade[]>.Error(result);
+                    if (!result.Success)
+                        return HttpResult.Fail<SharedUserTrade[]>(result);
 
                     var data = result.Data.Where(x => x.Symbol == request.Symbol!.GetSymbol(FormatSymbol));
                     var nextPageRequest = Pagination.GetNextPageRequest(
@@ -549,7 +506,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
                              request.EndTime ?? DateTime.UtcNow,
                              pageParams);
 
-                    return SharedExecutionResult<SharedUserTrade[]>.Ok(result, ExchangeHelpers.ApplyFilter(data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
+                    return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(data, x => x.Timestamp, request.StartTime, request.EndTime, direction)
                             .Select(x =>
                                 new SharedUserTrade(
                                 ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol),
@@ -565,28 +522,25 @@ namespace HyperLiquid.Net.Clients.SpotApi
                                     FeeAsset = HyperLiquidExchange.AssetAliases.ExchangeToCommonName(x.FeeToken),
                                     Role = x.Crossed ? SharedRole.Taker : SharedRole.Maker
                                 }).ToArray(), nextPageRequest);
-                });
+                
         }
 
-        EndpointOptions<CancelOrderRequest, ISpotOrderRestClient> ISpotOrderRestClient.CancelSpotOrderOptions { get; } = new EndpointOptions<CancelOrderRequest, ISpotOrderRestClient>(_exchangeName, true);
-        Task<HttpResult<SharedId>> ISpotOrderRestClient.CancelSpotOrderAsync(CancelOrderRequest request, CancellationToken ct)
+        CancelSpotOrderOptions ISpotOrderRestClient.CancelSpotOrderOptions { get; } = new CancelSpotOrderOptions(_exchangeName, true);
+        async Task<HttpResult<SharedId>> ISpotOrderRestClient.CancelSpotOrderAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<ISpotOrderRestClient, CancelOrderRequest, SharedId>(
-                this,
-                client => client.CancelSpotOrderOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.CancelSpotOrderOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
                     if (!long.TryParse(request.OrderId, out var orderId))
-                        return SharedExecutionResult<SharedId>.Error(ArgumentError.Invalid(nameof(CancelOrderRequest.OrderId), "Invalid order id"));
+                        return HttpResult.Fail<SharedId>(Exchange, ArgumentError.Invalid(nameof(CancelOrderRequest.OrderId), "Invalid order id"));
 
                     var order = await Trading.CancelOrderAsync(request.Symbol!.GetSymbol(FormatSymbol), orderId, ct: ct).ConfigureAwait(false);
-                    if (!order)
-                        return SharedExecutionResult<SharedId>.Error(order);
+                    if (!order.Success)
+                        return HttpResult.Fail<SharedId>(order);
 
-                    return SharedExecutionResult<SharedId>.Ok(order, new SharedId(request.OrderId));
-                });
+                    return HttpResult.Ok(order, new SharedId(request.OrderId));
+                
         }
 
         private SharedTimeInForce? ParseTimeInForce(TimeInForce? timeInForce)
@@ -654,21 +608,18 @@ namespace HyperLiquid.Net.Clients.SpotApi
 
         #region Spot Client Id Order Client
 
-        EndpointOptions<GetOrderRequest, ISpotOrderClientIdRestClient> ISpotOrderClientIdRestClient.GetSpotOrderByClientOrderIdOptions { get; } = new EndpointOptions<GetOrderRequest, ISpotOrderClientIdRestClient>(_exchangeName, true);
-        Task<HttpResult<SharedSpotOrder>> ISpotOrderClientIdRestClient.GetSpotOrderByClientOrderIdAsync(GetOrderRequest request, CancellationToken ct)
+        GetSpotOrderByClientOrderIdOptions ISpotOrderClientIdRestClient.GetSpotOrderByClientOrderIdOptions { get; } = new GetSpotOrderByClientOrderIdOptions(_exchangeName, true);
+        async Task<HttpResult<SharedSpotOrder>> ISpotOrderClientIdRestClient.GetSpotOrderByClientOrderIdAsync(GetOrderRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<ISpotOrderClientIdRestClient, GetOrderRequest, SharedSpotOrder>(
-                this,
-                client => client.GetSpotOrderByClientOrderIdOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetSpotOrderByClientOrderIdOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedSpotOrder>(Exchange, validationError);
 
                     var order = await Trading.GetOrderAsync(clientOrderId: request.OrderId, ct: ct).ConfigureAwait(false);
-                    if (!order)
-                        return SharedExecutionResult<SharedSpotOrder>.Error(order);
+                    if (!order.Success)
+                        return HttpResult.Fail<SharedSpotOrder>(order);
 
-                    return SharedExecutionResult<SharedSpotOrder>.Ok(order, new SharedSpotOrder(
+                    return HttpResult.Ok(order, new SharedSpotOrder(
                         ExchangeSymbolCache.ParseSymbol(_topicId, order.Data.Order.Symbol!),
                         order.Data.Order.Symbol!,
                         order.Data.Order.OrderId.ToString(),
@@ -686,118 +637,103 @@ namespace HyperLiquid.Net.Clients.SpotApi
                         TriggerPrice = order.Data.Order.TriggerPrice,
                         IsTriggerOrder = order.Data.Order.TriggerPrice > 0
                     });
-                });
+                
         }
 
-        EndpointOptions<CancelOrderRequest, ISpotOrderClientIdRestClient> ISpotOrderClientIdRestClient.CancelSpotOrderByClientOrderIdOptions { get; } = new EndpointOptions<CancelOrderRequest, ISpotOrderClientIdRestClient>(_exchangeName, true);
-        Task<HttpResult<SharedId>> ISpotOrderClientIdRestClient.CancelSpotOrderByClientOrderIdAsync(CancelOrderRequest request, CancellationToken ct)
+        CancelSpotOrderByClientOrderIdOptions ISpotOrderClientIdRestClient.CancelSpotOrderByClientOrderIdOptions { get; } = new CancelSpotOrderByClientOrderIdOptions(_exchangeName, true);
+        async Task<HttpResult<SharedId>> ISpotOrderClientIdRestClient.CancelSpotOrderByClientOrderIdAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<ISpotOrderClientIdRestClient, CancelOrderRequest, SharedId>(
-                this,
-                client => client.CancelSpotOrderByClientOrderIdOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.CancelSpotOrderByClientOrderIdOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
                     var order = await Trading.CancelOrderByClientOrderIdAsync(request.Symbol!.GetSymbol(FormatSymbol), clientOrderId: request.OrderId, ct: ct).ConfigureAwait(false);
-                    if (!order)
-                        return SharedExecutionResult<SharedId>.Error(order);
+                    if (!order.Success)
+                        return HttpResult.Fail<SharedId>(order);
 
-                    return SharedExecutionResult<SharedId>.Ok(order, new SharedId(request.OrderId));
-                });
+                    return HttpResult.Ok(order, new SharedId(request.OrderId));
+                
         }
         #endregion
 
         #region Asset client
-        EndpointOptions<GetAssetsRequest, IAssetsRestClient> IAssetsRestClient.GetAssetsOptions { get; } = new EndpointOptions<GetAssetsRequest, IAssetsRestClient>(_exchangeName, true);
+        GetAssetsOptions IAssetsRestClient.GetAssetsOptions { get; } = new GetAssetsOptions(_exchangeName, true);
 
-        Task<HttpResult<SharedAsset[]>> IAssetsRestClient.GetAssetsAsync(GetAssetsRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedAsset[]>> IAssetsRestClient.GetAssetsAsync(GetAssetsRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IAssetsRestClient, GetAssetsRequest, SharedAsset[]>(
-                this,
-                client => client.GetAssetsOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetAssetsOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedAsset[]>(Exchange, validationError);
 
                     var assets = await ExchangeData.GetExchangeInfoAsync(ct: ct).ConfigureAwait(false);
-                    if (!assets)
-                        return SharedExecutionResult<SharedAsset[]>.Error(assets);
+                    if (!assets.Success)
+                        return HttpResult.Fail<SharedAsset[]>(assets);
 
-                    return SharedExecutionResult<SharedAsset[]>.Ok(assets, assets.Data.Assets.Select(x => new SharedAsset(HyperLiquidExchange.AssetAliases.ExchangeToCommonName(x.Name))
+                    return HttpResult.Ok(assets, assets.Data.Assets.Select(x => new SharedAsset(HyperLiquidExchange.AssetAliases.ExchangeToCommonName(x.Name))
                     {
                         FullName = x.FullName,
                         Networks = [new SharedAssetNetwork("HyperLiquid") {
                     ContractAddress = x.AssetId
                 }]
                     }).ToArray());
-                });
+                
         }
 
-        EndpointOptions<GetAssetRequest, IAssetsRestClient> IAssetsRestClient.GetAssetOptions { get; } = new EndpointOptions<GetAssetRequest, IAssetsRestClient>(_exchangeName, false);
-        Task<HttpResult<SharedAsset>> IAssetsRestClient.GetAssetAsync(GetAssetRequest request, CancellationToken ct)
+        GetAssetOptions IAssetsRestClient.GetAssetOptions { get; } = new GetAssetOptions(_exchangeName, false);
+        async Task<HttpResult<SharedAsset>> IAssetsRestClient.GetAssetAsync(GetAssetRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IAssetsRestClient, GetAssetRequest, SharedAsset>(
-                this,
-                client => client.GetAssetOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetAssetOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedAsset>(Exchange, validationError);
 
                     var assets = await ExchangeData.GetExchangeInfoAsync(ct: ct).ConfigureAwait(false);
-                    if (!assets)
-                        return SharedExecutionResult<SharedAsset>.Error(assets);
+                    if (!assets.Success)
+                        return HttpResult.Fail<SharedAsset>(assets);
 
                     var asset = assets.Data.Assets.SingleOrDefault(x => x.Name.Equals(HyperLiquidExchange.AssetAliases.CommonToExchangeName(request.Asset), StringComparison.InvariantCultureIgnoreCase));
                     if (asset == null)
-                        return SharedExecutionResult<SharedAsset>.Error(assets.AsError<SharedAsset>(new ServerError(new ErrorInfo(ErrorType.UnknownAsset, "Asset not found"))));
+                        return HttpResult.Fail<SharedAsset>(assets, new ServerError(new ErrorInfo(ErrorType.UnknownAsset, "Asset not found")));
 
-                    return SharedExecutionResult<SharedAsset>.Ok(assets, new SharedAsset(HyperLiquidExchange.AssetAliases.ExchangeToCommonName(asset.Name))
+                    return HttpResult.Ok(assets, new SharedAsset(HyperLiquidExchange.AssetAliases.ExchangeToCommonName(asset.Name))
                     {
                         FullName = asset.FullName,
                         Networks = [new SharedAssetNetwork("HyperLiquid") {
                     ContractAddress = asset.AssetId
                 }]
                     });
-                });
+                
         }
 
         #endregion
 
         #region Fee Client
-        EndpointOptions<GetFeeRequest, IFeeRestClient> IFeeRestClient.GetFeeOptions { get; } = new EndpointOptions<GetFeeRequest, IFeeRestClient>(_exchangeName, true);
+        GetFeeOptions IFeeRestClient.GetFeeOptions { get; } = new GetFeeOptions(_exchangeName, true);
 
-        Task<HttpResult<SharedFee>> IFeeRestClient.GetFeesAsync(GetFeeRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedFee>> IFeeRestClient.GetFeesAsync(GetFeeRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IFeeRestClient, GetFeeRequest, SharedFee>(
-                this,
-                client => client.GetFeeOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.GetFeeOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedFee>(Exchange, validationError);
 
                     // Get data
                     var result = await Account.GetFeeInfoAsync(ct: ct).ConfigureAwait(false);
-                    if (!result)
-                        return SharedExecutionResult<SharedFee>.Error(result);
+                    if (!result.Success)
+                        return HttpResult.Fail<SharedFee>(result);
 
                     // Return
-                    return SharedExecutionResult<SharedFee>.Ok(result, new SharedFee(result.Data.MakerFeeRateSpot * 100, result.Data.TakerFeeRateSpot * 100));
-                });
+                    return HttpResult.Ok(result, new SharedFee(result.Data.MakerFeeRateSpot * 100, result.Data.TakerFeeRateSpot * 100));
+                
         }
         #endregion
 
         #region Withdraw client
 
         WithdrawOptions IWithdrawRestClient.WithdrawOptions { get; } = new WithdrawOptions(_exchangeName);
-        Task<HttpResult<SharedId>> IWithdrawRestClient.WithdrawAsync(WithdrawRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> IWithdrawRestClient.WithdrawAsync(WithdrawRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<IWithdrawRestClient, WithdrawRequest, SharedId>(
-                this,
-                client => client.WithdrawOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.WithdrawOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
                     // Get data
                     var withdrawal = await Account.TransferSpotAsync(
@@ -805,11 +741,11 @@ namespace HyperLiquid.Net.Clients.SpotApi
                         HyperLiquidExchange.AssetAliases.CommonToExchangeName(request.Asset),
                         request.Quantity,
                         ct: ct).ConfigureAwait(false);
-                    if (!withdrawal)
-                        return SharedExecutionResult<SharedId>.Error(withdrawal);
+                    if (!withdrawal.Success)
+                        return HttpResult.Fail<SharedId>(withdrawal);
 
-                    return SharedExecutionResult<SharedId>.Ok(withdrawal, new SharedId(string.Empty));
-                });
+                    return HttpResult.Ok(withdrawal, new SharedId(string.Empty));
+                
         }
 
         #endregion
@@ -823,35 +759,32 @@ namespace HyperLiquid.Net.Clients.SpotApi
             SharedAccountType.DeliveryInverseFutures,
             SharedAccountType.Spot
             ]);
-        Task<HttpResult<SharedId>> ITransferRestClient.TransferAsync(TransferRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> ITransferRestClient.TransferAsync(TransferRequest request, CancellationToken ct)
         {
-            return SharedUtils.ExecuteSharedAsync<ITransferRestClient, TransferRequest, SharedId>(
-                this,
-                client => client.TransferOptions,
-                request,
-                async () =>
-                {
+            var validationError = SharedClient.TransferOptions.ValidateRequest(request, this);
+            if (validationError != null)
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
                     if (!request.Asset.Equals("USDC", StringComparison.InvariantCultureIgnoreCase)
                         && !request.Asset.Equals("USD", StringComparison.InvariantCultureIgnoreCase))
                     {
-                        return SharedExecutionResult<SharedId>.Error(ArgumentError.Invalid("Asset", "invalid asset, only USD is supported"));
+                        return HttpResult.Fail<SharedId>(Exchange, ArgumentError.Invalid("Asset", "invalid asset, only USD is supported"));
                     }
 
                     var type = GetTransferType(request);
                     if (type == null)
-                        return SharedExecutionResult<SharedId>.Error(ArgumentError.Invalid("To/From AccountType", "invalid to/from account combination"));
+                        return HttpResult.Fail<SharedId>(Exchange, ArgumentError.Invalid("To/From AccountType", "invalid to/from account combination"));
 
                     // Get data
                     var transfer = await Account.TransferInternalAsync(
                         type.Value,
                         request.Quantity,
                         ct: ct).ConfigureAwait(false);
-                    if (!transfer)
-                        return SharedExecutionResult<SharedId>.Error(transfer);
+                    if (!transfer.Success)
+                        return HttpResult.Fail<SharedId>(transfer);
 
-                    return SharedExecutionResult<SharedId>.Ok(transfer, new SharedId(""));
-                });
+                    return HttpResult.Ok(transfer, new SharedId(""));
+                
         }
 
         private TransferDirection? GetTransferType(TransferRequest request)

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiShared.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiShared.cs
@@ -336,7 +336,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
                         price: request.Price!.Value,
                         timeInForce: GetTimeInForce(request.TimeInForce, request.OrderType),
                         clientOrderId: request.ClientOrderId,
-                        rawParameter: request.ExchangeParameters?.GetCollection(Exchange),
+                        rawParameter: request.ExchangeParameters?.GetRawParameters(Exchange),
                         ct: ct).ConfigureAwait(false);
 
                     if (!result)

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiShared.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiShared.cs
@@ -36,7 +36,12 @@ namespace HyperLiquid.Net.Clients.SpotApi
             if (!result.Success)
                 return HttpResult.Fail<SharedBalance[]>(result);
 
-            return HttpResult.Ok(result, result.Data.Select(x => new SharedBalance(HyperLiquidExchange.AssetAliases.ExchangeToCommonName(x.Asset), x.Total - x.Hold, x.Total)).ToArray());
+            return HttpResult.Ok(result, result.Data.Select(x => 
+                new SharedBalance(
+                    SupportedTradingModes,
+                    HyperLiquidExchange.AssetAliases.ExchangeToCommonName(x.Asset), 
+                    x.Total - x.Hold, 
+                    x.Total)).ToArray());
         }
 
         #endregion

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidSocketClientSpotApi.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidSocketClientSpotApi.cs
@@ -19,12 +19,12 @@ namespace HyperLiquid.Net.Clients.SpotApi
         /// <summary>
         /// ctor
         /// </summary>
-        internal HyperLiquidSocketClientSpotApi(ILogger logger, HyperLiquidSocketClient baseClient, HyperLiquidSocketOptions options) :
-            base(logger, baseClient, options, options.SpotOptions)
+        internal HyperLiquidSocketClientSpotApi(ILoggerFactory? loggerFactory, HyperLiquidSocketClient baseClient, HyperLiquidSocketOptions options) :
+            base(loggerFactory, baseClient, options, options.SpotOptions)
         {
-            Account = new HyperLiquidSocketClientSpotApiAccount(logger, this);
-            ExchangeData = new HyperLiquidSocketClientSpotApiExchangeData(logger, this);
-            Trading = new HyperLiquidSocketClientSpotApiTrading(logger, this);
+            Account = new HyperLiquidSocketClientSpotApiAccount(_logger, this);
+            ExchangeData = new HyperLiquidSocketClientSpotApiExchangeData(_logger, this);
+            Trading = new HyperLiquidSocketClientSpotApiTrading(_logger, this);
         }
         #endregion
 

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidSocketClientSpotApiAccount.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidSocketClientSpotApiAccount.cs
@@ -20,12 +20,6 @@ namespace HyperLiquid.Net.Clients.SpotApi
     /// </summary>
     internal partial class HyperLiquidSocketClientSpotApiAccount : HyperLiquidSocketClientApiAccount, IHyperLiquidSocketClientSpotApiAccount
     {
-        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
-        {
-            Decimal = DecimalSerialization.String,
-            Sort = false
-        };
-
         #region constructor/destructor
 
         /// <summary>
@@ -40,7 +34,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #region Get Spot Balances
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidBalance[]>> GetBalancesAsync(string? address = null, CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidBalance[]>> GetBalancesAsync(string? address = null, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");
@@ -55,7 +49,10 @@ namespace HyperLiquid.Net.Clients.SpotApi
 
             var result = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidBalances>(_baseClient, "post", "info", parameters, false), ct).ConfigureAwait(false);
-            return result.As<HyperLiquidBalance[]>(result.Data?.Balances);
+            if (!result.Success)
+                return QueryResult.Fail<HyperLiquidBalance[]>(result);
+
+            return QueryResult.Ok(result, result.Data.Balances);
         }
 
         #endregion
@@ -63,15 +60,15 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #region Spot Transfer
 
         /// <inheritdoc />
-        public async Task<CallResult> TransferSpotAsync(
+        public async Task<QueryResult> TransferSpotAsync(
             string destinationAddress,
             string asset,
             decimal quantity,
             CancellationToken ct = default)
         {
             var assetId = await HyperLiquidUtils.GetAssetNameAndIdAsync(_baseClient.BaseClient, asset).ConfigureAwait(false);
-            if (!assetId)
-                return new HttpResult(assetId.Error!);
+            if (!assetId.Success)
+                return QueryResult.Fail(_baseClient.Exchange, assetId.Error!);
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
@@ -95,7 +92,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #endregion
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToBalanceUpdatesAsync(string? address, Action<DataEvent<HyperLiquidBalanceUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToBalanceUpdatesAsync(string? address, Action<DataEvent<HyperLiquidBalanceUpdate>> onMessage, CancellationToken ct = default)
         {
             if (address == null && _baseClient.AuthenticationProvider == null)
                 throw new ArgumentNullException(nameof(address), "Address needs to be provided if API credentials not set");

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidSocketClientSpotApiAccount.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidSocketClientSpotApiAccount.cs
@@ -71,7 +71,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         {
             var assetId = await HyperLiquidUtils.GetAssetNameAndIdAsync(_baseClient.BaseClient, asset).ConfigureAwait(false);
             if (!assetId)
-                return new WebCallResult(assetId.Error!);
+                return new HttpResult(assetId.Error!);
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidSocketClientSpotApiAccount.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidSocketClientSpotApiAccount.cs
@@ -20,6 +20,12 @@ namespace HyperLiquid.Net.Clients.SpotApi
     /// </summary>
     internal partial class HyperLiquidSocketClientSpotApiAccount : HyperLiquidSocketClientApiAccount, IHyperLiquidSocketClientSpotApiAccount
     {
+        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
+        {
+            Decimal = DecimalSerialization.String,
+            Sort = false
+        };
+
         #region constructor/destructor
 
         /// <summary>
@@ -41,7 +47,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "spotClearinghouseState" },
                 { "user", address ?? _baseClient.AuthenticationProvider!.Key }
@@ -69,8 +75,8 @@ namespace HyperLiquid.Net.Clients.SpotApi
 
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
 
-            var parameters = new ParameterCollection();
-            var actionParameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "spotSend" },
                 { "hyperliquidChain", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? "Testnet" : "Mainnet" },
@@ -78,8 +84,8 @@ namespace HyperLiquid.Net.Clients.SpotApi
                 { "destination", destinationAddress },
                 { "token", assetId.Data }
             };
-            actionParameters.AddString("amount", quantity);
-            actionParameters.AddMilliseconds("time", DateTime.UtcNow);
+            actionParameters.Add("amount", quantity);
+            actionParameters.Add("time", DateTime.UtcNow);
             parameters.Add("action", actionParameters);
 
             return await _baseClient.QueryInternalAsync(

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidSocketClientSpotApiExchangeData.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidSocketClientSpotApiExchangeData.cs
@@ -21,6 +21,12 @@ namespace HyperLiquid.Net.Clients.SpotApi
     /// </summary>
     internal partial class HyperLiquidSocketClientSpotApiExchangeData : HyperLiquidSocketClientApiExchangeData, IHyperLiquidSocketClientSpotApiExchangeData
     {
+        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
+        {
+            Decimal = DecimalSerialization.String,
+            Sort = false
+        };
+
         #region constructor/destructor
 
         /// <summary>
@@ -39,7 +45,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         /// <inheritdoc />
         public async Task<CallResult<HyperLiquidSpotExchangeInfo>> GetExchangeInfoAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "spotMeta" }
             };
@@ -54,7 +60,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         /// <inheritdoc />
         public async Task<CallResult<HyperLiquidExchangeInfoAndTickers>> GetExchangeInfoAndTickersAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "spotMetaAndAssetCtxs" }
             };
@@ -81,7 +87,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         /// <inheritdoc />
         public async Task<CallResult<HyperLiquidAssetInfo>> GetAssetInfoAsync(string assetId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "tokenDetails" },
                 { "tokenId", assetId }
@@ -98,7 +104,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         /// <inheritdoc />
         public async Task<CallResult<HyperLiquidQuestionsAndOutcomesInfo>> GetQuestionsAndOutcomesInfoAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "outcomeMeta" }
             };
@@ -113,7 +119,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         /// <inheritdoc />
         public async Task<CallResult<HyperLiquidSettledOutcome>> GetSettledOutcomeAsync(long outcomeId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
                 { "type", "settledOutcome" },
                 { "outcome", outcomeId }

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidSocketClientSpotApiExchangeData.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidSocketClientSpotApiExchangeData.cs
@@ -21,11 +21,6 @@ namespace HyperLiquid.Net.Clients.SpotApi
     /// </summary>
     internal partial class HyperLiquidSocketClientSpotApiExchangeData : HyperLiquidSocketClientApiExchangeData, IHyperLiquidSocketClientSpotApiExchangeData
     {
-        private static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
-        {
-            Decimal = DecimalSerialization.String,
-            Sort = false
-        };
 
         #region constructor/destructor
 
@@ -38,12 +33,10 @@ namespace HyperLiquid.Net.Clients.SpotApi
         }
         #endregion
 
-
-
         #region Get Spot Exchange Info
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidSpotExchangeInfo>> GetExchangeInfoAsync(CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidSpotExchangeInfo>> GetExchangeInfoAsync(CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
@@ -58,7 +51,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #region Get Spot Exchange Info And Tickers
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidExchangeInfoAndTickers>> GetExchangeInfoAndTickersAsync(CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidExchangeInfoAndTickers>> GetExchangeInfoAndTickersAsync(CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
@@ -67,13 +60,13 @@ namespace HyperLiquid.Net.Clients.SpotApi
 
             var result = await _baseClient.QueryInternalAsync(
                 new HyperLiquidRequestQuery<HyperLiquidExchangeInfoAndTickers>(_baseClient, "post", "info", parameters, false), ct).ConfigureAwait(false);
-            if (!result)
+            if (!result.Success)
                 return result;
 
             foreach (var ticker in result.Data.Tickers)
             {
                 var nameResult = await HyperLiquidUtils.GetSymbolNameFromExchangeNameAsync(_baseClient.BaseClient, ticker.Symbol!).ConfigureAwait(false);
-                if (nameResult)
+                if (nameResult.Success)
                     ticker.Symbol = nameResult.Data;
             }
 
@@ -85,7 +78,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #region Get Asset Info
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidAssetInfo>> GetAssetInfoAsync(string assetId, CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidAssetInfo>> GetAssetInfoAsync(string assetId, CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
@@ -98,11 +91,10 @@ namespace HyperLiquid.Net.Clients.SpotApi
 
         #endregion
 
-
         #region Get Outcomes Info
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidQuestionsAndOutcomesInfo>> GetQuestionsAndOutcomesInfoAsync(CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidQuestionsAndOutcomesInfo>> GetQuestionsAndOutcomesInfoAsync(CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
@@ -117,7 +109,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #region Get Settled Outcome
 
         /// <inheritdoc />
-        public async Task<CallResult<HyperLiquidSettledOutcome>> GetSettledOutcomeAsync(long outcomeId, CancellationToken ct = default)
+        public async Task<QueryResult<HyperLiquidSettledOutcome>> GetSettledOutcomeAsync(long outcomeId, CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
             {
@@ -131,15 +123,15 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #endregion
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToSymbolUpdatesAsync(string symbol, Action<DataEvent<HyperLiquidTicker>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToSymbolUpdatesAsync(string symbol, Action<DataEvent<HyperLiquidTicker>> onMessage, CancellationToken ct = default)
         {
             var coin = symbol;
             if (HyperLiquidUtils.SymbolIsExchangeSpotSymbol(coin))
             {
                 // Spot symbol
                 var spotName = await HyperLiquidUtils.GetExchangeNameFromSymbolNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
-                if (!spotName)
-                    return new HttpResult<UpdateSubscription>(spotName.Error);
+                if (!spotName.Success)
+                    return WebSocketResult.Fail<UpdateSubscription>(_baseClient.Exchange, spotName.Error);
 
                 coin = spotName.Data;
             }
@@ -165,7 +157,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
 
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToOutcomeInfoUpdatesAsync(
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToOutcomeInfoUpdatesAsync(
             Action<DataEvent<long>>? onOutcomeCreateUpdate = null,
             Action<DataEvent<HyperLiquidOutcomeInfo>>? onOutcomeSettleUpdate = null,
             Action<DataEvent<HyperLiquidQuestion>>? onQuestionUpdate = null,

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidSocketClientSpotApiExchangeData.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidSocketClientSpotApiExchangeData.cs
@@ -139,7 +139,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
                 // Spot symbol
                 var spotName = await HyperLiquidUtils.GetExchangeNameFromSymbolNameAsync(_baseClient.BaseClient, symbol).ConfigureAwait(false);
                 if (!spotName)
-                    return new WebCallResult<UpdateSubscription>(spotName.Error);
+                    return new HttpResult<UpdateSubscription>(spotName.Error);
 
                 coin = spotName.Data;
             }

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidSocketClientSpotApiShared.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidSocketClientSpotApiShared.cs
@@ -252,7 +252,12 @@ namespace HyperLiquid.Net.Clients.SpotApi
 
             var result = await Account.SubscribeToUserUpdatesAsync(
                 null,
-                update => handler(update.ToType<SharedBalance[]>(update.Data.SpotBalances.Balances.Select(x => new SharedBalance(HyperLiquidExchange.AssetAliases.ExchangeToCommonName(x.Asset), x.Total - x.Hold, x.Total)).ToArray())),
+                update => handler(update.ToType<SharedBalance[]>(update.Data.SpotBalances.Balances.Select(x => 
+                    new SharedBalance(
+                        SupportedTradingModes, 
+                        HyperLiquidExchange.AssetAliases.ExchangeToCommonName(x.Asset), 
+                        x.Total - x.Hold,
+                        x.Total)).ToArray())),
                 ct: ct).ConfigureAwait(false);
 
             return result;

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidSocketClientSpotApiShared.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidSocketClientSpotApiShared.cs
@@ -23,11 +23,11 @@ namespace HyperLiquid.Net.Clients.SpotApi
 
         #region Ticker client
         SubscribeTickerOptions ITickerSocketClient.SubscribeTickerOptions { get; } = new SubscribeTickerOptions(_exchangeName);
-        async Task<ExchangeResult<UpdateSubscription>> ITickerSocketClient.SubscribeToTickerUpdatesAsync(SubscribeTickerRequest request, Action<DataEvent<SharedSpotTicker>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> ITickerSocketClient.SubscribeToTickerUpdatesAsync(SubscribeTickerRequest request, Action<DataEvent<SharedSpotTicker>> handler, CancellationToken ct)
         {
             var validationError = ((ITickerSocketClient)this).SubscribeTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.SubscribeToSymbolUpdatesAsync(symbol, update => 
@@ -36,18 +36,18 @@ namespace HyperLiquid.Net.Clients.SpotApi
                 QuoteVolume = update.Data.QuoteVolume
             })), ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return new WebSocketResult<UpdateSubscription>(Exchange, result);
         }
         #endregion
 
         #region Trade client
 
         EndpointOptions<SubscribeTradeRequest, ITradeSocketClient> ITradeSocketClient.SubscribeTradeOptions { get; } = new EndpointOptions<SubscribeTradeRequest, ITradeSocketClient>(_exchangeName, false);
-        async Task<ExchangeResult<UpdateSubscription>> ITradeSocketClient.SubscribeToTradeUpdatesAsync(SubscribeTradeRequest request, Action<DataEvent<SharedTrade[]>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> ITradeSocketClient.SubscribeToTradeUpdatesAsync(SubscribeTradeRequest request, Action<DataEvent<SharedTrade[]>> handler, CancellationToken ct)
         {
             var validationError = ((ITradeSocketClient)this).SubscribeTradeOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.SubscribeToTradeUpdatesAsync(symbol, update =>
@@ -63,7 +63,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
                 ));
             }, ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return new WebSocketResult<UpdateSubscription>(Exchange, result);
         }
 
         #endregion
@@ -83,15 +83,15 @@ namespace HyperLiquid.Net.Clients.SpotApi
             SharedKlineInterval.OneDay,
             SharedKlineInterval.OneWeek,
             SharedKlineInterval.OneMonth);
-        async Task<ExchangeResult<UpdateSubscription>> IKlineSocketClient.SubscribeToKlineUpdatesAsync(SubscribeKlineRequest request, Action<DataEvent<SharedKline>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> IKlineSocketClient.SubscribeToKlineUpdatesAsync(SubscribeKlineRequest request, Action<DataEvent<SharedKline>> handler, CancellationToken ct)
         {
             var interval = (Enums.KlineInterval)request.Interval;
             if (!Enum.IsDefined(typeof(Enums.KlineInterval), interval))
-                return new ExchangeResult<UpdateSubscription>(Exchange, ArgumentError.Invalid(nameof(GetKlinesRequest.Interval), "Interval not supported"));
+                return new WebSocketResult<UpdateSubscription>(Exchange, ArgumentError.Invalid(nameof(GetKlinesRequest.Interval), "Interval not supported"));
 
             var validationError = ((IKlineSocketClient)this).SubscribeKlineOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.SubscribeToKlineUpdatesAsync(symbol, interval, 
@@ -103,33 +103,33 @@ namespace HyperLiquid.Net.Clients.SpotApi
                     handler(update.ToType(new SharedKline(request.Symbol, symbol, update.Data.OpenTime, update.Data.ClosePrice, update.Data.HighPrice, update.Data.LowPrice, update.Data.OpenPrice, update.Data.Volume)));
                 }, ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return new WebSocketResult<UpdateSubscription>(Exchange, result);
         }
         #endregion
 
         #region Order Book client
         SubscribeOrderBookOptions IOrderBookSocketClient.SubscribeOrderBookOptions { get; } = new SubscribeOrderBookOptions(_exchangeName, false, new[] { 20 });
-        async Task<ExchangeResult<UpdateSubscription>> IOrderBookSocketClient.SubscribeToOrderBookUpdatesAsync(SubscribeOrderBookRequest request, Action<DataEvent<SharedOrderBook>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> IOrderBookSocketClient.SubscribeToOrderBookUpdatesAsync(SubscribeOrderBookRequest request, Action<DataEvent<SharedOrderBook>> handler, CancellationToken ct)
         {
             var validationError = ((IOrderBookSocketClient)this).SubscribeOrderBookOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.SubscribeToOrderBookUpdatesAsync(symbol, update => handler(update.ToType(new SharedOrderBook(update.Data.Levels.Asks, update.Data.Levels.Bids))), ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return new WebSocketResult<UpdateSubscription>(Exchange, result);
         }
         #endregion
 
         #region Spot Order client
 
         EndpointOptions<SubscribeSpotOrderRequest, ISpotOrderSocketClient> ISpotOrderSocketClient.SubscribeSpotOrderOptions { get; } = new EndpointOptions<SubscribeSpotOrderRequest, ISpotOrderSocketClient>(_exchangeName, true);
-        async Task<ExchangeResult<UpdateSubscription>> ISpotOrderSocketClient.SubscribeToSpotOrderUpdatesAsync(SubscribeSpotOrderRequest request, Action<DataEvent<SharedSpotOrder[]>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> ISpotOrderSocketClient.SubscribeToSpotOrderUpdatesAsync(SubscribeSpotOrderRequest request, Action<DataEvent<SharedSpotOrder[]>> handler, CancellationToken ct)
         {
             var validationError = ((ISpotOrderSocketClient)this).SubscribeSpotOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
 
             var result = await Trading.SubscribeToOrderUpdatesAsync(null,
                 update =>
@@ -163,7 +163,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
                 },
                 ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return new WebSocketResult<UpdateSubscription>(Exchange, result);
         }
 
         private SharedOrderStatus ParseOrderStatus(Enums.OrderStatus status)
@@ -206,11 +206,11 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #region User Trade client
 
         EndpointOptions<SubscribeUserTradeRequest, IUserTradeSocketClient> IUserTradeSocketClient.SubscribeUserTradeOptions { get; } = new EndpointOptions<SubscribeUserTradeRequest, IUserTradeSocketClient>(_exchangeName, true);
-        async Task<ExchangeResult<UpdateSubscription>> IUserTradeSocketClient.SubscribeToUserTradeUpdatesAsync(SubscribeUserTradeRequest request, Action<DataEvent<SharedUserTrade[]>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> IUserTradeSocketClient.SubscribeToUserTradeUpdatesAsync(SubscribeUserTradeRequest request, Action<DataEvent<SharedUserTrade[]>> handler, CancellationToken ct)
         {
             var validationError = ((IUserTradeSocketClient)this).SubscribeUserTradeOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
 
             var result = await Trading.SubscribeToUserTradeUpdatesAsync(null,
                 update =>
@@ -241,24 +241,24 @@ namespace HyperLiquid.Net.Clients.SpotApi
                 },
                 ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return new WebSocketResult<UpdateSubscription>(Exchange, result);
         }
         #endregion
 
         #region Balance client
         EndpointOptions<SubscribeBalancesRequest, IBalanceSocketClient> IBalanceSocketClient.SubscribeBalanceOptions { get; } = new EndpointOptions<SubscribeBalancesRequest, IBalanceSocketClient>(_exchangeName, false);
-        async Task<ExchangeResult<UpdateSubscription>> IBalanceSocketClient.SubscribeToBalanceUpdatesAsync(SubscribeBalancesRequest request, Action<DataEvent<SharedBalance[]>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> IBalanceSocketClient.SubscribeToBalanceUpdatesAsync(SubscribeBalancesRequest request, Action<DataEvent<SharedBalance[]>> handler, CancellationToken ct)
         {
             var validationError = ((IBalanceSocketClient)this).SubscribeBalanceOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
 
             var result = await Account.SubscribeToUserUpdatesAsync(
                 null,
                 update => handler(update.ToType<SharedBalance[]>(update.Data.SpotBalances.Balances.Select(x => new SharedBalance(HyperLiquidExchange.AssetAliases.ExchangeToCommonName(x.Asset), x.Total - x.Hold, x.Total)).ToArray())),
                 ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return new WebSocketResult<UpdateSubscription>(Exchange, result);
         }
 
         #endregion
@@ -266,11 +266,11 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #region Book Ticker client
 
         EndpointOptions<SubscribeBookTickerRequest, IBookTickerSocketClient> IBookTickerSocketClient.SubscribeBookTickerOptions { get; } = new EndpointOptions<SubscribeBookTickerRequest, IBookTickerSocketClient>(_exchangeName, false);
-        async Task<ExchangeResult<UpdateSubscription>> IBookTickerSocketClient.SubscribeToBookTickerUpdatesAsync(SubscribeBookTickerRequest request, Action<DataEvent<SharedBookTicker>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> IBookTickerSocketClient.SubscribeToBookTickerUpdatesAsync(SubscribeBookTickerRequest request, Action<DataEvent<SharedBookTicker>> handler, CancellationToken ct)
         {
             var validationError = ((IBookTickerSocketClient)this).SubscribeBookTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.SubscribeToBookTickerUpdatesAsync(symbol, update => 
@@ -283,7 +283,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
                     update.Data.BestBid.Price,
                     update.Data.BestBid.Quantity))), ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return new WebSocketResult<UpdateSubscription>(Exchange, result);
         }
 
         #endregion

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidSocketClientSpotApiShared.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidSocketClientSpotApiShared.cs
@@ -19,7 +19,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
 
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
-        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(HyperLiquidExchange.Metadata, this);
 
         #region Ticker client
         SubscribeTickerOptions ITickerSocketClient.SubscribeTickerOptions { get; } = new SubscribeTickerOptions(_exchangeName);
@@ -31,7 +31,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.SubscribeToSymbolUpdatesAsync(symbol, update => 
-            handler(update.ToType(new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, update.Data.Symbol), update.Data.Symbol!, update.Data.MidPrice, null, null, update.Data.BaseVolume, update.Data.MidPrice == null ? null : Math.Round((update.Data.MidPrice.Value / update.Data.PreviousDayPrice * 100 - 100) / 10, 3) * 10)
+            handler(update.ToType(new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, update.Data.Symbol), update.Data.Symbol!, update.Data.MidPrice, null, null, update.Data.BaseVolume, update.Data.MidPrice == null ? null : Math.Round((update.Data.MidPrice.Value / update.Data.PreviousDayPrice * 100 - 100) / 10, 3) * 10)
             {
                 QuoteVolume = update.Data.QuoteVolume
             })), ct).ConfigureAwait(false);
@@ -140,7 +140,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
 
                     handler(update.ToType<SharedSpotOrder[]>(spotOrders.Select(x =>
                         new SharedSpotOrder(
-                            ExchangeSymbolCache.ParseSymbol(_topicId, x.Order.Symbol!),
+                            ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Order.Symbol!),
                             x.Order.Symbol!,
                             x.Order.OrderId.ToString(),
                             x.Order.OrderType == Enums.OrderType.Limit || x.Order.OrderType == Enums.OrderType.Limit ? SharedOrderType.Limit : x.Order.OrderType == Enums.OrderType.Market ? SharedOrderType.Market : SharedOrderType.Other,
@@ -221,7 +221,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
 
                     handler(update.ToType<SharedUserTrade[]>(spotOrders.Select(x =>
                         new SharedUserTrade(
-                            ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol),
+                            ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Symbol),
                             x.Symbol!,
                             x.OrderId.ToString(),
                             x.TradeId.ToString(),
@@ -273,7 +273,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
             var result = await ExchangeData.SubscribeToBookTickerUpdatesAsync(symbol, update => 
             handler(update.ToType(
                 new SharedBookTicker(
-                    ExchangeSymbolCache.ParseSymbol(_topicId, update.Data.Symbol),
+                    ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, update.Data.Symbol),
                     update.Data.Symbol,
                     update.Data.BestAsk.Price,
                     update.Data.BestAsk.Quantity,

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidSocketClientSpotApiShared.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidSocketClientSpotApiShared.cs
@@ -12,6 +12,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
 {
     internal partial class HyperLiquidSocketClientSpotApi : IHyperLiquidSocketClientSpotApiShared
     {
+        private const string _exchangeName = "HyperLiquid";
         private const string _topicId = "HyperLiquidSpot";
         public string Exchange => "HyperLiquid";
 
@@ -21,10 +22,10 @@ namespace HyperLiquid.Net.Clients.SpotApi
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
 
         #region Ticker client
-        SubscribeTickerOptions ITickerSocketClient.SubscribeTickerOptions { get; } = new SubscribeTickerOptions();
+        SubscribeTickerOptions ITickerSocketClient.SubscribeTickerOptions { get; } = new SubscribeTickerOptions(_exchangeName);
         async Task<ExchangeResult<UpdateSubscription>> ITickerSocketClient.SubscribeToTickerUpdatesAsync(SubscribeTickerRequest request, Action<DataEvent<SharedSpotTicker>> handler, CancellationToken ct)
         {
-            var validationError = ((ITickerSocketClient)this).SubscribeTickerOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = ((ITickerSocketClient)this).SubscribeTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
                 return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
 
@@ -41,10 +42,10 @@ namespace HyperLiquid.Net.Clients.SpotApi
 
         #region Trade client
 
-        EndpointOptions<SubscribeTradeRequest> ITradeSocketClient.SubscribeTradeOptions { get; } = new EndpointOptions<SubscribeTradeRequest>(false);
+        EndpointOptions<SubscribeTradeRequest, ITradeSocketClient> ITradeSocketClient.SubscribeTradeOptions { get; } = new EndpointOptions<SubscribeTradeRequest, ITradeSocketClient>(_exchangeName, false);
         async Task<ExchangeResult<UpdateSubscription>> ITradeSocketClient.SubscribeToTradeUpdatesAsync(SubscribeTradeRequest request, Action<DataEvent<SharedTrade[]>> handler, CancellationToken ct)
         {
-            var validationError = ((ITradeSocketClient)this).SubscribeTradeOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = ((ITradeSocketClient)this).SubscribeTradeOptions.ValidateRequest(request, this);
             if (validationError != null)
                 return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
 
@@ -68,7 +69,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #endregion
 
         #region Kline client
-        SubscribeKlineOptions IKlineSocketClient.SubscribeKlineOptions { get; } = new SubscribeKlineOptions(false,
+        SubscribeKlineOptions IKlineSocketClient.SubscribeKlineOptions { get; } = new SubscribeKlineOptions(_exchangeName, false,
             SharedKlineInterval.OneMinute,
             SharedKlineInterval.ThreeMinutes,
             SharedKlineInterval.FiveMinutes,
@@ -88,7 +89,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
             if (!Enum.IsDefined(typeof(Enums.KlineInterval), interval))
                 return new ExchangeResult<UpdateSubscription>(Exchange, ArgumentError.Invalid(nameof(GetKlinesRequest.Interval), "Interval not supported"));
 
-            var validationError = ((IKlineSocketClient)this).SubscribeKlineOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = ((IKlineSocketClient)this).SubscribeKlineOptions.ValidateRequest(request, this);
             if (validationError != null)
                 return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
 
@@ -107,10 +108,10 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #endregion
 
         #region Order Book client
-        SubscribeOrderBookOptions IOrderBookSocketClient.SubscribeOrderBookOptions { get; } = new SubscribeOrderBookOptions(false, new[] { 20 });
+        SubscribeOrderBookOptions IOrderBookSocketClient.SubscribeOrderBookOptions { get; } = new SubscribeOrderBookOptions(_exchangeName, false, new[] { 20 });
         async Task<ExchangeResult<UpdateSubscription>> IOrderBookSocketClient.SubscribeToOrderBookUpdatesAsync(SubscribeOrderBookRequest request, Action<DataEvent<SharedOrderBook>> handler, CancellationToken ct)
         {
-            var validationError = ((IOrderBookSocketClient)this).SubscribeOrderBookOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = ((IOrderBookSocketClient)this).SubscribeOrderBookOptions.ValidateRequest(request, this);
             if (validationError != null)
                 return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
 
@@ -123,10 +124,10 @@ namespace HyperLiquid.Net.Clients.SpotApi
 
         #region Spot Order client
 
-        EndpointOptions<SubscribeSpotOrderRequest> ISpotOrderSocketClient.SubscribeSpotOrderOptions { get; } = new EndpointOptions<SubscribeSpotOrderRequest>(true);
+        EndpointOptions<SubscribeSpotOrderRequest, ISpotOrderSocketClient> ISpotOrderSocketClient.SubscribeSpotOrderOptions { get; } = new EndpointOptions<SubscribeSpotOrderRequest, ISpotOrderSocketClient>(_exchangeName, true);
         async Task<ExchangeResult<UpdateSubscription>> ISpotOrderSocketClient.SubscribeToSpotOrderUpdatesAsync(SubscribeSpotOrderRequest request, Action<DataEvent<SharedSpotOrder[]>> handler, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderSocketClient)this).SubscribeSpotOrderOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = ((ISpotOrderSocketClient)this).SubscribeSpotOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
                 return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
 
@@ -204,10 +205,10 @@ namespace HyperLiquid.Net.Clients.SpotApi
 
         #region User Trade client
 
-        EndpointOptions<SubscribeUserTradeRequest> IUserTradeSocketClient.SubscribeUserTradeOptions { get; } = new EndpointOptions<SubscribeUserTradeRequest>(true);
+        EndpointOptions<SubscribeUserTradeRequest, IUserTradeSocketClient> IUserTradeSocketClient.SubscribeUserTradeOptions { get; } = new EndpointOptions<SubscribeUserTradeRequest, IUserTradeSocketClient>(_exchangeName, true);
         async Task<ExchangeResult<UpdateSubscription>> IUserTradeSocketClient.SubscribeToUserTradeUpdatesAsync(SubscribeUserTradeRequest request, Action<DataEvent<SharedUserTrade[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IUserTradeSocketClient)this).SubscribeUserTradeOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = ((IUserTradeSocketClient)this).SubscribeUserTradeOptions.ValidateRequest(request, this);
             if (validationError != null)
                 return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
 
@@ -245,10 +246,10 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #endregion
 
         #region Balance client
-        EndpointOptions<SubscribeBalancesRequest> IBalanceSocketClient.SubscribeBalanceOptions { get; } = new EndpointOptions<SubscribeBalancesRequest>(false);
+        EndpointOptions<SubscribeBalancesRequest, IBalanceSocketClient> IBalanceSocketClient.SubscribeBalanceOptions { get; } = new EndpointOptions<SubscribeBalancesRequest, IBalanceSocketClient>(_exchangeName, false);
         async Task<ExchangeResult<UpdateSubscription>> IBalanceSocketClient.SubscribeToBalanceUpdatesAsync(SubscribeBalancesRequest request, Action<DataEvent<SharedBalance[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IBalanceSocketClient)this).SubscribeBalanceOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = ((IBalanceSocketClient)this).SubscribeBalanceOptions.ValidateRequest(request, this);
             if (validationError != null)
                 return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
 
@@ -264,10 +265,10 @@ namespace HyperLiquid.Net.Clients.SpotApi
 
         #region Book Ticker client
 
-        EndpointOptions<SubscribeBookTickerRequest> IBookTickerSocketClient.SubscribeBookTickerOptions { get; } = new EndpointOptions<SubscribeBookTickerRequest>(false);
+        EndpointOptions<SubscribeBookTickerRequest, IBookTickerSocketClient> IBookTickerSocketClient.SubscribeBookTickerOptions { get; } = new EndpointOptions<SubscribeBookTickerRequest, IBookTickerSocketClient>(_exchangeName, false);
         async Task<ExchangeResult<UpdateSubscription>> IBookTickerSocketClient.SubscribeToBookTickerUpdatesAsync(SubscribeBookTickerRequest request, Action<DataEvent<SharedBookTicker>> handler, CancellationToken ct)
         {
-            var validationError = ((IBookTickerSocketClient)this).SubscribeBookTickerOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = ((IBookTickerSocketClient)this).SubscribeBookTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
                 return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
 

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidSocketClientSpotApiShared.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidSocketClientSpotApiShared.cs
@@ -14,20 +14,20 @@ namespace HyperLiquid.Net.Clients.SpotApi
     {
         private const string _exchangeName = "HyperLiquid";
         private const string _topicId = "HyperLiquidSpot";
-        public string Exchange => "HyperLiquid";
 
         public TradingMode[] SupportedTradingModes => new[] { TradingMode.Spot };
 
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
 
         #region Ticker client
         SubscribeTickerOptions ITickerSocketClient.SubscribeTickerOptions { get; } = new SubscribeTickerOptions(_exchangeName);
         async Task<WebSocketResult<UpdateSubscription>> ITickerSocketClient.SubscribeToTickerUpdatesAsync(SubscribeTickerRequest request, Action<DataEvent<SharedSpotTicker>> handler, CancellationToken ct)
         {
-            var validationError = ((ITickerSocketClient)this).SubscribeTickerOptions.ValidateRequest(request, this);
+            var validationError = SharedClient.SubscribeTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.SubscribeToSymbolUpdatesAsync(symbol, update => 
@@ -36,18 +36,18 @@ namespace HyperLiquid.Net.Clients.SpotApi
                 QuoteVolume = update.Data.QuoteVolume
             })), ct).ConfigureAwait(false);
 
-            return new WebSocketResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Trade client
 
-        EndpointOptions<SubscribeTradeRequest, ITradeSocketClient> ITradeSocketClient.SubscribeTradeOptions { get; } = new EndpointOptions<SubscribeTradeRequest, ITradeSocketClient>(_exchangeName, false);
+        SubscribeTradeOptions ITradeSocketClient.SubscribeTradeOptions { get; } = new SubscribeTradeOptions(_exchangeName, false);
         async Task<WebSocketResult<UpdateSubscription>> ITradeSocketClient.SubscribeToTradeUpdatesAsync(SubscribeTradeRequest request, Action<DataEvent<SharedTrade[]>> handler, CancellationToken ct)
         {
-            var validationError = ((ITradeSocketClient)this).SubscribeTradeOptions.ValidateRequest(request, this);
+            var validationError = SharedClient.SubscribeTradeOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.SubscribeToTradeUpdatesAsync(symbol, update =>
@@ -63,7 +63,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
                 ));
             }, ct).ConfigureAwait(false);
 
-            return new WebSocketResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
 
         #endregion
@@ -86,12 +86,9 @@ namespace HyperLiquid.Net.Clients.SpotApi
         async Task<WebSocketResult<UpdateSubscription>> IKlineSocketClient.SubscribeToKlineUpdatesAsync(SubscribeKlineRequest request, Action<DataEvent<SharedKline>> handler, CancellationToken ct)
         {
             var interval = (Enums.KlineInterval)request.Interval;
-            if (!Enum.IsDefined(typeof(Enums.KlineInterval), interval))
-                return new WebSocketResult<UpdateSubscription>(Exchange, ArgumentError.Invalid(nameof(GetKlinesRequest.Interval), "Interval not supported"));
-
-            var validationError = ((IKlineSocketClient)this).SubscribeKlineOptions.ValidateRequest(request, this);
+            var validationError = SharedClient.SubscribeKlineOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.SubscribeToKlineUpdatesAsync(symbol, interval, 
@@ -103,7 +100,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
                     handler(update.ToType(new SharedKline(request.Symbol, symbol, update.Data.OpenTime, update.Data.ClosePrice, update.Data.HighPrice, update.Data.LowPrice, update.Data.OpenPrice, update.Data.Volume)));
                 }, ct).ConfigureAwait(false);
 
-            return new WebSocketResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
@@ -111,25 +108,25 @@ namespace HyperLiquid.Net.Clients.SpotApi
         SubscribeOrderBookOptions IOrderBookSocketClient.SubscribeOrderBookOptions { get; } = new SubscribeOrderBookOptions(_exchangeName, false, new[] { 20 });
         async Task<WebSocketResult<UpdateSubscription>> IOrderBookSocketClient.SubscribeToOrderBookUpdatesAsync(SubscribeOrderBookRequest request, Action<DataEvent<SharedOrderBook>> handler, CancellationToken ct)
         {
-            var validationError = ((IOrderBookSocketClient)this).SubscribeOrderBookOptions.ValidateRequest(request, this);
+            var validationError = SharedClient.SubscribeOrderBookOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.SubscribeToOrderBookUpdatesAsync(symbol, update => handler(update.ToType(new SharedOrderBook(update.Data.Levels.Asks, update.Data.Levels.Bids))), ct: ct).ConfigureAwait(false);
 
-            return new WebSocketResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Spot Order client
 
-        EndpointOptions<SubscribeSpotOrderRequest, ISpotOrderSocketClient> ISpotOrderSocketClient.SubscribeSpotOrderOptions { get; } = new EndpointOptions<SubscribeSpotOrderRequest, ISpotOrderSocketClient>(_exchangeName, true);
+        SubscribeSpotOrderOptions ISpotOrderSocketClient.SubscribeSpotOrderOptions { get; } = new SubscribeSpotOrderOptions(_exchangeName, true);
         async Task<WebSocketResult<UpdateSubscription>> ISpotOrderSocketClient.SubscribeToSpotOrderUpdatesAsync(SubscribeSpotOrderRequest request, Action<DataEvent<SharedSpotOrder[]>> handler, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderSocketClient)this).SubscribeSpotOrderOptions.ValidateRequest(request, this);
+            var validationError = SharedClient.SubscribeSpotOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var result = await Trading.SubscribeToOrderUpdatesAsync(null,
                 update =>
@@ -163,7 +160,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
                 },
                 ct: ct).ConfigureAwait(false);
 
-            return new WebSocketResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
 
         private SharedOrderStatus ParseOrderStatus(Enums.OrderStatus status)
@@ -205,12 +202,12 @@ namespace HyperLiquid.Net.Clients.SpotApi
 
         #region User Trade client
 
-        EndpointOptions<SubscribeUserTradeRequest, IUserTradeSocketClient> IUserTradeSocketClient.SubscribeUserTradeOptions { get; } = new EndpointOptions<SubscribeUserTradeRequest, IUserTradeSocketClient>(_exchangeName, true);
+        SubscribeUserTradeOptions IUserTradeSocketClient.SubscribeUserTradeOptions { get; } = new SubscribeUserTradeOptions(_exchangeName, true);
         async Task<WebSocketResult<UpdateSubscription>> IUserTradeSocketClient.SubscribeToUserTradeUpdatesAsync(SubscribeUserTradeRequest request, Action<DataEvent<SharedUserTrade[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IUserTradeSocketClient)this).SubscribeUserTradeOptions.ValidateRequest(request, this);
+            var validationError = SharedClient.SubscribeUserTradeOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var result = await Trading.SubscribeToUserTradeUpdatesAsync(null,
                 update =>
@@ -241,36 +238,36 @@ namespace HyperLiquid.Net.Clients.SpotApi
                 },
                 ct: ct).ConfigureAwait(false);
 
-            return new WebSocketResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Balance client
-        EndpointOptions<SubscribeBalancesRequest, IBalanceSocketClient> IBalanceSocketClient.SubscribeBalanceOptions { get; } = new EndpointOptions<SubscribeBalancesRequest, IBalanceSocketClient>(_exchangeName, false);
+        SubscribeBalanceOptions IBalanceSocketClient.SubscribeBalanceOptions { get; } = new SubscribeBalanceOptions(_exchangeName, false);
         async Task<WebSocketResult<UpdateSubscription>> IBalanceSocketClient.SubscribeToBalanceUpdatesAsync(SubscribeBalancesRequest request, Action<DataEvent<SharedBalance[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IBalanceSocketClient)this).SubscribeBalanceOptions.ValidateRequest(request, this);
+            var validationError = SharedClient.SubscribeBalanceOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var result = await Account.SubscribeToUserUpdatesAsync(
                 null,
                 update => handler(update.ToType<SharedBalance[]>(update.Data.SpotBalances.Balances.Select(x => new SharedBalance(HyperLiquidExchange.AssetAliases.ExchangeToCommonName(x.Asset), x.Total - x.Hold, x.Total)).ToArray())),
                 ct: ct).ConfigureAwait(false);
 
-            return new WebSocketResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
 
         #endregion
 
         #region Book Ticker client
 
-        EndpointOptions<SubscribeBookTickerRequest, IBookTickerSocketClient> IBookTickerSocketClient.SubscribeBookTickerOptions { get; } = new EndpointOptions<SubscribeBookTickerRequest, IBookTickerSocketClient>(_exchangeName, false);
+        SubscribeBookTickerOptions IBookTickerSocketClient.SubscribeBookTickerOptions { get; } = new SubscribeBookTickerOptions(_exchangeName, false);
         async Task<WebSocketResult<UpdateSubscription>> IBookTickerSocketClient.SubscribeToBookTickerUpdatesAsync(SubscribeBookTickerRequest request, Action<DataEvent<SharedBookTicker>> handler, CancellationToken ct)
         {
-            var validationError = ((IBookTickerSocketClient)this).SubscribeBookTickerOptions.ValidateRequest(request, this);
+            var validationError = SharedClient.SubscribeBookTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new WebSocketResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.SubscribeToBookTickerUpdatesAsync(symbol, update => 
@@ -283,7 +280,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
                     update.Data.BestBid.Price,
                     update.Data.BestBid.Quantity))), ct).ConfigureAwait(false);
 
-            return new WebSocketResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
 
         #endregion

--- a/HyperLiquid.Net/Converters/HyperLiquidSourceGenerationContext.cs
+++ b/HyperLiquid.Net/Converters/HyperLiquidSourceGenerationContext.cs
@@ -8,6 +8,8 @@ using System.Text.Json.Serialization;
 
 namespace HyperLiquid.Net.Converters
 {
+    [JsonSerializable(typeof(Parameters))]
+    [JsonSerializable(typeof(List<Parameters>))]
     [JsonSerializable(typeof(UserAbstractionState))]
     [JsonSerializable(typeof(HyperLiquidSettledOutcome))]
     [JsonSerializable(typeof(HyperLiquidQuestionsAndOutcomesInfo))]
@@ -68,7 +70,6 @@ namespace HyperLiquid.Net.Converters
     [JsonSerializable(typeof(HyperLiquidUserAgent[]))]
     [JsonSerializable(typeof(object[]))]
     [JsonSerializable(typeof(Dictionary<string, decimal>))]
-    [JsonSerializable(typeof(List<ParameterCollection>))]
     [JsonSerializable(typeof(HyperLiquidResponse<HyperLiquidOrderResultIntWrapper>))]
     [JsonSerializable(typeof(HyperLiquidResponse<HyperLiquidCancelResult>))]
     [JsonSerializable(typeof(HyperLiquidResponse<HyperLiquidTwapOrderResultIntWrapper>))]

--- a/HyperLiquid.Net/Converters/HyperLiquidSourceGenerationContext.cs
+++ b/HyperLiquid.Net/Converters/HyperLiquidSourceGenerationContext.cs
@@ -9,6 +9,7 @@ using System.Text.Json.Serialization;
 namespace HyperLiquid.Net.Converters
 {
     [JsonSerializable(typeof(Parameters))]
+    [JsonSerializable(typeof(Parameters[]))]
     [JsonSerializable(typeof(List<Parameters>))]
     [JsonSerializable(typeof(UserAbstractionState))]
     [JsonSerializable(typeof(HyperLiquidSettledOutcome))]

--- a/HyperLiquid.Net/HyperLiquid.Net.csproj
+++ b/HyperLiquid.Net/HyperLiquid.Net.csproj
@@ -53,11 +53,13 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="CryptoExchange.Net" Version="11.2.0" />
     <PackageReference Include="Secp256k1.Net" Version="2.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/HyperLiquid.Net/HyperLiquid.Net.csproj
+++ b/HyperLiquid.Net/HyperLiquid.Net.csproj
@@ -53,13 +53,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="CryptoExchange.Net" Version="12.0.1" />
     <PackageReference Include="Secp256k1.Net" Version="2.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/HyperLiquid.Net/HyperLiquidAuthenticationProvider.cs
+++ b/HyperLiquid.Net/HyperLiquidAuthenticationProvider.cs
@@ -51,17 +51,17 @@ namespace HyperLiquid.Net
             if (!request.Authenticated)
                 return;
 
-            var action = (Dictionary<string, object>)request.BodyParameters!["action"];
+            var action = (IDictionary<string, object>)request.BodyParameters!.Dictionary["action"];
             var nonce = GetNonce(action, () => GetMillisecondTimestampLong(apiClient));
-            request.BodyParameters!.Add("nonce", nonce);
+            request.BodyParameters!.Dictionary.Add("nonce", nonce);
 
             var signature = GenerateSignature(
                 ((HyperLiquidRestOptions)apiClient.ClientOptions).Environment,
                 action,
                 nonce,
-                request.BodyParameters.TryGetValue("vaultAddress", out var vaultAddressObj) ? (string)vaultAddressObj : null,
-                request.BodyParameters.TryGetValue("expiresAfter", out var expiresAfterObj) ? (long)expiresAfterObj : null);
-            request.BodyParameters["signature"] = signature;
+                request.BodyParameters.Dictionary.TryGetValue("vaultAddress", out var vaultAddressObj) ? (string)vaultAddressObj : null,
+                request.BodyParameters.Dictionary.TryGetValue("expiresAfter", out var expiresAfterObj) ? (long)expiresAfterObj : null);
+            request.BodyParameters.Dictionary["signature"] = signature;
         }
 
         public void ProcessRequest(SocketApiClient apiClient, ParameterCollection request)
@@ -79,7 +79,7 @@ namespace HyperLiquid.Net
             request["signature"] = signature;
         }
 
-        private long GetNonce(Dictionary<string, object> actionParameters, Func<long> getTimestamp)
+        private long GetNonce(IDictionary<string, object> actionParameters, Func<long> getTimestamp)
         {
             if (actionParameters.TryGetValue("time", out var time))
                 return (long)time;
@@ -101,7 +101,7 @@ namespace HyperLiquid.Net
 
         internal Dictionary<string, object> GenerateSignature(
             HyperLiquidEnvironment environment,
-            Dictionary<string, object> action,
+            IDictionary<string, object> action,
             long nonce,
             string? vaultAddress,
             long? expiresAfter)

--- a/HyperLiquid.Net/HyperLiquidAuthenticationProvider.cs
+++ b/HyperLiquid.Net/HyperLiquidAuthenticationProvider.cs
@@ -2,6 +2,7 @@
 using CryptoExchange.Net.Authentication.Signing;
 using CryptoExchange.Net.Clients;
 using CryptoExchange.Net.Converters.SystemTextJson;
+using CryptoExchange.Net.Interfaces;
 using CryptoExchange.Net.Objects;
 using CryptoExchange.Net.Sockets;
 using CryptoExchange.Net.Sockets.Default;
@@ -51,22 +52,22 @@ namespace HyperLiquid.Net
             if (!request.Authenticated)
                 return;
 
-            var action = (IDictionary<string, object>)request.BodyParameters!.Dictionary["action"];
+            var action = (Parameters)request.BodyParameters!["action"];
             var nonce = GetNonce(action, () => GetMillisecondTimestampLong(apiClient));
-            request.BodyParameters!.Dictionary.Add("nonce", nonce);
+            request.BodyParameters!.Add("nonce", nonce);
 
             var signature = GenerateSignature(
                 ((HyperLiquidRestOptions)apiClient.ClientOptions).Environment,
                 action,
                 nonce,
-                request.BodyParameters.Dictionary.TryGetValue("vaultAddress", out var vaultAddressObj) ? (string)vaultAddressObj : null,
-                request.BodyParameters.Dictionary.TryGetValue("expiresAfter", out var expiresAfterObj) ? (long)expiresAfterObj : null);
-            request.BodyParameters.Dictionary["signature"] = signature;
+                request.BodyParameters.TryGetValue("vaultAddress", out var vaultAddressObj) ? (string)vaultAddressObj : null,
+                request.BodyParameters.TryGetValue("expiresAfter", out var expiresAfterObj) ? (long)expiresAfterObj : null);
+            request.BodyParameters["signature"] = signature;
         }
 
-        public void ProcessRequest(SocketApiClient apiClient, ParameterCollection request)
+        public void ProcessRequest(SocketApiClient apiClient, Parameters request)
         {
-            var action = (Dictionary<string, object>)request["action"];
+            var action = (Parameters)request["action"];
             var nonce = GetNonce(action, () => GetMillisecondTimestampLong(apiClient));
             request.Add("nonce", nonce);
 
@@ -79,7 +80,7 @@ namespace HyperLiquid.Net
             request["signature"] = signature;
         }
 
-        private long GetNonce(IDictionary<string, object> actionParameters, Func<long> getTimestamp)
+        private long GetNonce(Parameters actionParameters, Func<long> getTimestamp)
         {
             if (actionParameters.TryGetValue("time", out var time))
                 return (long)time;
@@ -101,7 +102,7 @@ namespace HyperLiquid.Net
 
         internal Dictionary<string, object> GenerateSignature(
             HyperLiquidEnvironment environment,
-            IDictionary<string, object> action,
+            Parameters action,
             long nonce,
             string? vaultAddress,
             long? expiresAfter)

--- a/HyperLiquid.Net/HyperLiquidAuthenticationProvider.cs
+++ b/HyperLiquid.Net/HyperLiquidAuthenticationProvider.cs
@@ -49,7 +49,7 @@ namespace HyperLiquid.Net
 
         public override void ProcessRequest(RestApiClient apiClient, RestRequestConfiguration request)
         {
-            if (!request.Authenticated)
+            if (!request.RequestDefinition.Authenticated)
                 return;
 
             var action = (Parameters)request.BodyParameters!["action"];

--- a/HyperLiquid.Net/HyperLiquidExchange.cs
+++ b/HyperLiquid.Net/HyperLiquidExchange.cs
@@ -100,6 +100,11 @@ namespace HyperLiquid.Net
         }
 
         internal static JsonSerializerOptions _serializerContext = SerializerOptions.WithConverters(JsonSerializerContextCache.GetOrCreate<HyperLiquidSourceGenerationContext>());
+        internal static readonly ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
+        {
+            Decimal = DecimalSerialization.String,
+            Sort = false
+        };
 
         /// <summary>
         /// Format a base and quote asset to an HyperLiquid recognized symbol 

--- a/HyperLiquid.Net/HyperLiquidExchange.cs
+++ b/HyperLiquid.Net/HyperLiquidExchange.cs
@@ -29,7 +29,8 @@ namespace HyperLiquid.Net
                 "https://app.hyperliquid.xyz/",
                 ["https://hyperliquid.gitbook.io/hyperliquid-docs"],
                 PlatformType.CryptoCurrencyExchange,
-                CentralizationType.Decentralized
+                CentralizationType.Decentralized,
+                HyperLiquidEnvironment.All
                 );
 
         /// <summary>

--- a/HyperLiquid.Net/HyperLiquidExchange.cs
+++ b/HyperLiquid.Net/HyperLiquidExchange.cs
@@ -131,7 +131,7 @@ namespace HyperLiquid.Net
         /// <summary>
         /// Rate limiter configuration for the HyperLiquid API
         /// </summary>
-        public static HyperLiquidRateLimiters RateLimiter { get; } = new HyperLiquidRateLimiters();
+        public static HyperLiquidRateLimiters RateLimiter { get; set; } = new HyperLiquidRateLimiters();
     }
 
     /// <summary>
@@ -150,13 +150,19 @@ namespace HyperLiquid.Net
         public event Action<RateLimitUpdateEvent> RateLimitUpdated;
 
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        internal HyperLiquidRateLimiters()
+        /// <summary>
+        /// ctor
+        /// </summary>
+        public HyperLiquidRateLimiters()
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         {
             Initialize();
         }
 
-        private void Initialize()
+        /// <summary>
+        /// Initialize the rate limits
+        /// </summary>
+        protected virtual void Initialize()
         {
             HyperLiquidRest = new RateLimitGate("HyperLiquid REST")
                 .AddGuard(new RateLimitGuard(RateLimitGuard.PerHost, [], 1200, TimeSpan.FromSeconds(60), RateLimitWindowType.Sliding)); // Limit of 1200 weight per minute

--- a/HyperLiquid.Net/HyperLiquidUserDataTracker.cs
+++ b/HyperLiquid.Net/HyperLiquidUserDataTracker.cs
@@ -19,7 +19,6 @@ namespace HyperLiquid.Net
             SpotUserDataTrackerConfig? config) : base(
                 logger,
                 restClient.SpotApi.SharedClient,
-                null,
                 restClient.SpotApi.SharedClient,
                 socketClient.SpotApi.SharedClient,
                 restClient.SpotApi.SharedClient,
@@ -47,7 +46,6 @@ namespace HyperLiquid.Net
             string? userIdentifier,
             FuturesUserDataTrackerConfig? config) : base(logger,
                 restClient.FuturesApi.SharedClient,
-                null,
                 restClient.FuturesApi.SharedClient,
                 socketClient.FuturesApi.SharedClient,
                 restClient.FuturesApi.SharedClient,

--- a/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidRestClientAccount.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidRestClientAccount.cs
@@ -17,7 +17,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// </summary>
         /// <param name="address">["<c>user</c>"] Address to request open orders for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidFeeInfo>> GetFeeInfoAsync(string? address = null, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidFeeInfo>> GetFeeInfoAsync(string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// This generalized method is used to transfer tokens between different perp DEXs, spot balance, users, and/or sub-accounts. Use "" to specify the default USDC perp DEX and "spot" to specify spot. Only the collateral token can be transferred to or from a perp DEX.
@@ -30,7 +30,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="quantity">["<c>amount</c>"] Quantity to send</param>
         /// <param name="fromSubAccount">["<c>fromSubAccount</c>"] Source sub account</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> SendAssetAsync(
+        Task<HttpResult> SendAssetAsync(
             string destination,
             string sourceDex,
             string destinationDex,
@@ -53,7 +53,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="endTime">["<c>endTime</c>"] Filter by end time</param>
         /// <param name="address">["<c>user</c>"] Address to request ledger for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidAccountLedger>> GetAccountLedgerAsync(DateTime startTime, DateTime? endTime = null, string? address = null, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidAccountLedger>> GetAccountLedgerAsync(DateTime startTime, DateTime? endTime = null, string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get user rate limits
@@ -66,7 +66,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// </summary>
         /// <param name="address">["<c>user</c>"] Address to request rate limits for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidRateLimit>> GetRateLimitsAsync(string? address = null, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidRateLimit>> GetRateLimitsAsync(string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get the approved builder fee
@@ -80,7 +80,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="builderAddress">["<c>builder</c>"] The address of the builder. If not provided will use the builder address for this library</param>
         /// <param name="address">["<c>user</c>"] Address to request approved builder fee for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<int>> GetApprovedBuilderFeeAsync(string? builderAddress = null, string? address = null, CancellationToken ct = default);
+        Task<HttpResult<int>> GetApprovedBuilderFeeAsync(string? builderAddress = null, string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Send usd to another address. This transfer does not touch the EVM bridge.
@@ -94,7 +94,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="destinationAddress">["<c>destination</c>"] Address in 42-character hexadecimal format; e.g. 0x0000000000000000000000000000000000000000</param>
         /// <param name="quantity">["<c>amount</c>"] Quantity of USD to send</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> TransferUsdAsync(string destinationAddress, decimal quantity, CancellationToken ct = default);
+        Task<HttpResult> TransferUsdAsync(string destinationAddress, decimal quantity, CancellationToken ct = default);
 
         /// <summary>
         /// Initiate the withdrawal flow. After making this request, the L1 validators will sign and send the withdrawal request to the bridge contract. There is a $1 fee for withdrawing at the time of this writing and withdrawals take approximately 5 minutes to finalize.
@@ -108,7 +108,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="destinationAddress">["<c>destination</c>"] Address in 42-character hexadecimal format; e.g. 0x0000000000000000000000000000000000000000</param>
         /// <param name="quantity">["<c>amount</c>"] Quantity of USD to send</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> WithdrawAsync(
+        Task<HttpResult> WithdrawAsync(
             string destinationAddress,
             decimal quantity,
             CancellationToken ct = default);
@@ -126,7 +126,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="quantity">["<c>amount</c>"] Quantity of USD to send</param>
         /// <param name="subAccount">Subaccount address</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> TransferInternalAsync(
+        Task<HttpResult> TransferInternalAsync(
             TransferDirection direction,
             decimal quantity,
             string? subAccount = null,
@@ -143,7 +143,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// </summary>
         /// <param name="wei">["<c>wei</c>"] Quantity</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> DepositIntoStakingAsync(long wei, CancellationToken ct = default);
+        Task<HttpResult> DepositIntoStakingAsync(long wei, CancellationToken ct = default);
 
         /// <summary>
         /// Withdraw from staking into the user's spot account. Note that transfers from staking to spot account go through a 7 day unstaking queue.
@@ -156,7 +156,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// </summary>
         /// <param name="wei">["<c>wei</c>"] Quantity</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> WithdrawFromStakingAsync(long wei, CancellationToken ct = default);
+        Task<HttpResult> WithdrawFromStakingAsync(long wei, CancellationToken ct = default);
 
         /// <summary>
         /// Delegate or undelegate native tokens to or from a validator. Note that delegations to a particular validator have a lockup duration of 1 day.
@@ -171,7 +171,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="validator">["<c>validator</c>"] Validator address in hex format, for example 0x0000000000000000000000000000000000000000</param>
         /// <param name="wei">["<c>wei</c>"] Quantity</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> DelegateOrUndelegateStakeFromValidatorAsync(DelegateDirection direction, string validator, long wei, CancellationToken ct = default);
+        Task<HttpResult> DelegateOrUndelegateStakeFromValidatorAsync(DelegateDirection direction, string validator, long wei, CancellationToken ct = default);
 
         /// <summary>
         /// Deposit or withdraw from vault
@@ -187,7 +187,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="usd">["<c>usd</c>"] USD to withdraw or deposit</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> DepositOrWithdrawFromVaultAsync(DepositWithdrawDirection direction, string vaultAddress, long usd, DateTime? expireAfter = null, CancellationToken ct = default);
+        Task<HttpResult> DepositOrWithdrawFromVaultAsync(DepositWithdrawDirection direction, string vaultAddress, long usd, DateTime? expireAfter = null, CancellationToken ct = default);
 
         /// <summary>
         /// Approve a builder address of the library to charge the fee percentage as defined in the BuilderFeePercentage client options field
@@ -199,7 +199,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> ApproveBuilderFeeAsync(CancellationToken ct = default);
+        Task<HttpResult> ApproveBuilderFeeAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Approve a builder address to charge a certain fee
@@ -213,28 +213,28 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="builderAddress">["<c>builder</c>"] The address of the builder in hex format, for example 0x0000000000000000000000000000000000000000</param>
         /// <param name="maxFeePercentage">["<c>maxFeeRate</c>"] Max fee percentage the builder can charge</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> ApproveBuilderFeeAsync(string builderAddress, decimal maxFeePercentage, CancellationToken ct = default);
+        Task<HttpResult> ApproveBuilderFeeAsync(string builderAddress, decimal maxFeePercentage, CancellationToken ct = default);
 
         /// <summary>
         /// Get sub account list
         /// </summary>
         /// <param name="address">["<c>user</c>"] Address to request balances for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidSubAccount[]>> GetSubAccountsAsync(string? address = null, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidSubAccount[]>> GetSubAccountsAsync(string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get user role
         /// </summary>
         /// <param name="address">["<c>user</c>"] Address to request balances for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidUserRole>> GetUserRoleAsync(string? address = null, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidUserRole>> GetUserRoleAsync(string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get extra agents associated with a user
         /// </summary>
         /// <param name="address">["<c>user</c>"] Address to request agents for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidUserAgent[]>> GetExtraAgentsAsync(string? address = null, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidUserAgent[]>> GetExtraAgentsAsync(string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get staking delegations
@@ -247,7 +247,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// </summary>
         /// <param name="address">["<c>user</c>"] Address to request delegations for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidStakingDelegation[]>> GetStakingDelegationsAsync(string? address = null, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidStakingDelegation[]>> GetStakingDelegationsAsync(string? address = null, CancellationToken ct = default);
         /// <summary>
         /// Get staking summary
         /// <para>
@@ -259,7 +259,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// </summary>
         /// <param name="address">["<c>user</c>"] Address to request summary for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidStakingSummary>> GetStakingSummaryAsync(string? address = null, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidStakingSummary>> GetStakingSummaryAsync(string? address = null, CancellationToken ct = default);
         /// <summary>
         /// Get staking history
         /// <para>
@@ -271,7 +271,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// </summary>
         /// <param name="address">["<c>user</c>"] Address to request history for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidStakingHistory[]>> GetStakingHistoryAsync(string? address = null, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidStakingHistory[]>> GetStakingHistoryAsync(string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get staking rewards history
@@ -284,7 +284,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// </summary>
         /// <param name="address">["<c>user</c>"] Address to request rewards for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidStakingReward[]>> GetStakingRewardsAsync(string? address = null, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidStakingReward[]>> GetStakingRewardsAsync(string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get the user's abstraction status
@@ -297,6 +297,6 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// </summary>
         /// <param name="address">["<c>user</c>"] Address to request rewards for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<UserAbstractionState>> GetUserAbstractionStateAsync(string? address = null, CancellationToken ct = default);
+        Task<HttpResult<UserAbstractionState>> GetUserAbstractionStateAsync(string? address = null, CancellationToken ct = default);
     }
 }

--- a/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidRestClientExchangeData.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidRestClientExchangeData.cs
@@ -28,7 +28,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// </summary>
         /// <param name="dex">["<c>dex</c>"] Filter by DEX</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<Dictionary<string, decimal>>> GetPricesAsync(string? dex = null, CancellationToken ct = default);
+        Task<HttpResult<Dictionary<string, decimal>>> GetPricesAsync(string? dex = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get order book
@@ -43,7 +43,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="numberSignificantFigures">["<c>nSigFigs</c>"] Asset name</param>
         /// <param name="mantissa">["<c>mantissa</c>"] Mantissa</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidOrderBook>> GetOrderBookAsync(string symbol, int? numberSignificantFigures = null, int? mantissa = null, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidOrderBook>> GetOrderBookAsync(string symbol, int? numberSignificantFigures = null, int? mantissa = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get klines/candlestick data
@@ -59,7 +59,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="startTime">["<c>startTime</c>"] Data start time</param>
         /// <param name="endTime">["<c>endTime</c>"] Data end time</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidKline[]>> GetKlinesAsync(string symbol, KlineInterval interval, DateTime startTime, DateTime endTime, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidKline[]>> GetKlinesAsync(string symbol, KlineInterval interval, DateTime startTime, DateTime endTime, CancellationToken ct = default);
 
     }
 }

--- a/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidRestClientTrading.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidRestClientTrading.cs
@@ -265,6 +265,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="tpSlType">["<c>action.order.t.trigger.tpsl</c>"] Trigger order type</param>
         /// <param name="tpSlGrouping">Trigger order grouping</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
+        /// <param name="alwaysPlace">["<c>a</c>"] When set to true the new order will be placed regardless of cancellation success</param>
         /// <param name="ct">Cancellation token</param>
         Task<HttpResult> EditOrderAsync(
             string symbol,
@@ -282,6 +283,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
             TpSlGrouping? tpSlGrouping = null,
             string? vaultAddress = null,
             DateTime? expireAfter = null,
+            bool? alwaysPlace = null,
             CancellationToken ct = default);
 
         /// <summary>
@@ -296,11 +298,13 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="requests">Edit requests</param>
         /// <param name="vaultAddress">["<c>vaultAddress</c>"] Vault address</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
+        /// <param name="alwaysPlace">["<c>a</c>"] When set to true the new order will be placed regardless of cancellation success</param>
         /// <param name="ct">Cancellation token</param>
         Task<HttpResult<CallResult<HyperLiquidOrderResult>[]>> EditOrdersAsync(
             IEnumerable<HyperLiquidEditOrderRequest> requests,
             string? vaultAddress = null,
             DateTime? expireAfter = null,
+            bool? alwaysPlace = null,
             CancellationToken ct = default);
 
         /// <summary>

--- a/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidRestClientTrading.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidRestClientTrading.cs
@@ -25,7 +25,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="address">["<c>user</c>"] Address to request open orders for. If not provided will use the address provided in the API credentials</param>
         /// <param name="dex">["<c>dex</c>"] DEX name, for example `xyz`, null for default Perp DEX</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidOpenOrder[]>> GetOpenOrdersAsync(string? address = null, string? dex = null, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidOpenOrder[]>> GetOpenOrdersAsync(string? address = null, string? dex = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get open orders including with additional info, will return both Spot and Futures orders
@@ -39,7 +39,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="address">["<c>user</c>"] Address to request open orders for. If not provided will use the address provided in the API credentials</param>
         /// <param name="dex">["<c>dex</c>"] DEX name, for example `xyz`, null for default Perp DEX</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidOrder[]>> GetOpenOrdersExtendedAsync(string? address = null, string? dex = null, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidOrder[]>> GetOpenOrdersExtendedAsync(string? address = null, string? dex = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get user trades, will return both Spot and Futures orders
@@ -52,7 +52,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// </summary>
         /// <param name="address">["<c>user</c>"] Address to request user trades for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidUserTrade[]>> GetUserTradesAsync(string? address = null, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidUserTrade[]>> GetUserTradesAsync(string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get user trades by time filter, will return both Spot and Futures orders
@@ -68,7 +68,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="aggregateByTime">["<c>aggregateByTime</c>"] Aggregate by time</param>
         /// <param name="address">["<c>user</c>"] Address to request user trades for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidUserTrade[]>> GetUserTradesByTimeAsync(
+        Task<HttpResult<HyperLiquidUserTrade[]>> GetUserTradesByTimeAsync(
             DateTime startTime,
             DateTime? endTime = null,
             bool? aggregateByTime = null,
@@ -88,7 +88,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="clientOrderId">["<c>oid</c>"] Get order by client order id. Either this or orderId should be provided</param>
         /// <param name="address">["<c>user</c>"] Address to request order for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidOrderStatus>> GetOrderAsync(long? orderId = null, string? clientOrderId = null, string? address = null, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidOrderStatus>> GetOrderAsync(long? orderId = null, string? clientOrderId = null, string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get user order history, will return both Spot and Futures orders
@@ -101,7 +101,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// </summary>
         /// <param name="address">["<c>user</c>"] Address to request order for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidOrderStatus[]>> GetOrderHistoryAsync(string? address = null, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidOrderStatus[]>> GetOrderHistoryAsync(string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel an order
@@ -117,7 +117,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="vaultAddress">["<c>vaultAddress</c>"] Vault address</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> CancelOrderAsync(string symbol, long orderId, string? vaultAddress = null, DateTime? expireAfter = null, CancellationToken ct = default);
+        Task<HttpResult> CancelOrderAsync(string symbol, long orderId, string? vaultAddress = null, DateTime? expireAfter = null, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel multiple orders
@@ -132,7 +132,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="vaultAddress">["<c>vaultAddress</c>"] Vault address</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<CallResult[]>> CancelOrdersAsync(IEnumerable<HyperLiquidCancelRequest> requests, string? vaultAddress = null, DateTime? expireAfter = null, CancellationToken ct = default);
+        Task<HttpResult<CallResult[]>> CancelOrdersAsync(IEnumerable<HyperLiquidCancelRequest> requests, string? vaultAddress = null, DateTime? expireAfter = null, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel order by client order id
@@ -148,7 +148,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="vaultAddress">["<c>vaultAddress</c>"] Vault address</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> CancelOrderByClientOrderIdAsync(string symbol, string clientOrderId, string? vaultAddress = null, DateTime? expireAfter = null, CancellationToken ct = default);
+        Task<HttpResult> CancelOrderByClientOrderIdAsync(string symbol, string clientOrderId, string? vaultAddress = null, DateTime? expireAfter = null, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel multiple orders by client order id
@@ -163,7 +163,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="vaultAddress">["<c>vaultAddress</c>"] Vault address</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<CallResult[]>> CancelOrdersByClientOrderIdAsync(IEnumerable<HyperLiquidCancelByClientOrderIdRequest> requests, string? vaultAddress = null, DateTime? expireAfter = null, CancellationToken ct = default);
+        Task<HttpResult<CallResult[]>> CancelOrdersByClientOrderIdAsync(IEnumerable<HyperLiquidCancelByClientOrderIdRequest> requests, string? vaultAddress = null, DateTime? expireAfter = null, CancellationToken ct = default);
 
         /// <summary>
         /// Place a new order
@@ -188,7 +188,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="vaultAddress">["<c>vaultAddress</c>"] Vault address</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidOrderResult>> PlaceOrderAsync(
+        Task<HttpResult<HyperLiquidOrderResult>> PlaceOrderAsync(
             string symbol,
             OrderSide side,
             OrderType orderType,
@@ -202,7 +202,6 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
             TpSlGrouping? tpSlGrouping = null,
             string? vaultAddress = null,
             DateTime? expireAfter = null,
-            IDictionary<string, object>? rawParameter = null,
             CancellationToken ct = default
             );
 
@@ -220,12 +219,11 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="vaultAddress">["<c>vaultAddress</c>"] Vault address</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<CallResult<HyperLiquidOrderResult>[]>> PlaceMultipleOrdersAsync(
+        Task<HttpResult<CallResult<HyperLiquidOrderResult>[]>> PlaceMultipleOrdersAsync(
             IEnumerable<HyperLiquidOrderRequest> orders,
             TpSlGrouping? tpSlGrouping = null,
             string? vaultAddress = null,
             DateTime? expireAfter = null,
-            IDictionary<string, object>? rawParameters = null,
             CancellationToken ct = default);
 
         /// <summary>
@@ -241,7 +239,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="vaultAddress">["<c>vaultAddress</c>"] Vault address</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidOrderStatus[]>> CancelAfterAsync(TimeSpan? timeout, string? vaultAddress = null, DateTime? expireAfter = null, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidOrderStatus[]>> CancelAfterAsync(TimeSpan? timeout, string? vaultAddress = null, DateTime? expireAfter = null, CancellationToken ct = default);
 
         /// <summary>
         /// Edit an existing order
@@ -268,7 +266,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="tpSlGrouping">Trigger order grouping</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> EditOrderAsync(
+        Task<HttpResult> EditOrderAsync(
             string symbol,
             long? orderId,
             string? clientOrderId,
@@ -299,7 +297,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="vaultAddress">["<c>vaultAddress</c>"] Vault address</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<CallResult<HyperLiquidOrderResult>[]>> EditOrdersAsync(
+        Task<HttpResult<CallResult<HyperLiquidOrderResult>[]>> EditOrdersAsync(
             IEnumerable<HyperLiquidEditOrderRequest> requests,
             string? vaultAddress = null,
             DateTime? expireAfter = null,
@@ -323,7 +321,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="vaultAddress">["<c>vaultAddress</c>"] Vault address</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidTwapOrderResult>> PlaceTwapOrderAsync(
+        Task<HttpResult<HyperLiquidTwapOrderResult>> PlaceTwapOrderAsync(
             string symbol, 
             OrderSide orderSide, 
             decimal quantity, 
@@ -348,6 +346,6 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="vaultAddress">["<c>vaultAddress</c>"] Vault address</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> CancelTwapOrderAsync(string symbol, long twapId, string? vaultAddress = null, DateTime? expireAfter = null, CancellationToken ct = default);
+        Task<HttpResult> CancelTwapOrderAsync(string symbol, long twapId, string? vaultAddress = null, DateTime? expireAfter = null, CancellationToken ct = default);
     }
 }

--- a/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidRestClientTrading.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidRestClientTrading.cs
@@ -202,6 +202,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
             TpSlGrouping? tpSlGrouping = null,
             string? vaultAddress = null,
             DateTime? expireAfter = null,
+            IDictionary<string, object>? rawParameter = null,
             CancellationToken ct = default
             );
 
@@ -224,6 +225,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
             TpSlGrouping? tpSlGrouping = null,
             string? vaultAddress = null,
             DateTime? expireAfter = null,
+            IDictionary<string, object>? rawParameters = null,
             CancellationToken ct = default);
 
         /// <summary>

--- a/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidSocketClientApiAccount.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidSocketClientApiAccount.cs
@@ -327,7 +327,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         Task<WebSocketResult<UpdateSubscription>> SubscribeToUserLedgerUpdatesAsync(string? address, Action<DataEvent<HyperLiquidAccountLedger>> onMessage, CancellationToken ct = default);
 
         /// <summary>
-        /// Subscribe to user updates, including Spot and Futures balances
+        /// OBSOLETE: will soon be discontinued. Use <see cref="SubscribeToWebData3UpdatesAsync(string?, Action{DataEvent{HyperLiquidWebDataV3Update}}, CancellationToken)"/> instead.
         /// <para>
         /// Docs:<br />
         /// <a href="https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/websocket/subscriptions" /><br />
@@ -335,10 +335,6 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// WS /ws (type: webData2)
         /// </para>
         /// </summary>
-        /// <param name="address">Address to subscribe for. If not provided will use the address provided in the API credentials</param>
-        /// <param name="onMessage">The data handler</param>
-        /// <param name="ct">Cancellation token for closing this subscription</param>
-        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected and to unsubscribe</returns>
         Task<WebSocketResult<UpdateSubscription>> SubscribeToUserUpdatesAsync(string? address, Action<DataEvent<HyperLiquidUserUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>

--- a/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidSocketClientApiAccount.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidSocketClientApiAccount.cs
@@ -18,7 +18,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// </summary>
         /// <param name="address">["<c>user</c>"] Address to request open orders for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidFeeInfo>> GetFeeInfoAsync(string? address = null, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidFeeInfo>> GetFeeInfoAsync(string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// This generalized method is used to transfer tokens between different perp DEXs, spot balance, users, and/or sub-accounts. Use "" to specify the default USDC perp DEX and "spot" to specify spot. Only the collateral token can be transferred to or from a perp DEX.
@@ -31,7 +31,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="quantity">["<c>amount</c>"] Quantity to send</param>
         /// <param name="fromSubAccount">["<c>fromSubAccount</c>"] Source sub account</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult> SendAssetAsync(
+        Task<QueryResult> SendAssetAsync(
             string destination,
             string sourceDex,
             string destinationDex,
@@ -54,7 +54,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="endTime">["<c>endTime</c>"] Filter by end time</param>
         /// <param name="address">["<c>user</c>"] Address to request ledger for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidAccountLedger>> GetAccountLedgerAsync(DateTime startTime, DateTime? endTime = null, string? address = null, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidAccountLedger>> GetAccountLedgerAsync(DateTime startTime, DateTime? endTime = null, string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get user rate limits
@@ -67,7 +67,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// </summary>
         /// <param name="address">["<c>user</c>"] Address to request rate limits for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidRateLimit>> GetRateLimitsAsync(string? address = null, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidRateLimit>> GetRateLimitsAsync(string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get the approved builder fee
@@ -81,7 +81,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="builderAddress">["<c>builder</c>"] The address of the builder. If not provided will use the builder address for this library</param>
         /// <param name="address">["<c>user</c>"] Address to request approved builder fee for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<int>> GetApprovedBuilderFeeAsync(string? builderAddress = null, string? address = null, CancellationToken ct = default);
+        Task<QueryResult<int>> GetApprovedBuilderFeeAsync(string? builderAddress = null, string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Send usd to another address. This transfer does not touch the EVM bridge.
@@ -95,7 +95,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="destinationAddress">["<c>destination</c>"] Address in 42-character hexadecimal format; e.g. 0x0000000000000000000000000000000000000000</param>
         /// <param name="quantity">["<c>amount</c>"] Quantity of USD to send</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult> TransferUsdAsync(string destinationAddress, decimal quantity, CancellationToken ct = default);
+        Task<QueryResult> TransferUsdAsync(string destinationAddress, decimal quantity, CancellationToken ct = default);
 
         /// <summary>
         /// Initiate the withdrawal flow. After making this request, the L1 validators will sign and send the withdrawal request to the bridge contract. There is a $1 fee for withdrawing at the time of this writing and withdrawals take approximately 5 minutes to finalize.
@@ -109,7 +109,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="destinationAddress">["<c>destination</c>"] Address in 42-character hexadecimal format; e.g. 0x0000000000000000000000000000000000000000</param>
         /// <param name="quantity">["<c>amount</c>"] Quantity of USD to send</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult> WithdrawAsync(
+        Task<QueryResult> WithdrawAsync(
             string destinationAddress,
             decimal quantity,
             CancellationToken ct = default);
@@ -127,7 +127,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="quantity">["<c>amount</c>"] Quantity of USD to send</param>
         /// <param name="subAccount">Subaccount address</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult> TransferInternalAsync(
+        Task<QueryResult> TransferInternalAsync(
             TransferDirection direction,
             decimal quantity,
             string? subAccount = null,
@@ -144,7 +144,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// </summary>
         /// <param name="wei">["<c>wei</c>"] Quantity</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult> DepositIntoStakingAsync(long wei, CancellationToken ct = default);
+        Task<QueryResult> DepositIntoStakingAsync(long wei, CancellationToken ct = default);
 
         /// <summary>
         /// Withdraw from staking into the user's spot account. Note that transfers from staking to spot account go through a 7 day unstaking queue.
@@ -157,7 +157,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// </summary>
         /// <param name="wei">["<c>wei</c>"] Quantity</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult> WithdrawFromStakingAsync(long wei, CancellationToken ct = default);
+        Task<QueryResult> WithdrawFromStakingAsync(long wei, CancellationToken ct = default);
 
         /// <summary>
         /// Delegate or undelegate native tokens to or from a validator. Note that delegations to a particular validator have a lockup duration of 1 day.
@@ -172,7 +172,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="validator">["<c>validator</c>"] Validator address in hex format, for example 0x0000000000000000000000000000000000000000</param>
         /// <param name="wei">["<c>wei</c>"] Quantity</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult> DelegateOrUndelegateStakeFromValidatorAsync(DelegateDirection direction, string validator, long wei, CancellationToken ct = default);
+        Task<QueryResult> DelegateOrUndelegateStakeFromValidatorAsync(DelegateDirection direction, string validator, long wei, CancellationToken ct = default);
 
         /// <summary>
         /// Deposit or withdraw from vault
@@ -188,7 +188,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="usd">["<c>usd</c>"] USD to withdraw or deposit</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult> DepositOrWithdrawFromVaultAsync(DepositWithdrawDirection direction, string vaultAddress, long usd, DateTime? expireAfter = null, CancellationToken ct = default);
+        Task<QueryResult> DepositOrWithdrawFromVaultAsync(DepositWithdrawDirection direction, string vaultAddress, long usd, DateTime? expireAfter = null, CancellationToken ct = default);
 
         /// <summary>
         /// Approve a builder address of the library to charge the fee percentage as defined in the BuilderFeePercentage client options field
@@ -200,7 +200,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult> ApproveBuilderFeeAsync(CancellationToken ct = default);
+        Task<QueryResult> ApproveBuilderFeeAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Approve a builder address to charge a certain fee
@@ -214,28 +214,28 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="builderAddress">["<c>builder</c>"] The address of the builder in hex format, for example 0x0000000000000000000000000000000000000000</param>
         /// <param name="maxFeePercentage">["<c>maxFeeRate</c>"] Max fee percentage the builder can charge</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult> ApproveBuilderFeeAsync(string builderAddress, decimal maxFeePercentage, CancellationToken ct = default);
+        Task<QueryResult> ApproveBuilderFeeAsync(string builderAddress, decimal maxFeePercentage, CancellationToken ct = default);
 
         /// <summary>
         /// Get sub account list
         /// </summary>
         /// <param name="address">["<c>user</c>"] Address to request balances for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidSubAccount[]>> GetSubAccountsAsync(string? address = null, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidSubAccount[]>> GetSubAccountsAsync(string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get user role
         /// </summary>
         /// <param name="address">["<c>user</c>"] Address to request balances for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidUserRole>> GetUserRoleAsync(string? address = null, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidUserRole>> GetUserRoleAsync(string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get extra agents associated with a user
         /// </summary>
         /// <param name="address">["<c>user</c>"] Address to request agents for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidUserAgent[]>> GetExtraAgentsAsync(string? address = null, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidUserAgent[]>> GetExtraAgentsAsync(string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get staking delegations
@@ -248,7 +248,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// </summary>
         /// <param name="address">["<c>user</c>"] Address to request delegations for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidStakingDelegation[]>> GetStakingDelegationsAsync(string? address = null, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidStakingDelegation[]>> GetStakingDelegationsAsync(string? address = null, CancellationToken ct = default);
         /// <summary>
         /// Get staking summary
         /// <para>
@@ -260,7 +260,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// </summary>
         /// <param name="address">["<c>user</c>"] Address to request summary for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidStakingSummary>> GetStakingSummaryAsync(string? address = null, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidStakingSummary>> GetStakingSummaryAsync(string? address = null, CancellationToken ct = default);
         /// <summary>
         /// Get staking history
         /// <para>
@@ -272,7 +272,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// </summary>
         /// <param name="address">["<c>user</c>"] Address to request history for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidStakingHistory[]>> GetStakingHistoryAsync(string? address = null, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidStakingHistory[]>> GetStakingHistoryAsync(string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get staking rewards history
@@ -285,7 +285,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// </summary>
         /// <param name="address">["<c>user</c>"] Address to request rewards for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidStakingReward[]>> GetStakingRewardsAsync(string? address = null, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidStakingReward[]>> GetStakingRewardsAsync(string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to user non-order updates
@@ -303,7 +303,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="onNonUserCancelation">Non-user order cancelation update</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected and to unsubscribe</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToUserEventUpdatesAsync(
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToUserEventUpdatesAsync(
             string? address,
             Action<DataEvent<HyperLiquidUserTrade[]>>? onTradeUpdate = null,
             Action<DataEvent<HyperLiquidUserFunding>>? onFundingUpdate = null,
@@ -324,7 +324,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="onMessage">The data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected and to unsubscribe</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToUserLedgerUpdatesAsync(string? address, Action<DataEvent<HyperLiquidAccountLedger>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToUserLedgerUpdatesAsync(string? address, Action<DataEvent<HyperLiquidAccountLedger>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to user updates, including Spot and Futures balances
@@ -339,7 +339,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="onMessage">The data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected and to unsubscribe</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToUserUpdatesAsync(string? address, Action<DataEvent<HyperLiquidUserUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToUserUpdatesAsync(string? address, Action<DataEvent<HyperLiquidUserUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to webData3 updates
@@ -354,6 +354,6 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="onMessage">The data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected and to unsubscribe</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToWebData3UpdatesAsync(string? address, Action<DataEvent<HyperLiquidWebDataV3Update>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToWebData3UpdatesAsync(string? address, Action<DataEvent<HyperLiquidWebDataV3Update>> onMessage, CancellationToken ct = default);
     }
 }

--- a/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidSocketClientApiExchangeData.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidSocketClientApiExchangeData.cs
@@ -23,7 +23,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// </summary>
         /// <param name="dex">["<c>dex</c>"] Filter by DEX</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<Dictionary<string, decimal>>> GetPricesAsync(string? dex = null, CancellationToken ct = default);
+        Task<QueryResult<Dictionary<string, decimal>>> GetPricesAsync(string? dex = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get order book
@@ -36,7 +36,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="numberSignificantFigures">["<c>nSigFigs</c>"] Asset name</param>
         /// <param name="mantissa">["<c>mantissa</c>"] Mantissa</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidOrderBook>> GetOrderBookAsync(string symbol, int? numberSignificantFigures = null, int? mantissa = null, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidOrderBook>> GetOrderBookAsync(string symbol, int? numberSignificantFigures = null, int? mantissa = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get klines/candlestick data
@@ -50,7 +50,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="startTime">["<c>startTime</c>"] Data start time</param>
         /// <param name="endTime">["<c>endTime</c>"] Data end time</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidKline[]>> GetKlinesAsync(string symbol, KlineInterval interval, DateTime startTime, DateTime endTime, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidKline[]>> GetKlinesAsync(string symbol, KlineInterval interval, DateTime startTime, DateTime endTime, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to mid price updates, will send updates for both Spot and Futures symbols
@@ -64,7 +64,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToPriceUpdatesAsync(Action<DataEvent<Dictionary<string, decimal>>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToPriceUpdatesAsync(Action<DataEvent<Dictionary<string, decimal>>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to kline/candlestick data
@@ -80,7 +80,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="onMessage">The data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected and to unsubscribe</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, KlineInterval interval, Action<DataEvent<HyperLiquidKline>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, KlineInterval interval, Action<DataEvent<HyperLiquidKline>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to order book updates
@@ -97,7 +97,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="mantissa">Mantissa to use for price, if not provided will use the default from the options</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected and to unsubscribe</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, Action<DataEvent<HyperLiquidOrderBook>> onMessage, int? nSigFigs = null, int? mantissa = null, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, Action<DataEvent<HyperLiquidOrderBook>> onMessage, int? nSigFigs = null, int? mantissa = null, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to trade updates
@@ -112,7 +112,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="onMessage">The data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected and to unsubscribe</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<HyperLiquidTrade[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<HyperLiquidTrade[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to book ticker updates
@@ -127,7 +127,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="onMessage">The data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected and to unsubscribe</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToBookTickerUpdatesAsync(string symbol, Action<DataEvent<HyperLiquidBookTicker>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToBookTickerUpdatesAsync(string symbol, Action<DataEvent<HyperLiquidBookTicker>> onMessage, CancellationToken ct = default);
 
     }
 }

--- a/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidSocketClientApiTrading.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidSocketClientApiTrading.cs
@@ -316,7 +316,8 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         Task<QueryResult> CancelTwapOrderAsync(string symbol, long twapId, string? vaultAddress = null, DateTime? expireAfter = null, CancellationToken ct = default);
 
         /// <summary>
-        /// Subscribe to order updates, will provided updates for both Spot and Futures orders
+        /// Subscribe to order updates, will provided updates for both Spot and Futures orders. Note that the update does not contain a user field, <br />
+        /// so updates for all addresses will be received on all handlers
         /// <para>
         /// Docs:<br />
         /// <a href="https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/websocket/subscriptions" /><br />

--- a/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidSocketClientApiTrading.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidSocketClientApiTrading.cs
@@ -24,7 +24,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="address">["<c>user</c>"] Address to request open orders for. If not provided will use the address provided in the API credentials</param>
         /// <param name="dex">["<c>dex</c>"] DEX name, for example `xyz`, null for default Perp DEX</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidOpenOrder[]>> GetOpenOrdersAsync(string? address = null, string? dex = null, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidOpenOrder[]>> GetOpenOrdersAsync(string? address = null, string? dex = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get open orders including with additional info, will return both Spot and Futures orders
@@ -36,7 +36,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="address">["<c>user</c>"] Address to request open orders for. If not provided will use the address provided in the API credentials</param>
         /// <param name="dex">["<c>dex</c>"] DEX name, for example `xyz`, null for default Perp DEX</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidOrder[]>> GetOpenOrdersExtendedAsync(string? address = null, string? dex = null, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidOrder[]>> GetOpenOrdersExtendedAsync(string? address = null, string? dex = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get user trades, will return both Spot and Futures orders
@@ -47,7 +47,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// </summary>
         /// <param name="address">["<c>user</c>"] Address to request user trades for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidUserTrade[]>> GetUserTradesAsync(string? address = null, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidUserTrade[]>> GetUserTradesAsync(string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get user trades by time filter, will return both Spot and Futures orders
@@ -61,7 +61,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="aggregateByTime">["<c>aggregateByTime</c>"] Aggregate by time</param>
         /// <param name="address">["<c>user</c>"] Address to request user trades for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidUserTrade[]>> GetUserTradesByTimeAsync(
+        Task<QueryResult<HyperLiquidUserTrade[]>> GetUserTradesByTimeAsync(
             DateTime startTime,
             DateTime? endTime = null,
             bool? aggregateByTime = null,
@@ -79,7 +79,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="clientOrderId">["<c>oid</c>"] Get order by client order id. Either this or orderId should be provided</param>
         /// <param name="address">["<c>user</c>"] Address to request order for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidOrderStatus>> GetOrderAsync(long? orderId = null, string? clientOrderId = null, string? address = null, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidOrderStatus>> GetOrderAsync(long? orderId = null, string? clientOrderId = null, string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get user order history, will return both Spot and Futures orders
@@ -90,7 +90,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// </summary>
         /// <param name="address">["<c>user</c>"] Address to request order for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidOrderStatus[]>> GetOrderHistoryAsync(string? address = null, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidOrderStatus[]>> GetOrderHistoryAsync(string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel an order
@@ -104,7 +104,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="vaultAddress">["<c>vaultAddress</c>"] Vault address</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult> CancelOrderAsync(string symbol, long orderId, string? vaultAddress = null, DateTime? expireAfter = null, CancellationToken ct = default);
+        Task<QueryResult> CancelOrderAsync(string symbol, long orderId, string? vaultAddress = null, DateTime? expireAfter = null, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel multiple orders
@@ -117,7 +117,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="vaultAddress">["<c>vaultAddress</c>"] Vault address</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<CallResult[]>> CancelOrdersAsync(IEnumerable<HyperLiquidCancelRequest> requests, string? vaultAddress = null, DateTime? expireAfter = null, CancellationToken ct = default);
+        Task<QueryResult<CallResult[]>> CancelOrdersAsync(IEnumerable<HyperLiquidCancelRequest> requests, string? vaultAddress = null, DateTime? expireAfter = null, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel order by client order id
@@ -131,7 +131,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="vaultAddress">["<c>vaultAddress</c>"] Vault address</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult> CancelOrderByClientOrderIdAsync(string symbol, string clientOrderId, string? vaultAddress = null, DateTime? expireAfter = null, CancellationToken ct = default);
+        Task<QueryResult> CancelOrderByClientOrderIdAsync(string symbol, string clientOrderId, string? vaultAddress = null, DateTime? expireAfter = null, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel multiple orders by client order id
@@ -144,7 +144,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="vaultAddress">["<c>vaultAddress</c>"] Vault address</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<CallResult[]>> CancelOrdersByClientOrderIdAsync(IEnumerable<HyperLiquidCancelByClientOrderIdRequest> requests, string? vaultAddress = null, DateTime? expireAfter = null, CancellationToken ct = default);
+        Task<QueryResult<CallResult[]>> CancelOrdersByClientOrderIdAsync(IEnumerable<HyperLiquidCancelByClientOrderIdRequest> requests, string? vaultAddress = null, DateTime? expireAfter = null, CancellationToken ct = default);
 
         /// <summary>
         /// Place a new order
@@ -167,7 +167,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="vaultAddress">["<c>vaultAddress</c>"] Vault address</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidOrderResult>> PlaceOrderAsync(
+        Task<QueryResult<HyperLiquidOrderResult>> PlaceOrderAsync(
             string symbol,
             OrderSide side,
             OrderType orderType,
@@ -196,7 +196,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="vaultAddress">["<c>vaultAddress</c>"] Vault address</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<CallResult<HyperLiquidOrderResult>[]>> PlaceMultipleOrdersAsync(
+        Task<QueryResult<CallResult<HyperLiquidOrderResult>[]>> PlaceMultipleOrdersAsync(
             IEnumerable<HyperLiquidOrderRequest> orders,
             TpSlGrouping? tpSlGrouping = null,
             string? vaultAddress = null,
@@ -214,7 +214,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="vaultAddress">["<c>vaultAddress</c>"] Vault address</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidOrderStatus[]>> CancelAfterAsync(TimeSpan? timeout, string? vaultAddress = null, DateTime? expireAfter = null, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidOrderStatus[]>> CancelAfterAsync(TimeSpan? timeout, string? vaultAddress = null, DateTime? expireAfter = null, CancellationToken ct = default);
 
         /// <summary>
         /// Edit an existing order
@@ -239,7 +239,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="tpSlGrouping">Trigger order grouping</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult> EditOrderAsync(
+        Task<QueryResult> EditOrderAsync(
             string symbol,
             long? orderId,
             string? clientOrderId,
@@ -268,7 +268,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="vaultAddress">["<c>vaultAddress</c>"] Vault address</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<CallResult<HyperLiquidOrderResult>[]>> EditOrdersAsync(
+        Task<QueryResult<CallResult<HyperLiquidOrderResult>[]>> EditOrdersAsync(
             IEnumerable<HyperLiquidEditOrderRequest> requests,
             string? vaultAddress = null,
             DateTime? expireAfter = null,
@@ -290,7 +290,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="vaultAddress">["<c>vaultAddress</c>"] Vault address</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidTwapOrderResult>> PlaceTwapOrderAsync(
+        Task<QueryResult<HyperLiquidTwapOrderResult>> PlaceTwapOrderAsync(
             string symbol,
             OrderSide orderSide,
             decimal quantity,
@@ -313,7 +313,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="vaultAddress">["<c>vaultAddress</c>"] Vault address</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult> CancelTwapOrderAsync(string symbol, long twapId, string? vaultAddress = null, DateTime? expireAfter = null, CancellationToken ct = default);
+        Task<QueryResult> CancelTwapOrderAsync(string symbol, long twapId, string? vaultAddress = null, DateTime? expireAfter = null, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to order updates, will provided updates for both Spot and Futures orders
@@ -328,7 +328,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="onMessage">The data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected and to unsubscribe</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(string? address, Action<DataEvent<HyperLiquidOrderStatus[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(string? address, Action<DataEvent<HyperLiquidOrderStatus[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to open order snapshot updates, will provided updates for both Spot and Futures orders
@@ -344,7 +344,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="onMessage">The data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected and to unsubscribe</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToOpenOrderUpdatesAsync(string? address, string? dex, Action<DataEvent<HyperLiquidOpenOrderUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToOpenOrderUpdatesAsync(string? address, string? dex, Action<DataEvent<HyperLiquidOpenOrderUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to user trade updates, will provided updates for both Spot and Futures orders
@@ -359,7 +359,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="onMessage">The data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected and to unsubscribe</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(string? address, Action<DataEvent<HyperLiquidUserTrade[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(string? address, Action<DataEvent<HyperLiquidUserTrade[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to Time Weighted Average Price trade updates, will provided updates for both Spot and Futures orders
@@ -374,7 +374,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="onMessage">The data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected and to unsubscribe</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToTwapTradeUpdatesAsync(string? address, Action<DataEvent<HyperLiquidTwapStatus[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToTwapTradeUpdatesAsync(string? address, Action<DataEvent<HyperLiquidTwapStatus[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to Time Weighted Average Price order history updates, will provided updates for both Spot and Futures orders
@@ -389,7 +389,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="onMessage">The data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected and to unsubscribe</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToTwapOrderUpdatesAsync(string? address, Action<DataEvent<HyperLiquidTwapOrderStatus[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToTwapOrderUpdatesAsync(string? address, Action<DataEvent<HyperLiquidTwapOrderStatus[]>> onMessage, CancellationToken ct = default);
 
     }
 }

--- a/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidSocketClientApiTrading.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidSocketClientApiTrading.cs
@@ -238,6 +238,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="tpSlType">["<c>action.order.t.trigger.tpsl</c>"] Trigger order type</param>
         /// <param name="tpSlGrouping">Trigger order grouping</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
+        /// <param name="alwaysPlace">["<c>a</c>"] When set to true the new order will be placed regardless of cancellation success</param>
         /// <param name="ct">Cancellation token</param>
         Task<QueryResult> EditOrderAsync(
             string symbol,
@@ -255,6 +256,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
             TpSlGrouping? tpSlGrouping = null,
             string? vaultAddress = null,
             DateTime? expireAfter = null,
+            bool? alwaysPlace = null,
             CancellationToken ct = default);
 
         /// <summary>
@@ -267,11 +269,13 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// <param name="requests">Edit requests</param>
         /// <param name="vaultAddress">["<c>vaultAddress</c>"] Vault address</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
+        /// <param name="alwaysPlace">["<c>a</c>"] When set to true the new order will be placed regardless of cancellation success</param>
         /// <param name="ct">Cancellation token</param>
         Task<QueryResult<CallResult<HyperLiquidOrderResult>[]>> EditOrdersAsync(
             IEnumerable<HyperLiquidEditOrderRequest> requests,
             string? vaultAddress = null,
             DateTime? expireAfter = null,
+            bool? alwaysPlace = null,
             CancellationToken ct = default);
 
         /// <summary>

--- a/HyperLiquid.Net/Interfaces/Clients/FuturesApi/IHyperLiquidRestClientFuturesApiAccount.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/FuturesApi/IHyperLiquidRestClientFuturesApiAccount.cs
@@ -25,7 +25,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// <param name="address">["<c>user</c>"] Address to request balances for. If not provided will use the address provided in the API credentials</param>
         /// <param name="dex">["<c>dex</c>"] The DEX to request data for, leave null for default perp DEX</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidFuturesAccount>> GetAccountInfoAsync(string? address = null, string? dex = null, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidFuturesAccount>> GetAccountInfoAsync(string? address = null, string? dex = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get user funding history
@@ -40,7 +40,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// <param name="endTime">["<c>endTime</c>"] Filter by end time</param>
         /// <param name="address">["<c>user</c>"] Address to request funding history for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidUserLedger<HyperLiquidUserFunding>[]>> GetFundingHistoryAsync(DateTime startTime, DateTime? endTime = null, string? address = null, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidUserLedger<HyperLiquidUserFunding>[]>> GetFundingHistoryAsync(DateTime startTime, DateTime? endTime = null, string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get user active symbols
@@ -54,7 +54,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// <param name="symbol">["<c>coin</c>"] The symbol, for example `ETH`</param>
         /// <param name="address">["<c>user</c>"] Address to request funding history for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidFuturesUserSymbolUpdate>> GetUserSymbolAsync(string symbol, string? address = null, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidFuturesUserSymbolUpdate>> GetUserSymbolAsync(string symbol, string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get whether HIP-3 DEX abstraction enabled
@@ -68,7 +68,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// <param name="user">["<c>user</c>"] User address. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct"></param>
         /// <returns></returns>
-        Task<WebCallResult<bool>> GetHip3DexAbstractionAsync(string? user = null, CancellationToken ct = default);
+        Task<HttpResult<bool>> GetHip3DexAbstractionAsync(string? user = null, CancellationToken ct = default);
 
         /// <summary>
         /// Toggle HIP-3 DEX abstraction. If set, actions on HIP-3 perps will automatically transfer collateral from validator-operated USDC perps balance for HIP-3 DEXs where USDC is the collateral token, and spot otherwise. 
@@ -84,6 +84,6 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// <param name="address">["<c>user</c>"] User address. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct"></param>
         /// <returns></returns>
-        Task<WebCallResult> ToggleHip3DexAbstractionAsync(bool enabled, string? address = null, CancellationToken ct = default);
+        Task<HttpResult> ToggleHip3DexAbstractionAsync(bool enabled, string? address = null, CancellationToken ct = default);
     }
 }

--- a/HyperLiquid.Net/Interfaces/Clients/FuturesApi/IHyperLiquidRestClientFuturesApiExchangeData.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/FuturesApi/IHyperLiquidRestClientFuturesApiExchangeData.cs
@@ -23,7 +23,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidPerpDex[]>> GetPerpDexesAsync(CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidPerpDex[]>> GetPerpDexesAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get exchange info
@@ -36,7 +36,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// </summary>
         /// <param name="dex">["<c>dex</c>"] DEX name, for example `xyz`, null for default Perp DEX</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidFuturesSymbol[]>> GetExchangeInfoAsync(string? dex = null, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidFuturesSymbol[]>> GetExchangeInfoAsync(string? dex = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get exchange info for all perp dexes
@@ -48,7 +48,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidFuturesDexInfo[]>> GetExchangeInfoAllDexesAsync(CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidFuturesDexInfo[]>> GetExchangeInfoAllDexesAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get exchange and ticker info
@@ -60,7 +60,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidFuturesExchangeInfoAndTickers>> GetExchangeInfoAndTickersAsync(CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidFuturesExchangeInfoAndTickers>> GetExchangeInfoAndTickersAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get funding rate history
@@ -75,7 +75,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// <param name="startTime">["<c>startTime</c>"] Filter by start time</param>
         /// <param name="endTime">["<c>endTime</c>"] Filter by end time</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidFundingRate[]>> GetFundingRateHistoryAsync(string symbol, DateTime startTime, DateTime? endTime = null, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidFundingRate[]>> GetFundingRateHistoryAsync(string symbol, DateTime startTime, DateTime? endTime = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get futures symbols at max open interest
@@ -88,7 +88,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// </summary>
         /// <param name="dex">["<c>dex</c>"] DEX name, for example `xyz`, null for default Perp DEX</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<string[]>> GetSymbolsAtMaxOpenInterestAsync(string? dex = null, CancellationToken ct = default);
+        Task<HttpResult<string[]>> GetSymbolsAtMaxOpenInterestAsync(string? dex = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get Perp DEX market limits
@@ -101,7 +101,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// </summary>
         /// <param name="dex">["<c>dex</c>"] DEX name, for example `xyz`, null for default Perp DEX</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidPerpDexLimit>> GetPerpDexMarketLimitsAsync(string? dex = null, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidPerpDexLimit>> GetPerpDexMarketLimitsAsync(string? dex = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get Perp DEX market status
@@ -114,6 +114,6 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// </summary>
         /// <param name="dex">["<c>dex</c>"] DEX name, for example `xyz`, null for default Perp DEX</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidPerpDexStatus>> GetPerpDexMarketStatusAsync(string? dex = null, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidPerpDexStatus>> GetPerpDexMarketStatusAsync(string? dex = null, CancellationToken ct = default);
     }
 }

--- a/HyperLiquid.Net/Interfaces/Clients/FuturesApi/IHyperLiquidRestClientFuturesApiTrading.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/FuturesApi/IHyperLiquidRestClientFuturesApiTrading.cs
@@ -28,7 +28,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// <param name="vaultAddress">["<c>vaultAddress</c>"] Vault address</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> SetLeverageAsync(
+        Task<HttpResult> SetLeverageAsync(
             string symbol,
             int leverage,
             MarginType marginType,
@@ -50,7 +50,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// <param name="vaultAddress">["<c>vaultAddress</c>"] Vault address</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> UpdateIsolatedMarginAsync(
+        Task<HttpResult> UpdateIsolatedMarginAsync(
             string symbol,
             decimal updateValue,
             string? vaultAddress = null, 

--- a/HyperLiquid.Net/Interfaces/Clients/FuturesApi/IHyperLiquidSocketClientFuturesApiAccount.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/FuturesApi/IHyperLiquidSocketClientFuturesApiAccount.cs
@@ -24,7 +24,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// <param name="address">["<c>user</c>"] Address to request balances for. If not provided will use the address provided in the API credentials</param>
         /// <param name="dex">["<c>dex</c>"] The DEX to request data for, leave null for default perp DEX</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidFuturesAccount>> GetAccountInfoAsync(string? address = null, string? dex = null, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidFuturesAccount>> GetAccountInfoAsync(string? address = null, string? dex = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get user funding history
@@ -37,7 +37,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// <param name="endTime">["<c>endTime</c>"] Filter by end time</param>
         /// <param name="address">["<c>user</c>"] Address to request funding history for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidUserLedger<HyperLiquidUserFunding>[]>> GetFundingHistoryAsync(DateTime startTime, DateTime? endTime = null, string? address = null, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidUserLedger<HyperLiquidUserFunding>[]>> GetFundingHistoryAsync(DateTime startTime, DateTime? endTime = null, string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get user active symbols
@@ -49,7 +49,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// <param name="symbol">["<c>coin</c>"] The symbol, for example `ETH`</param>
         /// <param name="address">["<c>user</c>"] Address to request funding history for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidFuturesUserSymbolUpdate>> GetUserSymbolAsync(string symbol, string? address = null, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidFuturesUserSymbolUpdate>> GetUserSymbolAsync(string symbol, string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get whether HIP-3 DEX abstraction enabled
@@ -61,7 +61,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// <param name="user">["<c>user</c>"] User address. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct"></param>
         /// <returns></returns>
-        Task<CallResult<bool>> GetHip3DexAbstractionAsync(string? user = null, CancellationToken ct = default);
+        Task<QueryResult<bool>> GetHip3DexAbstractionAsync(string? user = null, CancellationToken ct = default);
 
         /// <summary>
         /// Toggle HIP-3 DEX abstraction. If set, actions on HIP-3 perps will automatically transfer collateral from validator-operated USDC perps balance for HIP-3 DEXs where USDC is the collateral token, and spot otherwise. 
@@ -75,7 +75,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// <param name="address">["<c>user</c>"] User address. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct"></param>
         /// <returns></returns>
-        Task<CallResult> ToggleHip3DexAbstractionAsync(bool enabled, string? address = null, CancellationToken ct = default);
+        Task<QueryResult> ToggleHip3DexAbstractionAsync(bool enabled, string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to user symbol updates
@@ -91,7 +91,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// <param name="onMessage">The data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected and to unsubscribe</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToUserSymbolUpdatesAsync(string? address, string symbol, Action<DataEvent<HyperLiquidFuturesUserSymbolUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToUserSymbolUpdatesAsync(string? address, string symbol, Action<DataEvent<HyperLiquidFuturesUserSymbolUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to user funding updates
@@ -106,6 +106,6 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// <param name="onMessage">The data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected and to unsubscribe</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToUserFundingUpdatesAsync(string? address, Action<DataEvent<HyperLiquidUserFunding[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToUserFundingUpdatesAsync(string? address, Action<DataEvent<HyperLiquidUserFunding[]>> onMessage, CancellationToken ct = default);
     }
 }

--- a/HyperLiquid.Net/Interfaces/Clients/FuturesApi/IHyperLiquidSocketClientFuturesApiExchangeData.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/FuturesApi/IHyperLiquidSocketClientFuturesApiExchangeData.cs
@@ -23,7 +23,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidPerpDex[]>> GetPerpDexesAsync(CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidPerpDex[]>> GetPerpDexesAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get exchange info
@@ -36,7 +36,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// </summary>
         /// <param name="dex">["<c>dex</c>"] DEX name, for example `xyz`, null for default Perp DEX</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidFuturesSymbol[]>> GetExchangeInfoAsync(string? dex = null, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidFuturesSymbol[]>> GetExchangeInfoAsync(string? dex = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get exchange info for all perp dexes
@@ -48,7 +48,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidFuturesDexInfo[]>> GetExchangeInfoAllDexesAsync(CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidFuturesDexInfo[]>> GetExchangeInfoAllDexesAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get exchange and ticker info
@@ -60,7 +60,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidFuturesExchangeInfoAndTickers>> GetExchangeInfoAndTickersAsync(CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidFuturesExchangeInfoAndTickers>> GetExchangeInfoAndTickersAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get funding rate history
@@ -75,7 +75,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// <param name="startTime">["<c>startTime</c>"] Filter by start time</param>
         /// <param name="endTime">["<c>endTime</c>"] Filter by end time</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidFundingRate[]>> GetFundingRateHistoryAsync(string symbol, DateTime startTime, DateTime? endTime = null, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidFundingRate[]>> GetFundingRateHistoryAsync(string symbol, DateTime startTime, DateTime? endTime = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get futures symbols at max open interest
@@ -88,7 +88,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// </summary>
         /// <param name="dex">["<c>dex</c>"] DEX name, for example `xyz`, null for default Perp DEX</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<string[]>> GetSymbolsAtMaxOpenInterestAsync(string? dex = null, CancellationToken ct = default);
+        Task<QueryResult<string[]>> GetSymbolsAtMaxOpenInterestAsync(string? dex = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get Perp DEX market limits
@@ -101,7 +101,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// </summary>
         /// <param name="dex">["<c>dex</c>"] DEX name, for example `xyz`, null for default Perp DEX</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidPerpDexLimit>> GetPerpDexMarketLimitsAsync(string? dex = null, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidPerpDexLimit>> GetPerpDexMarketLimitsAsync(string? dex = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get Perp DEX market status
@@ -114,7 +114,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// </summary>
         /// <param name="dex">["<c>dex</c>"] DEX name, for example `xyz`, null for default Perp DEX</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidPerpDexStatus>> GetPerpDexMarketStatusAsync(string? dex = null, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidPerpDexStatus>> GetPerpDexMarketStatusAsync(string? dex = null, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to symbol updates
@@ -129,7 +129,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// <param name="onMessage">The data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected and to unsubscribe</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToSymbolUpdatesAsync(string symbol, Action<DataEvent<HyperLiquidFuturesTicker>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToSymbolUpdatesAsync(string symbol, Action<DataEvent<HyperLiquidFuturesTicker>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to mid price updates
@@ -144,7 +144,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// <param name="onMessage">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToPriceUpdatesAsync(string? dex, Action<DataEvent<Dictionary<string, decimal>>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToPriceUpdatesAsync(string? dex, Action<DataEvent<Dictionary<string, decimal>>> onMessage, CancellationToken ct = default);
 
     }
 }

--- a/HyperLiquid.Net/Interfaces/Clients/FuturesApi/IHyperLiquidSocketClientFuturesApiTrading.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/FuturesApi/IHyperLiquidSocketClientFuturesApiTrading.cs
@@ -30,7 +30,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// <param name="vaultAddress">["<c>vaultAddress</c>"] Vault address</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult> SetLeverageAsync(
+        Task<QueryResult> SetLeverageAsync(
             string symbol,
             int leverage,
             MarginType marginType,
@@ -52,7 +52,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// <param name="vaultAddress">["<c>vaultAddress</c>"] Vault address</param>
         /// <param name="expireAfter">["<c>expiresAfter</c>"] Timestamp after which the request expires and is rejected by the server</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult> UpdateIsolatedMarginAsync(
+        Task<QueryResult> UpdateIsolatedMarginAsync(
             string symbol,
             decimal updateValue,
             string? vaultAddress = null,
@@ -73,7 +73,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// <param name="onMessage">The data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected and to unsubscribe</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToBalanceAndPositionUpdatesAsync(string? address, string? dex, Action<DataEvent<HyperLiquidPositionUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToBalanceAndPositionUpdatesAsync(string? address, string? dex, Action<DataEvent<HyperLiquidPositionUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to futures account margin and position snapshot updates for all dexes
@@ -88,6 +88,6 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// <param name="onMessage">The data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected and to unsubscribe</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToBalanceAndPositionUpdatesAllDexesAsync(string? address, Action<DataEvent<HyperLiquidAllDexPositionUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToBalanceAndPositionUpdatesAllDexesAsync(string? address, Action<DataEvent<HyperLiquidAllDexPositionUpdate>> onMessage, CancellationToken ct = default);
     }
 }

--- a/HyperLiquid.Net/Interfaces/Clients/IHyperLiquidUserClientProvider.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/IHyperLiquidUserClientProvider.cs
@@ -22,6 +22,11 @@ namespace HyperLiquid.Net.Interfaces.Clients
         void ClearUserClients(string userIdentifier);
 
         /// <summary>
+        /// Clear all client from the cache
+        /// </summary>
+        void Clear();
+
+        /// <summary>
         /// Get the Rest client for a specific user. In case the client does not exist yet it will be created and the <paramref name="credentials"/> should be provided, unless <see cref="InitializeUserClient" /> has been called prior for this user.
         /// </summary>
         /// <param name="userIdentifier">The identifier for user</param>

--- a/HyperLiquid.Net/Interfaces/Clients/SpotApi/IHyperLiquidRestClientSpotApiAccount.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/SpotApi/IHyperLiquidRestClientSpotApiAccount.cs
@@ -25,7 +25,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.SpotApi
         /// </summary>
         /// <param name="address">["<c>user</c>"] Address to request balances for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidBalance[]>> GetBalancesAsync(string? address = null, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidBalance[]>> GetBalancesAsync(string? address = null, CancellationToken ct = default);
                 
         /// <summary>
         /// Send spot assets to another address. This transfer does not touch the EVM bridge.
@@ -40,7 +40,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.SpotApi
         /// <param name="asset">Asset name, for example "HYPE"</param>
         /// <param name="quantity">["<c>amount</c>"] Quantity to send</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> TransferSpotAsync(
+        Task<HttpResult> TransferSpotAsync(
             string destinationAddress,
             string asset,
             decimal quantity,

--- a/HyperLiquid.Net/Interfaces/Clients/SpotApi/IHyperLiquidRestClientSpotApiExchangeData.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/SpotApi/IHyperLiquidRestClientSpotApiExchangeData.cs
@@ -23,7 +23,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.SpotApi
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidSpotExchangeInfo>> GetExchangeInfoAsync(CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidSpotExchangeInfo>> GetExchangeInfoAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get exchange and ticker info. For tickers:
@@ -37,7 +37,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.SpotApi
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidExchangeInfoAndTickers>> GetExchangeInfoAndTickersAsync(CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidExchangeInfoAndTickers>> GetExchangeInfoAndTickersAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get information on an asset
@@ -50,7 +50,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.SpotApi
         /// </summary>
         /// <param name="assetId">["<c>tokenId</c>"] The asset id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidAssetInfo>> GetAssetInfoAsync(string assetId, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidAssetInfo>> GetAssetInfoAsync(string assetId, CancellationToken ct = default);
 
         /// <summary>
         /// Get HIP-4 questions and outcomes info
@@ -62,7 +62,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.SpotApi
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidQuestionsAndOutcomesInfo>> GetQuestionsAndOutcomesInfoAsync(CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidQuestionsAndOutcomesInfo>> GetQuestionsAndOutcomesInfoAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get HIP-4 settled outcome info
@@ -75,6 +75,6 @@ namespace HyperLiquid.Net.Interfaces.Clients.SpotApi
         /// </summary>
         /// <param name="outcomeId">The outcome id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<HyperLiquidSettledOutcome>> GetSettledOutcomeAsync(long outcomeId, CancellationToken ct = default);
+        Task<HttpResult<HyperLiquidSettledOutcome>> GetSettledOutcomeAsync(long outcomeId, CancellationToken ct = default);
     }
 }

--- a/HyperLiquid.Net/Interfaces/Clients/SpotApi/IHyperLiquidSocketClientSpotApiAccount.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/SpotApi/IHyperLiquidSocketClientSpotApiAccount.cs
@@ -23,7 +23,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.SpotApi
         /// </summary>
         /// <param name="address">["<c>user</c>"] Address to request balances for. If not provided will use the address provided in the API credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidBalance[]>> GetBalancesAsync(string? address = null, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidBalance[]>> GetBalancesAsync(string? address = null, CancellationToken ct = default);
 
         /// <summary>
         /// Send spot assets to another address. This transfer does not touch the EVM bridge.
@@ -36,7 +36,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.SpotApi
         /// <param name="asset">Asset name, for example "HYPE"</param>
         /// <param name="quantity">["<c>amount</c>"] Quantity to send</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult> TransferSpotAsync(
+        Task<QueryResult> TransferSpotAsync(
             string destinationAddress,
             string asset,
             decimal quantity,
@@ -56,6 +56,6 @@ namespace HyperLiquid.Net.Interfaces.Clients.SpotApi
         /// <param name="onMessage">The data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected and to unsubscribe</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToBalanceUpdatesAsync(string? address, Action<DataEvent<HyperLiquidBalanceUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToBalanceUpdatesAsync(string? address, Action<DataEvent<HyperLiquidBalanceUpdate>> onMessage, CancellationToken ct = default);
     }
 }

--- a/HyperLiquid.Net/Interfaces/Clients/SpotApi/IHyperLiquidSocketClientSpotApiExchangeData.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/SpotApi/IHyperLiquidSocketClientSpotApiExchangeData.cs
@@ -24,7 +24,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.SpotApi
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidSpotExchangeInfo>> GetExchangeInfoAsync(CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidSpotExchangeInfo>> GetExchangeInfoAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get exchange and ticker info
@@ -36,7 +36,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.SpotApi
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidExchangeInfoAndTickers>> GetExchangeInfoAndTickersAsync(CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidExchangeInfoAndTickers>> GetExchangeInfoAndTickersAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get information on an asset
@@ -49,7 +49,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.SpotApi
         /// </summary>
         /// <param name="assetId">["<c>tokenId</c>"] The asset id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidAssetInfo>> GetAssetInfoAsync(string assetId, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidAssetInfo>> GetAssetInfoAsync(string assetId, CancellationToken ct = default);
 
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.SpotApi
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidQuestionsAndOutcomesInfo>> GetQuestionsAndOutcomesInfoAsync(CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidQuestionsAndOutcomesInfo>> GetQuestionsAndOutcomesInfoAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get HIP-4 settled outcome info
@@ -75,7 +75,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.SpotApi
         /// </summary>
         /// <param name="outcomeId">The outcome id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<CallResult<HyperLiquidSettledOutcome>> GetSettledOutcomeAsync(long outcomeId, CancellationToken ct = default);
+        Task<QueryResult<HyperLiquidSettledOutcome>> GetSettledOutcomeAsync(long outcomeId, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to spot symbol updates
@@ -90,7 +90,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.SpotApi
         /// <param name="onMessage">The data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected and to unsubscribe</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToSymbolUpdatesAsync(string symbol, Action<DataEvent<HyperLiquidTicker>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToSymbolUpdatesAsync(string symbol, Action<DataEvent<HyperLiquidTicker>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to HIP-4 outcome updates 
@@ -101,7 +101,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.SpotApi
         /// <param name="onQuestionSettleUpdate">Question settled data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected and to unsubscribe</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToOutcomeInfoUpdatesAsync(
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToOutcomeInfoUpdatesAsync(
             Action<DataEvent<long>>? onOutcomeCreateUpdate = null,
             Action<DataEvent<HyperLiquidOutcomeInfo>>? onOutcomeSettleUpdate = null,
             Action<DataEvent<HyperLiquidQuestion>>? onQuestionUpdate = null,

--- a/HyperLiquid.Net/Objects/Internal/HyperLiquidSocketRequest.cs
+++ b/HyperLiquid.Net/Objects/Internal/HyperLiquidSocketRequest.cs
@@ -23,7 +23,7 @@ namespace HyperLiquid.Net.Objects.Internal
         [JsonPropertyName("type")]
         public string Type { get; set; } = string.Empty;
         [JsonPropertyName("payload")]
-        public ParameterCollection Payload { get; set; } = default!;
+        public Parameters Payload { get; set; } = default!;
     }
 
     internal class HyperLiquidSubscribeRequest: HyperLiquidSocketRequest

--- a/HyperLiquid.Net/Objects/Sockets/HyperLiquidPingQuery.cs
+++ b/HyperLiquid.Net/Objects/Sockets/HyperLiquidPingQuery.cs
@@ -10,7 +10,7 @@ namespace HyperLiquid.Net.Objects.Sockets
         public HyperLiquidPingQuery() : base(new HyperLiquidPing(), false)
         {
             RequestTimeout = TimeSpan.FromSeconds(5);
-            MessageRouter = MessageRouter.CreateWithoutHandler<HyperLiquidPong>("pong");
+            MessageRouter = MessageRouter.CreateVoid<HyperLiquidPong>("pong");
         }
     }
 }

--- a/HyperLiquid.Net/Objects/Sockets/HyperLiquidQuery.cs
+++ b/HyperLiquid.Net/Objects/Sockets/HyperLiquidQuery.cs
@@ -25,11 +25,11 @@ namespace HyperLiquid.Net.Objects.Sockets
             _client = client;
             MessageRouter = MessageRouter.Create([
                 MessageRoute.CreateForQuery<HyperLiquidSocketUpdate<T>>("subscriptionResponse", listenId, HandleMessage),
-                MessageRoute.CreateForQuery<HyperLiquidSocketUpdate<string>>("error", listenId, HandleError)
+                MessageRoute.CreateForQuery<HyperLiquidSocketUpdate<string>, HyperLiquidSocketUpdate<T>>("error", listenId, HandleError)
                 ]);
         }
 
-        public CallResult<HyperLiquidSocketUpdate<string>> HandleError(SocketConnection connection, DateTime receiveTime, string? originalData, HyperLiquidSocketUpdate<string> message)
+        public CallResult<HyperLiquidSocketUpdate<T>> HandleError(SocketConnection connection, DateTime receiveTime, string? originalData, HyperLiquidSocketUpdate<string> message)
         {
             var error = message.Data;
 
@@ -37,10 +37,10 @@ namespace HyperLiquid.Net.Objects.Sockets
              || error.StartsWith("Already unsubscribed"))
             {
                 // Allow duplicate subscriptions
-                return CallResult<HyperLiquidSocketUpdate<string>>.Ok(message, originalData);
+                return CallResult.Ok(new HyperLiquidSocketUpdate<T> { Channel = message.Channel }, originalData);
             }
 
-            return CallResult<HyperLiquidSocketUpdate<string>>.Fail(new ServerError(_client.GetErrorInfo("Subscription", error)), originalData);
+            return CallResult<HyperLiquidSocketUpdate<T>>.Fail(new ServerError(_client.GetErrorInfo("Subscription", error)), originalData);
         }
 
         public CallResult<HyperLiquidSocketUpdate<T>> HandleMessage(SocketConnection connection, DateTime receiveTime, string? originalData, HyperLiquidSocketUpdate<T> message)

--- a/HyperLiquid.Net/Objects/Sockets/HyperLiquidQuery.cs
+++ b/HyperLiquid.Net/Objects/Sockets/HyperLiquidQuery.cs
@@ -24,8 +24,8 @@ namespace HyperLiquid.Net.Objects.Sockets
         {
             _client = client;
             MessageRouter = MessageRouter.Create([
-                MessageRoute<HyperLiquidSocketUpdate<T>>.CreateWithTopicFilter("subscriptionResponse", listenId, HandleMessage),
-                MessageRoute<HyperLiquidSocketUpdate<string>>.CreateWithTopicFilter("error", listenId, HandleError)
+                MessageRoute.CreateForQuery<HyperLiquidSocketUpdate<T>>("subscriptionResponse", listenId, HandleMessage),
+                MessageRoute.CreateForQuery<HyperLiquidSocketUpdate<string>>("error", listenId, HandleError)
                 ]);
         }
 
@@ -37,10 +37,10 @@ namespace HyperLiquid.Net.Objects.Sockets
              || error.StartsWith("Already unsubscribed"))
             {
                 // Allow duplicate subscriptions
-                return new CallResult<HyperLiquidSocketUpdate<string>>(message, originalData, null);
+                return CallResult<HyperLiquidSocketUpdate<string>>.Ok(message, originalData);
             }
 
-            return new CallResult<HyperLiquidSocketUpdate<string>>(new ServerError(_client.GetErrorInfo("Subscription", error)));
+            return CallResult<HyperLiquidSocketUpdate<string>>.Fail(new ServerError(_client.GetErrorInfo("Subscription", error)), originalData);
         }
 
         public CallResult<HyperLiquidSocketUpdate<T>> HandleMessage(SocketConnection connection, DateTime receiveTime, string? originalData, HyperLiquidSocketUpdate<T> message)
@@ -51,10 +51,10 @@ namespace HyperLiquid.Net.Objects.Sockets
             {
                 var err = _errorString;
                 _errorString = null;
-                return new CallResult<HyperLiquidSocketUpdate<T>>(new ServerError(_client.GetErrorInfo("Subscription", err)));
+                return CallResult.Fail<HyperLiquidSocketUpdate<T>>(new ServerError(_client.GetErrorInfo("Subscription", err)), originalData);
             }
 
-            return new CallResult<HyperLiquidSocketUpdate<T>>(message, originalData, null);
+            return CallResult.Ok(message, originalData);
         }
     }
 }

--- a/HyperLiquid.Net/Objects/Sockets/HyperLiquidRequestQuery.cs
+++ b/HyperLiquid.Net/Objects/Sockets/HyperLiquidRequestQuery.cs
@@ -16,7 +16,7 @@ namespace HyperLiquid.Net.Objects.Sockets
             HyperLiquidSocketClientApi client,
             string method,
             string type,
-            ParameterCollection request,
+            Parameters request,
             bool authenticated, 
             int weight = 1) 
             : base(

--- a/HyperLiquid.Net/Objects/Sockets/HyperLiquidRequestQuery.cs
+++ b/HyperLiquid.Net/Objects/Sockets/HyperLiquidRequestQuery.cs
@@ -34,13 +34,13 @@ namespace HyperLiquid.Net.Objects.Sockets
                 client.AuthenticationProvider!.ProcessRequest(client, request);
 
                 MessageRouter = MessageRouter.Create([
-                    MessageRoute<HyperLiquidSocketUpdate<HyperLiquidSocketResponseAuth<TResponse>>>.CreateWithoutTopicFilter(((HyperLiquidRequest)Request).Id.ToString(), HandleMessage),
+                    MessageRoute.CreateForQuery<HyperLiquidSocketUpdate<HyperLiquidSocketResponseAuth<TResponse>>, TResponse>(((HyperLiquidRequest)Request).Id.ToString(), HandleMessage),
                 ]);
             }
             else
             {
                 MessageRouter = MessageRouter.Create([
-                    MessageRoute<HyperLiquidSocketUpdate<HyperLiquidSocketResponse<TResponse>>>.CreateWithoutTopicFilter(((HyperLiquidRequest)Request).Id.ToString(), HandleMessage),
+                    MessageRoute.CreateForQuery<HyperLiquidSocketUpdate<HyperLiquidSocketResponse<TResponse>>, TResponse>(((HyperLiquidRequest)Request).Id.ToString(), HandleMessage),
                 ]);
             }
         }
@@ -48,14 +48,14 @@ namespace HyperLiquid.Net.Objects.Sockets
         public CallResult<TResponse> HandleMessage(SocketConnection connection, DateTime receiveTime, string? originalData, HyperLiquidSocketUpdate<HyperLiquidSocketResponseAuth<TResponse>> message)
         {
             if (!message.Data.Response.Payload.Status.Equals("ok"))
-                return new CallResult<TResponse>(new ServerError(ErrorInfo.Unknown with { Message = message.Data.Response.Payload.Status }), originalData);
+                return CallResult<TResponse>.Fail(new ServerError(ErrorInfo.Unknown with { Message = message.Data.Response.Payload.Status }), originalData);
 
-            return new CallResult<TResponse>(message.Data.Response.Payload.Data!.Data, originalData, null);
+            return CallResult<TResponse>.Ok(message.Data.Response.Payload.Data!.Data, originalData);
         }
 
         public CallResult<TResponse> HandleMessage(SocketConnection connection, DateTime receiveTime, string? originalData, HyperLiquidSocketUpdate<HyperLiquidSocketResponse<TResponse>> message)
         {
-            return new CallResult<TResponse>(message.Data.Response.Payload.Data, originalData, null);
+            return CallResult<TResponse>.Ok(message.Data.Response.Payload.Data, originalData);
         }
     }
 }

--- a/HyperLiquid.Net/Objects/Sockets/Subscriptions/HyperLiquidSubscription.cs
+++ b/HyperLiquid.Net/Objects/Sockets/Subscriptions/HyperLiquidSubscription.cs
@@ -37,7 +37,6 @@ namespace HyperLiquid.Net.Objects.Sockets.Subscriptions
             _topic = topic;
             _parameters = parameters ?? new();
 
-            var listenId = (alternativeTopic ?? topic) + listenSuffix;
             MessageRouter = MessageRouter.CreateForEvent<HyperLiquidSocketUpdate<T>>(alternativeTopic ?? topic, listenSuffix, DoHandleMessage);
         }
 

--- a/HyperLiquid.Net/Objects/Sockets/Subscriptions/HyperLiquidSubscription.cs
+++ b/HyperLiquid.Net/Objects/Sockets/Subscriptions/HyperLiquidSubscription.cs
@@ -38,7 +38,7 @@ namespace HyperLiquid.Net.Objects.Sockets.Subscriptions
             _parameters = parameters ?? new();
 
             var listenId = (alternativeTopic ?? topic) + listenSuffix;
-            MessageRouter = MessageRouter.CreateWithOptionalTopicFilter<HyperLiquidSocketUpdate<T>>(alternativeTopic ?? topic, listenSuffix, DoHandleMessage);
+            MessageRouter = MessageRouter.CreateForEvent<HyperLiquidSocketUpdate<T>>(alternativeTopic ?? topic, listenSuffix, DoHandleMessage);
         }
 
         /// <inheritdoc />
@@ -73,7 +73,7 @@ namespace HyperLiquid.Net.Objects.Sockets.Subscriptions
         public CallResult DoHandleMessage(SocketConnection connection, DateTime receiveTime, string? originalData, HyperLiquidSocketUpdate<T> message)
         {
             _handler.Invoke(receiveTime, originalData, ConnectionInvocations, message);
-            return CallResult.SuccessResult;
+            return CallResult.Ok();
         }
     }
 }

--- a/HyperLiquid.Net/SymbolOrderBooks/HyperLiquidSymbolOrderBook.cs
+++ b/HyperLiquid.Net/SymbolOrderBooks/HyperLiquidSymbolOrderBook.cs
@@ -69,20 +69,20 @@ namespace HyperLiquid.Net.SymbolOrderBooks
         {
             // Uses SpotApi but can also be used for futures
             var sub = await _socketClient.SpotApi.ExchangeData.SubscribeToOrderBookUpdatesAsync(Symbol, HandleUpdate, nSigFigs: _nSigFigs, mantissa: _mantissa,  ct: ct).ConfigureAwait(false);
-            if (!sub)
-                return sub;
+            if (!sub.Success)
+                return CallResult.Fail<UpdateSubscription>(sub.Error);
 
             Status = OrderBookStatus.Syncing;
 
             var set = await WaitForSetOrderBookAsync(_initialDataTimeout, ct).ConfigureAwait(false);
-            if (!set)
+            if (!set.Success)
             {
                 await sub.Data.CloseAsync().ConfigureAwait(false);
-                return new CallResult<UpdateSubscription>(set.Error!);
+                return CallResult.Fail<UpdateSubscription>(set.Error!);
             }
 
             Status = OrderBookStatus.Synced;
-            return sub;
+            return CallResult.Ok(sub.Data);
         }
 
         private void HandleUpdate(DataEvent<HyperLiquidOrderBook> @event)
@@ -96,7 +96,7 @@ namespace HyperLiquid.Net.SymbolOrderBooks
         }
 
         /// <inheritdoc />
-        protected override async Task<CallResult<bool>> DoResyncAsync(CancellationToken ct)
+        protected override async Task<CallResult> DoResyncAsync(CancellationToken ct)
         {
             return await WaitForSetOrderBookAsync(_initialDataTimeout, ct).ConfigureAwait(false);
         }

--- a/HyperLiquid.Net/Utils/HyperLiquidUtils.cs
+++ b/HyperLiquid.Net/Utils/HyperLiquidUtils.cs
@@ -38,29 +38,7 @@ namespace HyperLiquid.Net.Utils
         // We should only send builder credentials if the check has succeeded
         internal static bool _builderFeeSuccess = false;
 
-        internal static async Task<CallResult> CheckBuilderFeeAsync(HyperLiquidSocketClient client)
-        {
-            if (!client.SpotApi.Authenticated)
-                // No credentials provided, no need to check builder fee
-                return CallResult.Ok();
-
-            var envName = client.ClientOptions.Environment.Name;
-            if (envName.Equals("UnitTest", StringComparison.Ordinal))
-                return CallResult.Ok();
-
-            var options = client.ClientOptions;
-            var result = await CheckBuilderFeeAsync(
-                options.BuilderFeePercentage, 
-                () => client.SpotApi.Account.GetApprovedBuilderFeeAsync(),
-                () => client.SpotApi.Account.ApproveBuilderFeeAsync()).ConfigureAwait(false);
-
-            if (!result.Success)
-                LibraryHelpers.StaticLogger?.LogDebug("Builder fee approval failed: {Error}", result.Error);
-
-            return result;
-        }
-
-        internal static async Task<CallResult> CheckBuilderFeeAsync(HyperLiquidRestClient client)
+        internal static async Task<ICallResult> CheckBuilderFeeAsync(HyperLiquidSocketClient client)
         {
             if (!client.SpotApi.Authenticated)
                 // No credentials provided, no need to check builder fee
@@ -82,10 +60,32 @@ namespace HyperLiquid.Net.Utils
             return result;
         }
 
-        internal static async Task<CallResult> CheckBuilderFeeAsync(
+        internal static async Task<ICallResult> CheckBuilderFeeAsync(HyperLiquidRestClient client)
+        {
+            if (!client.SpotApi.Authenticated)
+                // No credentials provided, no need to check builder fee
+                return CallResult.Ok();
+
+            var envName = client.ClientOptions.Environment.Name;
+            if (envName.Equals("UnitTest", StringComparison.Ordinal))
+                return CallResult.Ok();
+
+            var options = client.ClientOptions;
+            var result = await CheckBuilderFeeAsync(
+                options.BuilderFeePercentage,
+                async () => await client.SpotApi.Account.GetApprovedBuilderFeeAsync().ConfigureAwait(false),
+                async () => await client.SpotApi.Account.ApproveBuilderFeeAsync().ConfigureAwait(false)).ConfigureAwait(false);
+
+            if (!result.Success)
+                LibraryHelpers.StaticLogger?.LogDebug("Builder fee approval failed: {Error}", result.Error);
+
+            return result;
+        }
+
+        internal static async Task<ICallResult> CheckBuilderFeeAsync(
             decimal? builderFeePercentage,
-            Func<Task<CallResult<int>>> getApprovedFee,
-            Func<Task<CallResult>> approveFee)
+            Func<Task<ICallResult<int>>> getApprovedFee,
+            Func<Task<ICallResult>> approveFee)
         {
             if (_checkedBuilderFee)
                 return CallResult.Ok();
@@ -104,7 +104,7 @@ namespace HyperLiquid.Net.Utils
                 _checkedBuilderFee = true;
 
                 var approvedResult = await getApprovedFee().ConfigureAwait(false);
-                if (!approvedResult)
+                if (!approvedResult.Success)
                     return approvedResult;
 
                 var targetBps = (int)(builderFeePercentage.Value * 1000);
@@ -116,7 +116,7 @@ namespace HyperLiquid.Net.Utils
                 }
 
                 var approveResult = await approveFee().ConfigureAwait(false);
-                if (approveResult)
+                if (approveResult.Success)
                     _builderFeeSuccess = true;
 
                 return approveResult;
@@ -130,7 +130,7 @@ namespace HyperLiquid.Net.Utils
         /// <summary>
         /// Update the internal spot symbol info
         /// </summary>
-        public static async Task<CallResult> UpdateFuturesSymbolInfoAsync(HyperLiquidRestClient client)
+        public static async Task<ICallResult> UpdateFuturesSymbolInfoAsync(HyperLiquidRestClient client)
         {
             var envName = client.ClientOptions.Environment.Name;
             if (envName.Equals("UnitTest", StringComparison.Ordinal))
@@ -142,7 +142,7 @@ namespace HyperLiquid.Net.Utils
         /// <summary>
         /// Update the internal spot symbol info
         /// </summary>
-        public static async Task<CallResult> UpdateFuturesSymbolInfoAsync(HyperLiquidSocketClient client)
+        public static async Task<ICallResult> UpdateFuturesSymbolInfoAsync(HyperLiquidSocketClient client)
         {
             var envName = client.ClientOptions.Environment.Name;
             if (envName.Equals("UnitTest", StringComparison.Ordinal))
@@ -154,7 +154,7 @@ namespace HyperLiquid.Net.Utils
         /// <summary>
         /// Update the internal futures symbol info
         /// </summary>
-        private static async Task<CallResult> UpdateFuturesSymbolInfoAsync(string envName, Func<Task<CallResult<HyperLiquidFuturesDexInfo[]>>> exchangeInfoCall)
+        private static async Task<ICallResult> UpdateFuturesSymbolInfoAsync(string envName, Func<Task<ICallResult<HyperLiquidFuturesDexInfo[]>>> exchangeInfoCall)
         {
             await _semaphoreFutures.WaitAsync().ConfigureAwait(false);
 
@@ -165,8 +165,8 @@ namespace HyperLiquid.Net.Utils
                     return CallResult.Ok();
 
                 var symbolInfo = await exchangeInfoCall().ConfigureAwait(false);
-                if (!symbolInfo)
-                    return symbolInfo.AsDataless();
+                if (!symbolInfo.Success)
+                    return symbolInfo;
 
                 _futuresSymbolInfo[envName] = symbolInfo.Data;
                 _lastFuturesUpdateTime[envName] = DateTime.UtcNow;
@@ -182,7 +182,7 @@ namespace HyperLiquid.Net.Utils
         /// <summary>
         /// Update the internal spot symbol info
         /// </summary>
-        public static async Task<CallResult> UpdateSpotSymbolInfoAsync(HyperLiquidRestClient client)
+        public static async Task<ICallResult> UpdateSpotSymbolInfoAsync(HyperLiquidRestClient client)
         {
             var envName = client.ClientOptions.Environment.Name;
             if (envName.Equals("UnitTest", StringComparison.Ordinal))
@@ -194,7 +194,7 @@ namespace HyperLiquid.Net.Utils
         /// <summary>
         /// Update the internal spot symbol info
         /// </summary>
-        public static async Task<CallResult> UpdateSpotSymbolInfoAsync(HyperLiquidSocketClient client)
+        public static async Task<ICallResult> UpdateSpotSymbolInfoAsync(HyperLiquidSocketClient client)
         {
             var envName = client.ClientOptions.Environment.Name;
             if (envName.Equals("UnitTest", StringComparison.Ordinal))
@@ -203,7 +203,7 @@ namespace HyperLiquid.Net.Utils
             return await UpdateSpotSymbolInfoAsync(envName, async () => await client.SpotApi.ExchangeData.GetExchangeInfoAsync().ConfigureAwait(false)).ConfigureAwait(false);
         }
 
-        private static async Task<CallResult> UpdateSpotSymbolInfoAsync(string envName, Func<Task<CallResult<HyperLiquidSpotExchangeInfo>>> exchangeInfoCall)
+        private static async Task<ICallResult> UpdateSpotSymbolInfoAsync(string envName, Func<Task<ICallResult<HyperLiquidSpotExchangeInfo>>> exchangeInfoCall)
         {
             await _semaphoreSpot.WaitAsync().ConfigureAwait(false);
             try
@@ -213,8 +213,8 @@ namespace HyperLiquid.Net.Utils
                     return CallResult.Ok();
 
                 var symbolInfo = await exchangeInfoCall().ConfigureAwait(false);
-                if (!symbolInfo)
-                    return symbolInfo.AsDataless();
+                if (!symbolInfo.Success)
+                    return symbolInfo;
 
                 _spotSymbolInfo[envName] = symbolInfo.Data.Symbols;
                 _spotAssetInfo[envName] = symbolInfo.Data.Assets;
@@ -230,7 +230,7 @@ namespace HyperLiquid.Net.Utils
         /// <summary>
         /// Update the internal spot symbol info
         /// </summary>
-        public static async Task<CallResult> UpdateOutcomeInfoAsync(HyperLiquidRestClient client)
+        public static async Task<ICallResult> UpdateOutcomeInfoAsync(HyperLiquidRestClient client)
         {
             var envName = client.ClientOptions.Environment.Name;
             if (envName.Equals("UnitTest", StringComparison.Ordinal))
@@ -251,7 +251,7 @@ namespace HyperLiquid.Net.Utils
         //    return await UpdateSpotSymbolInfoAsync(envName, async () => await client.SpotApi.ExchangeData.GetQuestionsAndOutcomesInfoAsync().ConfigureAwait(false)).ConfigureAwait(false);
         //}
 
-        private static async Task<CallResult> UpdateOutcomeInfoAsync(string envName, Func<Task<CallResult<HyperLiquidQuestionsAndOutcomesInfo>>> infoCall)
+        private static async Task<ICallResult> UpdateOutcomeInfoAsync(string envName, Func<Task<ICallResult<HyperLiquidQuestionsAndOutcomesInfo>>> infoCall)
         {
             await _semaphoreOutcomes.WaitAsync().ConfigureAwait(false);
             try
@@ -261,8 +261,8 @@ namespace HyperLiquid.Net.Utils
                     return CallResult.Ok();
 
                 var infoResult = await infoCall().ConfigureAwait(false);
-                if (!infoResult)
-                    return infoResult.AsDataless();
+                if (!infoResult.Success)
+                    return infoResult;
 
                 _outcomesInfo[envName] = infoResult.Data;
                 _lastOutcomesUpdateTime[envName] = DateTime.UtcNow;
@@ -277,11 +277,11 @@ namespace HyperLiquid.Net.Utils
         /// <summary>
         /// Get symbol id from a symbol name
         /// </summary>
-        public static async Task<CallResult<int>> GetSymbolIdFromNameAsync(HyperLiquidRestClient client, string symbolName)
+        public static async Task<ICallResult<int>> GetSymbolIdFromNameAsync(HyperLiquidRestClient client, string symbolName)
         {
             var envName = client.ClientOptions.Environment.Name;
             if (envName.Equals("UnitTest", StringComparison.Ordinal))
-                return new CallResult<int>(1);
+                return CallResult.Ok(1);
 
             return await GetSymbolIdFromNameAsync(envName, symbolName, () => UpdateSpotSymbolInfoAsync(client), () => UpdateFuturesSymbolInfoAsync(client)).ConfigureAwait(false);
         }
@@ -289,34 +289,34 @@ namespace HyperLiquid.Net.Utils
         /// <summary>
         /// Get symbol id from a symbol name
         /// </summary>
-        public static async Task<CallResult<int>> GetSymbolIdFromNameAsync(HyperLiquidSocketClient client, string symbolName)
+        public static async Task<ICallResult<int>> GetSymbolIdFromNameAsync(HyperLiquidSocketClient client, string symbolName)
         {
             var envName = client.ClientOptions.Environment.Name;
             if (envName.Equals("UnitTest", StringComparison.Ordinal))
-                return new CallResult<int>(1);
+                return CallResult.Ok(1);
 
             return await GetSymbolIdFromNameAsync(envName, symbolName, () => UpdateSpotSymbolInfoAsync(client), () => UpdateFuturesSymbolInfoAsync(client)).ConfigureAwait(false);
         }
 
-        private static async Task<CallResult<int>> GetSymbolIdFromNameAsync(string envName, string symbolName, Func<Task<CallResult>> spotUpdate, Func<Task<CallResult>> futuresUpdate)
+        private static async Task<ICallResult<int>> GetSymbolIdFromNameAsync(string envName, string symbolName, Func<Task<ICallResult>> spotUpdate, Func<Task<ICallResult>> futuresUpdate)
         {
             if (SymbolIsExchangeSpotSymbol(symbolName))
             {
                 var update = await spotUpdate().ConfigureAwait(false);
-                if (!update)
-                    return new CallResult<int>(update.Error!);
+                if (!update.Success)
+                    return CallResult.Fail<int>(update.Error!);
 
                 var symbol = _spotSymbolInfo[envName].SingleOrDefault(x => x.Name == symbolName);
                 if (symbol == null)
-                    return new CallResult<int>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
+                    return CallResult.Fail<int>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
-                return new CallResult<int>(symbol.Index + 10000);
+                return CallResult.Ok(symbol.Index + 10000);
             }
             else
             {
                 var update = await futuresUpdate().ConfigureAwait(false);
-                if (!update)
-                    return new CallResult<int>(update.Error!);
+                if (!update.Success)
+                    return CallResult.Fail<int>(update.Error!);
 
                 var symbolSplit = symbolName.Split(':');
                 if (symbolSplit.Length == 2)
@@ -325,21 +325,21 @@ namespace HyperLiquid.Net.Utils
                     var dexName = symbolSplit[0];
                     var dex = _futuresSymbolInfo[envName].SingleOrDefault(x => x.Name.Equals(dexName, StringComparison.InvariantCultureIgnoreCase));
                     if (dex == null)
-                        return new CallResult<int>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "DEX not found")));
+                        return CallResult.Fail<int>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "DEX not found")));
 
                     var symbol = dex.Symbols.SingleOrDefault(x => x.Name == symbolName);
                     if (symbol == null)
-                        return new CallResult<int>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
+                        return CallResult.Fail<int>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
-                    return new CallResult<int>(100000 + dex.Index * 10000 + symbol.Index);
+                    return CallResult.Ok(100000 + dex.Index * 10000 + symbol.Index);
                 }
                 else
                 {
                     var symbol = _futuresSymbolInfo[envName][0].Symbols.SingleOrDefault(x => x.Name == symbolName);
                     if (symbol == null)
-                        return new CallResult<int>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
+                        return CallResult.Fail<int>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
-                    return new CallResult<int>(symbol.Index);
+                    return CallResult.Ok(symbol.Index);
                 }
             }
         }
@@ -347,11 +347,11 @@ namespace HyperLiquid.Net.Utils
         /// <summary>
         /// Get the quantity decimal places for a symbol
         /// </summary>
-        public static async Task<CallResult<int>> GetQuantityDecimalPlacesForSymbolAsync(HyperLiquidRestClient client, string symbolName)
+        public static async Task<ICallResult<int>> GetQuantityDecimalPlacesForSymbolAsync(HyperLiquidRestClient client, string symbolName)
         {
             var envName = client.ClientOptions.Environment.Name;
             if (envName.Equals("UnitTest", StringComparison.Ordinal))
-                return new CallResult<int>(1);
+                return CallResult<int>.Ok(1);
 
             return await GetQuantityDecimalPlacesForSymbolAsync(envName, symbolName, () => UpdateSpotSymbolInfoAsync(client), () => UpdateFuturesSymbolInfoAsync(client)).ConfigureAwait(false);
         }
@@ -359,34 +359,34 @@ namespace HyperLiquid.Net.Utils
         /// <summary>
         /// Get the quantity decimal places for a symbol
         /// </summary>
-        public static async Task<CallResult<int>> GetQuantityDecimalPlacesForSymbolAsync(HyperLiquidSocketClient client, string symbolName)
+        public static async Task<ICallResult<int>> GetQuantityDecimalPlacesForSymbolAsync(HyperLiquidSocketClient client, string symbolName)
         {
             var envName = client.ClientOptions.Environment.Name;
             if (envName.Equals("UnitTest", StringComparison.Ordinal))
-                return new CallResult<int>(1);
+                return CallResult<int>.Ok(1);
 
             return await GetQuantityDecimalPlacesForSymbolAsync(envName, symbolName, () => UpdateSpotSymbolInfoAsync(client), () => UpdateFuturesSymbolInfoAsync(client)).ConfigureAwait(false);
         }
 
-        private static async Task<CallResult<int>> GetQuantityDecimalPlacesForSymbolAsync(string envName, string symbolName, Func<Task<CallResult>> spotUpdate, Func<Task<CallResult>> futuresUpdate)
+        private static async Task<CallResult<int>> GetQuantityDecimalPlacesForSymbolAsync(string envName, string symbolName, Func<Task<ICallResult>> spotUpdate, Func<Task<ICallResult>> futuresUpdate)
         {
             if (SymbolIsExchangeSpotSymbol(symbolName))
             {
                 var update = await spotUpdate().ConfigureAwait(false);
-                if (!update)
-                    return new CallResult<int>(update.Error!);
+                if (!update.Success)
+                    return CallResult.Fail<int>(update.Error!);
 
                 var symbol = _spotSymbolInfo[envName].SingleOrDefault(x => x.Name == symbolName);
                 if (symbol == null)
-                    return new CallResult<int>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
+                    return CallResult.Fail<int>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
-                return new CallResult<int>(symbol.BaseAsset.QuantityDecimals);
+                return CallResult<int>.Ok(symbol.BaseAsset.QuantityDecimals);
             }
             else
             {
                 var update = await futuresUpdate().ConfigureAwait(false);
-                if (!update)
-                    return new CallResult<int>(update.Error!);
+                if (!update.Success)
+                    return CallResult.Fail<int>(update.Error!);
 
                 var symbolSplit = symbolName.Split(':');
                 if (symbolSplit.Length == 2)
@@ -395,22 +395,22 @@ namespace HyperLiquid.Net.Utils
                     var dexName = symbolSplit[0];
                     var dex = _futuresSymbolInfo[envName].SingleOrDefault(x => x.Name.Equals(dexName, StringComparison.InvariantCultureIgnoreCase));
                     if (dex == null)
-                        return new CallResult<int>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "DEX not found")));
+                        return CallResult.Fail<int>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "DEX not found")));
 
                     var symbol = dex.Symbols.SingleOrDefault(x => x.Name == symbolName);
                     if (symbol == null)
-                        return new CallResult<int>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
+                        return CallResult.Fail<int>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
-                    return new CallResult<int>(symbol.QuantityDecimals);
+                    return CallResult<int>.Ok(symbol.QuantityDecimals);
                 }
                 else
                 {
 
                     var symbol = _futuresSymbolInfo[envName][0].Symbols.SingleOrDefault(x => x.Name == symbolName);
                     if (symbol == null)
-                        return new CallResult<int>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
+                        return CallResult.Fail<int>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
-                    return new CallResult<int>(symbol.QuantityDecimals);
+                    return CallResult<int>.Ok(symbol.QuantityDecimals);
                 }
             }
         }
@@ -421,23 +421,23 @@ namespace HyperLiquid.Net.Utils
         public static CallResult<string> GetSymbolNameFromExchangeName(string envName, string id)
         {
             if (envName.Equals("UnitTest", StringComparison.Ordinal))
-                return new CallResult<string>("HYPE");
+                return CallResult<string>.Ok("HYPE");
 
             var symbol = _spotSymbolInfo[envName].SingleOrDefault(x => x.ExchangeName == id);
             if (symbol == null)
-                return new CallResult<string>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
+                return CallResult<string>.Fail(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
-            return new CallResult<string>(symbol.Name);
+            return CallResult<string>.Ok(symbol.Name);
         }
 
         /// <summary>
         /// Get a symbol name from an exchange symbol name
         /// </summary>
-        public static async Task<CallResult<string>> GetSymbolNameFromExchangeNameAsync(HyperLiquidRestClient client, string id)
+        public static async Task<ICallResult<string>> GetSymbolNameFromExchangeNameAsync(HyperLiquidRestClient client, string id)
         {
             var envName = client.ClientOptions.Environment.Name;
             if (envName.Equals("UnitTest", StringComparison.Ordinal))
-                return new CallResult<string>("HYPE");
+                return CallResult<string>.Ok("HYPE");
 
             return await GetSymbolNameFromExchangeNameAsync(envName, id, () => UpdateSpotSymbolInfoAsync(client)).ConfigureAwait(false);
         }
@@ -445,37 +445,37 @@ namespace HyperLiquid.Net.Utils
         /// <summary>
         /// Get a symbol name from an exchange symbol name
         /// </summary>
-        public static async Task<CallResult<string>> GetSymbolNameFromExchangeNameAsync(HyperLiquidSocketClient client, string id)
+        public static async Task<ICallResult<string>> GetSymbolNameFromExchangeNameAsync(HyperLiquidSocketClient client, string id)
         {
             var envName = client.ClientOptions.Environment.Name;
             if (envName.Equals("UnitTest", StringComparison.Ordinal))
-                return new CallResult<string>("HYPE");
+                return CallResult<string>.Ok("HYPE");
 
             return await GetSymbolNameFromExchangeNameAsync(envName, id, () => UpdateSpotSymbolInfoAsync(client)).ConfigureAwait(false);
         }
 
-        private static async Task<CallResult<string>> GetSymbolNameFromExchangeNameAsync(string envName, string id, Func<Task<CallResult>> spotUpdate)
+        private static async Task<ICallResult<string>> GetSymbolNameFromExchangeNameAsync(string envName, string id, Func<Task<ICallResult>> spotUpdate)
         {
             var update = await spotUpdate().ConfigureAwait(false);
-            if (!update)
-                return new CallResult<string>(update.Error!);
+            if (!update.Success)
+                return CallResult.Fail<string>(update.Error!);
 
             var symbol = _spotSymbolInfo[envName].SingleOrDefault(x => x.ExchangeName == id);
             if (symbol == null)
-                return new CallResult<string>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
+                return CallResult.Fail<string>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
-            return new CallResult<string>(symbol.Name);
+            return CallResult<string>.Ok(symbol.Name);
         }
 
 
         /// <summary>
         /// Get an exchange symbol name from a symbol name
         /// </summary>
-        public static async Task<CallResult<string>> GetExchangeNameFromSymbolNameAsync(HyperLiquidRestClient client, string name)
+        public static async Task<ICallResult<string>> GetExchangeNameFromSymbolNameAsync(HyperLiquidRestClient client, string name)
         {
             var envName = client.ClientOptions.Environment.Name;
             if (envName.Equals("UnitTest", StringComparison.Ordinal))
-                return new CallResult<string>("HYPE");
+                return CallResult.Ok<string>("HYPE");
 
             return await GetExchangeNameFromSymbolNameAsync(envName, name, () => UpdateSpotSymbolInfoAsync(client)).ConfigureAwait(false);
         }
@@ -483,26 +483,26 @@ namespace HyperLiquid.Net.Utils
         /// <summary>
         /// Get an exchange symbol name from a symbol name
         /// </summary>
-        public static async Task<CallResult<string>> GetExchangeNameFromSymbolNameAsync(HyperLiquidSocketClient client, string name)
+        public static async Task<ICallResult<string>> GetExchangeNameFromSymbolNameAsync(HyperLiquidSocketClient client, string name)
         {
             var envName = client.ClientOptions.Environment.Name;
             if (envName.Equals("UnitTest", StringComparison.Ordinal))
-                return new CallResult<string>("HYPE");
+                return CallResult.Ok<string>("HYPE");
 
             return await GetExchangeNameFromSymbolNameAsync(envName, name, () => UpdateSpotSymbolInfoAsync(client)).ConfigureAwait(false);
         }
 
-        private static async Task<CallResult<string>> GetExchangeNameFromSymbolNameAsync(string envName, string name, Func<Task<CallResult>> spotUpdate)
+        private static async Task<CallResult<string>> GetExchangeNameFromSymbolNameAsync(string envName, string name, Func<Task<ICallResult>> spotUpdate)
         {
             var update = await spotUpdate().ConfigureAwait(false);
-            if (!update)
-                return new CallResult<string>(update.Error!);
+            if (!update.Success)
+                return CallResult.Fail<string>(update.Error!);
 
             var symbol = _spotSymbolInfo[envName].SingleOrDefault(x => x.Name == name);
             if (symbol == null)
-                return new CallResult<string>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
+                return CallResult.Fail<string>(new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
-            return new CallResult<string>(symbol.ExchangeName);
+            return CallResult.Ok<string>(symbol.ExchangeName);
         }
 
         /// <summary>
@@ -529,11 +529,11 @@ namespace HyperLiquid.Net.Utils
         /// <summary>
         /// Get asset name and id for an asset
         /// </summary>
-        public static async Task<CallResult<string>> GetAssetNameAndIdAsync(HyperLiquidRestClient client, string asset)
+        public static async Task<ICallResult<string>> GetAssetNameAndIdAsync(HyperLiquidRestClient client, string asset)
         {
             var envName = client.ClientOptions.Environment.Name;
             if (envName.Equals("UnitTest", StringComparison.Ordinal))
-                return new CallResult<string>("HYPE");
+                return CallResult.Ok<string>("HYPE");
 
             return await GetAssetNameAndIdAsync(envName, asset, () => UpdateSpotSymbolInfoAsync(client)).ConfigureAwait(false);
         }
@@ -541,26 +541,26 @@ namespace HyperLiquid.Net.Utils
         /// <summary>
         /// Get asset name and id for an asset
         /// </summary>
-        public static async Task<CallResult<string>> GetAssetNameAndIdAsync(HyperLiquidSocketClient client, string asset)
+        public static async Task<ICallResult<string>> GetAssetNameAndIdAsync(HyperLiquidSocketClient client, string asset)
         {
             var envName = client.ClientOptions.Environment.Name;
             if (envName.Equals("UnitTest", StringComparison.Ordinal))
-                return new CallResult<string>("HYPE");
+                return CallResult.Ok<string>("HYPE");
 
             return await GetAssetNameAndIdAsync(envName, asset, () => UpdateSpotSymbolInfoAsync(client)).ConfigureAwait(false);
         }
 
-        private static async Task<CallResult<string>> GetAssetNameAndIdAsync(string envName, string asset, Func<Task<CallResult>> spotUpdate)
+        private static async Task<CallResult<string>> GetAssetNameAndIdAsync(string envName, string asset, Func<Task<ICallResult>> spotUpdate)
         {
             var update = await spotUpdate().ConfigureAwait(false);
-            if (!update)
-                return new CallResult<string>(update.Error!);
+            if (!update.Success)
+                return CallResult.Fail<string>(update.Error!);
 
             var assetInfo = _spotAssetInfo[envName].SingleOrDefault(x => x.Name == asset);
             if (assetInfo == null)
-                return new CallResult<string>(new ServerError(new ErrorInfo(ErrorType.UnknownAsset, "Asset not found")));
+                return CallResult.Fail<string>(new ServerError(new ErrorInfo(ErrorType.UnknownAsset, "Asset not found")));
 
-            return new CallResult<string>(assetInfo.Name + ":" + assetInfo.AssetId);
+            return CallResult.Ok<string>(assetInfo.Name + ":" + assetInfo.AssetId);
         }
 
         /// <summary>
@@ -576,7 +576,7 @@ namespace HyperLiquid.Net.Utils
         {
             var envName = client.ClientOptions.Environment.Name;
             if (envName.Equals("UnitTest", StringComparison.Ordinal))
-                return new CallResult<HyperLiquidOutcomeSideModel>(new HyperLiquidOutcomeSideModel { OutcomeInfo = new HyperLiquidOutcomeInfo { }, Side = { } });
+                return CallResult.Ok<HyperLiquidOutcomeSideModel>(new HyperLiquidOutcomeSideModel { OutcomeInfo = new HyperLiquidOutcomeInfo { }, Side = { } });
 
             return await GetOutcomeInfoAsync(envName, outcomeId, () => UpdateOutcomeInfoAsync(client)).ConfigureAwait(false);
         }
@@ -590,26 +590,26 @@ namespace HyperLiquid.Net.Utils
         //    return await GetOutcomeInfoAsync(envName, outcomeId, () => UpdateOutcomeInfoAsync(client)).ConfigureAwait(false);
         //}
 
-        private static async Task<CallResult<HyperLiquidOutcomeSideModel>> GetOutcomeInfoAsync(string envName, string outcomeId, Func<Task<CallResult>> outcomeInfoUpdate)
+        private static async Task<CallResult<HyperLiquidOutcomeSideModel>> GetOutcomeInfoAsync(string envName, string outcomeId, Func<Task<ICallResult>> outcomeInfoUpdate)
         {
             var update = await outcomeInfoUpdate().ConfigureAwait(false);
-            if (!update)
-                return new CallResult<HyperLiquidOutcomeSideModel>(update.Error!);
+            if (!update.Success)
+                return CallResult.Fail<HyperLiquidOutcomeSideModel>(update.Error!);
 
             if (!outcomeId.StartsWith("#") && !outcomeId.StartsWith("#"))
-                return new CallResult<HyperLiquidOutcomeSideModel>(new ServerError(ErrorInfo.Unknown with { Message = "Invalid outcome id, should start with '#' (coin) or '+' (token name)" }));
+                return CallResult.Fail<HyperLiquidOutcomeSideModel>(new ServerError(ErrorInfo.Unknown with { Message = "Invalid outcome id, should start with '#' (coin) or '+' (token name)" }));
 
             var sideId = int.Parse(outcomeId[outcomeId.Length - 1].ToString());
             var parsedOutcomeId = (long.Parse(outcomeId.Substring(1)) - sideId) / 10;
             var outcomeInfo = _outcomesInfo[envName].Outcomes.SingleOrDefault(x => x.Id == parsedOutcomeId);
             if (outcomeInfo == null)
-                return new CallResult<HyperLiquidOutcomeSideModel>(new ServerError(ErrorInfo.Unknown with { Message = "Outcome not found" }));
+                return CallResult.Fail<HyperLiquidOutcomeSideModel>(new ServerError(ErrorInfo.Unknown with { Message = "Outcome not found" }));
 
             var sideInfo = outcomeInfo.Specs[sideId];
             if (sideId >= outcomeInfo.Specs.Length || sideInfo == null)
-                return new CallResult<HyperLiquidOutcomeSideModel>(new ServerError(ErrorInfo.Unknown with { Message = "Side not found" }));
+                return CallResult.Fail<HyperLiquidOutcomeSideModel>(new ServerError(ErrorInfo.Unknown with { Message = "Side not found" }));
 
-            return new CallResult<HyperLiquidOutcomeSideModel>(new HyperLiquidOutcomeSideModel
+            return CallResult.Ok<HyperLiquidOutcomeSideModel>(new HyperLiquidOutcomeSideModel
             {
                 OutcomeInfo = outcomeInfo!,
                 Side = sideInfo!

--- a/HyperLiquid.Net/Utils/HyperLiquidUtils.cs
+++ b/HyperLiquid.Net/Utils/HyperLiquidUtils.cs
@@ -42,11 +42,11 @@ namespace HyperLiquid.Net.Utils
         {
             if (!client.SpotApi.Authenticated)
                 // No credentials provided, no need to check builder fee
-                return CallResult.SuccessResult;
+                return CallResult.Ok();
 
             var envName = client.ClientOptions.Environment.Name;
             if (envName.Equals("UnitTest", StringComparison.Ordinal))
-                return CallResult.SuccessResult;
+                return CallResult.Ok();
 
             var options = client.ClientOptions;
             var result = await CheckBuilderFeeAsync(
@@ -64,11 +64,11 @@ namespace HyperLiquid.Net.Utils
         {
             if (!client.SpotApi.Authenticated)
                 // No credentials provided, no need to check builder fee
-                return CallResult.SuccessResult;
+                return CallResult.Ok();
 
             var envName = client.ClientOptions.Environment.Name;
             if (envName.Equals("UnitTest", StringComparison.Ordinal))
-                return CallResult.SuccessResult;
+                return CallResult.Ok();
 
             var options = client.ClientOptions;
             var result = await CheckBuilderFeeAsync(
@@ -88,13 +88,13 @@ namespace HyperLiquid.Net.Utils
             Func<Task<CallResult>> approveFee)
         {
             if (_checkedBuilderFee)
-                return CallResult.SuccessResult;
+                return CallResult.Ok();
 
             if (builderFeePercentage == null
                 || builderFeePercentage == 0)
             {
                 // No builder fee, no need to check
-                return CallResult.SuccessResult;
+                return CallResult.Ok();
             }
 
             await _semaphoreBuilderFee.WaitAsync().ConfigureAwait(false);
@@ -112,7 +112,7 @@ namespace HyperLiquid.Net.Utils
                 {
                     // Builder fee is approved, we're good
                     _builderFeeSuccess = true;
-                    return CallResult.SuccessResult;
+                    return CallResult.Ok();
                 }
 
                 var approveResult = await approveFee().ConfigureAwait(false);
@@ -134,7 +134,7 @@ namespace HyperLiquid.Net.Utils
         {
             var envName = client.ClientOptions.Environment.Name;
             if (envName.Equals("UnitTest", StringComparison.Ordinal))
-                return CallResult.SuccessResult;
+                return CallResult.Ok();
 
             return await UpdateFuturesSymbolInfoAsync(envName, async () => await client.FuturesApi.ExchangeData.GetExchangeInfoAllDexesAsync().ConfigureAwait(false)).ConfigureAwait(false);
         }
@@ -146,7 +146,7 @@ namespace HyperLiquid.Net.Utils
         {
             var envName = client.ClientOptions.Environment.Name;
             if (envName.Equals("UnitTest", StringComparison.Ordinal))
-                return CallResult.SuccessResult;
+                return CallResult.Ok();
 
             return await UpdateFuturesSymbolInfoAsync(envName, async () => await client.FuturesApi.ExchangeData.GetExchangeInfoAllDexesAsync().ConfigureAwait(false)).ConfigureAwait(false);
         }
@@ -162,7 +162,7 @@ namespace HyperLiquid.Net.Utils
             {
                 _lastFuturesUpdateTime.TryGetValue(envName, out var lastUpdateTime);
                 if (DateTime.UtcNow - lastUpdateTime < TimeSpan.FromHours(1))
-                    return CallResult.SuccessResult;
+                    return CallResult.Ok();
 
                 var symbolInfo = await exchangeInfoCall().ConfigureAwait(false);
                 if (!symbolInfo)
@@ -171,7 +171,7 @@ namespace HyperLiquid.Net.Utils
                 _futuresSymbolInfo[envName] = symbolInfo.Data;
                 _lastFuturesUpdateTime[envName] = DateTime.UtcNow;
 
-                return CallResult.SuccessResult;
+                return CallResult.Ok();
             }
             finally
             {
@@ -186,7 +186,7 @@ namespace HyperLiquid.Net.Utils
         {
             var envName = client.ClientOptions.Environment.Name;
             if (envName.Equals("UnitTest", StringComparison.Ordinal))
-                return CallResult.SuccessResult;
+                return CallResult.Ok();
 
             return await UpdateSpotSymbolInfoAsync(envName, async () => await client.SpotApi.ExchangeData.GetExchangeInfoAsync().ConfigureAwait(false)).ConfigureAwait(false);
         }
@@ -198,7 +198,7 @@ namespace HyperLiquid.Net.Utils
         {
             var envName = client.ClientOptions.Environment.Name;
             if (envName.Equals("UnitTest", StringComparison.Ordinal))
-                return CallResult.SuccessResult;
+                return CallResult.Ok();
 
             return await UpdateSpotSymbolInfoAsync(envName, async () => await client.SpotApi.ExchangeData.GetExchangeInfoAsync().ConfigureAwait(false)).ConfigureAwait(false);
         }
@@ -210,7 +210,7 @@ namespace HyperLiquid.Net.Utils
             {
                 _lastSpotUpdateTime.TryGetValue(envName, out var lastUpdateTime);
                 if (DateTime.UtcNow - lastUpdateTime < TimeSpan.FromHours(1))
-                    return CallResult.SuccessResult;
+                    return CallResult.Ok();
 
                 var symbolInfo = await exchangeInfoCall().ConfigureAwait(false);
                 if (!symbolInfo)
@@ -219,7 +219,7 @@ namespace HyperLiquid.Net.Utils
                 _spotSymbolInfo[envName] = symbolInfo.Data.Symbols;
                 _spotAssetInfo[envName] = symbolInfo.Data.Assets;
                 _lastSpotUpdateTime[envName] = DateTime.UtcNow;
-                return CallResult.SuccessResult;
+                return CallResult.Ok();
             }
             finally
             {
@@ -234,7 +234,7 @@ namespace HyperLiquid.Net.Utils
         {
             var envName = client.ClientOptions.Environment.Name;
             if (envName.Equals("UnitTest", StringComparison.Ordinal))
-                return CallResult.SuccessResult;
+                return CallResult.Ok();
 
             return await UpdateOutcomeInfoAsync(envName, async () => await client.SpotApi.ExchangeData.GetQuestionsAndOutcomesInfoAsync().ConfigureAwait(false)).ConfigureAwait(false);
         }
@@ -246,7 +246,7 @@ namespace HyperLiquid.Net.Utils
         //{
         //    var envName = client.ClientOptions.Environment.Name;
         //    if (envName.Equals("UnitTest", StringComparison.Ordinal))
-        //        return CallResult.SuccessResult;
+        //        return CallResult.Ok();
 
         //    return await UpdateSpotSymbolInfoAsync(envName, async () => await client.SpotApi.ExchangeData.GetQuestionsAndOutcomesInfoAsync().ConfigureAwait(false)).ConfigureAwait(false);
         //}
@@ -258,7 +258,7 @@ namespace HyperLiquid.Net.Utils
             {
                 _lastOutcomesUpdateTime.TryGetValue(envName, out var lastUpdateTime);
                 if (DateTime.UtcNow - lastUpdateTime < TimeSpan.FromHours(1))
-                    return CallResult.SuccessResult;
+                    return CallResult.Ok();
 
                 var infoResult = await infoCall().ConfigureAwait(false);
                 if (!infoResult)
@@ -266,7 +266,7 @@ namespace HyperLiquid.Net.Utils
 
                 _outcomesInfo[envName] = infoResult.Data;
                 _lastOutcomesUpdateTime[envName] = DateTime.UtcNow;
-                return CallResult.SuccessResult;
+                return CallResult.Ok();
             }
             finally
             {

--- a/HyperLiquid.Net/Utils/PackConverter.cs
+++ b/HyperLiquid.Net/Utils/PackConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
@@ -36,6 +37,8 @@ namespace HyperLiquid.Net.Utils
                 Pack(s, objList);
             else if (o is IDictionary objDict)
                 Pack(s, objDict);
+            else if (o is IDictionary<string, object> objDict2)
+                Pack(s, objDict2);
             else if (o is bool objBool)
                 Pack(s, objBool);
             else if (o is sbyte objSbyte)
@@ -108,6 +111,30 @@ namespace HyperLiquid.Net.Utils
                 Write(s, (uint)count);
             }
             foreach (object key in dict.Keys)
+            {
+                Pack(s, key);
+                Pack(s, dict[key]!);
+            }
+        }
+
+        private void Pack(Stream s, IDictionary<string, object> dict)
+        {
+            int count = dict.Count;
+            if (count < 16)
+            {
+                s.WriteByte((byte)(0x80 + count));
+            }
+            else if (count < 0x10000)
+            {
+                s.WriteByte(0xde);
+                Write(s, (ushort)count);
+            }
+            else
+            {
+                s.WriteByte(0xdf);
+                Write(s, (uint)count);
+            }
+            foreach (var key in dict.Keys)
             {
                 Pack(s, key);
                 Pack(s, dict[key]!);

--- a/docs/ai-api-map.md
+++ b/docs/ai-api-map.md
@@ -149,6 +149,7 @@ Use SharedApis for exchange-agnostic code across HyperLiquid, Binance, OKX, Bybi
 | Shared futures REST client | `new HyperLiquidRestClient().FuturesApi.SharedClient` |
 | Shared spot socket client | `new HyperLiquidSocketClient().SpotApi.SharedClient` |
 | Shared futures socket client | `new HyperLiquidSocketClient().FuturesApi.SharedClient` |
+| Discover shared capabilities | `client.SpotApi.SharedClient.Discover()` |
 | Shared spot ticker REST | `ISpotTickerRestClient.GetSpotTickerAsync(new GetTickerRequest(symbol))` |
 | Shared futures ticker REST | `IFuturesTickerRestClient.GetFuturesTickerAsync(new GetTickerRequest(symbol))` |
 | Shared spot order REST | `ISpotOrderRestClient.PlaceSpotOrderAsync(...)` |
@@ -159,6 +160,8 @@ Use SharedApis for exchange-agnostic code across HyperLiquid, Binance, OKX, Bybi
 | Shared order book socket | `IOrderBookSocketClient.SubscribeToOrderBookUpdatesAsync(...)` |
 | Shared trade socket | `ITradeSocketClient.SubscribeToTradeUpdatesAsync(...)` |
 
+Shared REST methods return `HttpResult<T>` / `HttpResult`; shared socket subscriptions return `WebSocketResult<UpdateSubscription>`; shared symbol/cache helpers such as `SupportsSpotSymbolAsync` and `SupportsFuturesSymbolAsync` can return `ExchangeCallResult<T>`.
+
 For shared socket subscriptions, keep the concrete socket client and unsubscribe with `await socketClient.UnsubscribeAsync(subscription.Data)`.
 
 ## Result Handling
@@ -166,8 +169,10 @@ For shared socket subscriptions, keep the concrete socket client and unsubscribe
 | Situation | Pattern |
 |---|---|
 | REST success check | `if (!result.Success) { Console.WriteLine(result.Error); return; }` |
-| Socket subscription success check | `if (!sub.Success) { Console.WriteLine(sub.Error); return; }` |
+| Socket subscription success check | `if (!sub.Success) { Console.WriteLine(sub.Error); return; }` where `sub` is `WebSocketResult<UpdateSubscription>` |
+| Socket request success check | `if (!query.Success) { Console.WriteLine(query.Error); return; }` where `query` is `QueryResult<T>` or `QueryResult` |
 | Read REST data | Read `result.Data` only after `result.Success` |
+| Read shared helper data | Read `ExchangeCallResult<T>.Data` only after `.Success` |
 | Retry decision | Retry only when `result.Error?.IsTransient == true` |
 | Cancellation | Pass `ct: cancellationToken` |
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -22,8 +22,8 @@ Primary documentation:
 - Use `HyperLiquidCredentials`, not generic `ApiCredentials`.
 - Include `using HyperLiquid.Net;` when using `HyperLiquidCredentials`, `HyperLiquidEnvironment`, or `HyperLiquidExchange`.
 - Always check `.Success` before reading `.Data`.
-- REST methods return `WebCallResult<T>` or `WebCallResult`.
-- WebSocket subscriptions and socket API requests return `CallResult<T>` or `CallResult`.
+- REST methods return `HttpResult<T>` or `HttpResult`.
+- WebSocket subscriptions and socket API requests return `WebSocketResult<T>` or `WebSocketResult`.
 - Reuse clients. Do not instantiate REST or socket clients per request in production.
 - Prefer dependency injection for long-running services.
 - Store WebSocket subscriptions and unsubscribe during shutdown.
@@ -160,9 +160,9 @@ Console.WriteLine(eth.MidPrice);
 For retry logic, only retry transient errors:
 
 ```csharp
-async Task<WebCallResult<T>> WithRetry<T>(Func<Task<WebCallResult<T>>> call, int maxAttempts = 3)
+async Task<HttpResult<T>> WithRetry<T>(Func<Task<HttpResult<T>>> call, int maxAttempts = 3)
 {
-    WebCallResult<T> last = default!;
+    HttpResult<T> last = default!;
 
     for (var attempt = 1; attempt <= maxAttempts; attempt++)
     {
@@ -462,7 +462,7 @@ Examples/ai-friendly/04-multi-exchange.cs
   CryptoExchange.Net SharedApis REST and socket patterns for spot and futures.
 
 Examples/ai-friendly/05-error-handling.cs
-  WebCallResult pattern, transient retry, symbol formatting, builder fee checks.
+  HttpResult pattern, transient retry, symbol formatting, builder fee checks.
 ```
 
 These files are intended to be copied into a console `Program.cs` after `dotnet add package HyperLiquid.Net`.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -23,7 +23,9 @@ Primary documentation:
 - Include `using HyperLiquid.Net;` when using `HyperLiquidCredentials`, `HyperLiquidEnvironment`, or `HyperLiquidExchange`.
 - Always check `.Success` before reading `.Data`.
 - REST methods return `HttpResult<T>` or `HttpResult`.
-- WebSocket subscriptions and socket API requests return `WebSocketResult<T>` or `WebSocketResult`.
+- WebSocket subscriptions return `WebSocketResult<UpdateSubscription>`.
+- WebSocket request API methods return `QueryResult<T>` or `QueryResult`.
+- Shared non-I/O symbol/cache helper methods can return `ExchangeCallResult<T>`.
 - Reuse clients. Do not instantiate REST or socket clients per request in production.
 - Prefer dependency injection for long-running services.
 - Store WebSocket subscriptions and unsubscribe during shutdown.
@@ -31,7 +33,7 @@ Primary documentation:
 - Do not invent endpoint names. If unsure, inspect `HyperLiquid.Net/Interfaces/Clients/**`.
 - Spot symbols are slash separated, for example `HYPE/USDC`; futures symbols are base asset only, for example `ETH`.
 - Market order examples still need a price argument because `PlaceOrderAsync` requires price for slippage calculation.
-- For multi-exchange code, use `CryptoExchange.Net.SharedApis` interfaces from each API's `.SharedClient`.
+- For multi-exchange code, use `CryptoExchange.Net.SharedApis` interfaces from each API's `.SharedClient` and call `.SharedClient.Discover()` to inspect supported features.
 
 ## Installation
 
@@ -353,8 +355,11 @@ await socketClient.UnsubscribeAsync(sub.Data);
 using CryptoExchange.Net.SharedApis;
 using HyperLiquid.Net.Clients;
 
-ISpotTickerRestClient tickerClient = new HyperLiquidRestClient().SpotApi.SharedClient;
+var restClient = new HyperLiquidRestClient();
+ISpotTickerRestClient tickerClient = restClient.SpotApi.SharedClient;
 var symbol = new SharedSymbol(TradingMode.Spot, "HYPE", "USDC");
+var info = restClient.SpotApi.SharedClient.Discover();
+var supportedFeatures = info.Features.Where(x => x.Supported).Select(x => x.EndpointName);
 
 var ticker = await tickerClient.GetSpotTickerAsync(new GetTickerRequest(symbol));
 if (!ticker.Success)
@@ -366,7 +371,9 @@ if (!ticker.Success)
 Console.WriteLine(ticker.Data.LastPrice);
 ```
 
-Shared socket subscriptions return an `UpdateSubscription` in `.Data`. Keep the concrete socket client and unsubscribe through it:
+Shared REST methods return `HttpResult<T>` / `HttpResult`. Shared socket subscriptions return `WebSocketResult<UpdateSubscription>` with an `UpdateSubscription` in `.Data`. Shared symbol helpers can return `ExchangeCallResult<T>`.
+
+Keep the concrete socket client and unsubscribe through it:
 
 ```csharp
 var socketClient = new HyperLiquidSocketClient();
@@ -459,10 +466,10 @@ Examples/ai-friendly/03-websocket.cs
   Public ticker/orderbook streams, authenticated order stream, success checks, teardown.
 
 Examples/ai-friendly/04-multi-exchange.cs
-  CryptoExchange.Net SharedApis REST and socket patterns for spot and futures.
+  CryptoExchange.Net SharedApis REST/socket patterns for spot and futures, plus capability discovery.
 
 Examples/ai-friendly/05-error-handling.cs
-  HttpResult pattern, transient retry, symbol formatting, builder fee checks.
+  HttpResult, QueryResult, WebSocketResult, ExchangeCallResult patterns; transient retry; symbol formatting; builder fee checks.
 ```
 
 These files are intended to be copied into a console `Program.cs` after `dotnet add package HyperLiquid.Net`.

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Strongly typed .NET client library for the HyperLiquid DEX REST and WebSocket APIs. Supports spot, perpetual futures, staking, vaults, HIP-3 DEX metadata, HIP-4 outcome metadata and streams, REST requests, WebSocket subscriptions, local order books, and CryptoExchange.Net SharedApis.
 
-HyperLiquid.Net is the C# client for HyperLiquid in the CryptoExchange.Net ecosystem. It provides strongly typed models, `HttpResult<T>` / `WebSocketResult<T>` result handling, automatic WebSocket reconnection, client-side rate limiting, local order book support, user client management, native AOT support, and shared interfaces for multi-exchange applications. Current version in this repository: 4.7.1. Targets netstandard2.0, netstandard2.1, net8.0, net9.0, net10.0.
+HyperLiquid.Net is the C# client for HyperLiquid in the CryptoExchange.Net ecosystem. It provides strongly typed models, automatic WebSocket reconnection, client-side rate limiting, local order book support, user client management, native AOT support, and shared interfaces for multi-exchange applications. REST methods return `HttpResult<T>` / `HttpResult`, WebSocket subscriptions return `WebSocketResult<UpdateSubscription>`, WebSocket request APIs return `QueryResult<T>` / `QueryResult`, and selected shared helper methods return `ExchangeCallResult<T>`. Current version in this repository: 4.7.1. Targets netstandard2.0, netstandard2.1, net8.0, net9.0, net10.0.
 
 ## Documentation
 
@@ -17,8 +17,8 @@ HyperLiquid.Net is the C# client for HyperLiquid in the CryptoExchange.Net ecosy
 - [Spot Quickstart](https://github.com/JKorf/HyperLiquid.Net/blob/main/Examples/ai-friendly/01-spot-quickstart.cs): Client setup, prices, spot ticker metadata, authenticated balances, spot order pattern
 - [Futures Trading](https://github.com/JKorf/HyperLiquid.Net/blob/main/Examples/ai-friendly/02-futures.cs): Perp metadata, leverage, futures account positions, market/reduce-only order pattern
 - [WebSocket Streams](https://github.com/JKorf/HyperLiquid.Net/blob/main/Examples/ai-friendly/03-websocket.cs): Spot ticker, futures ticker, order book, authenticated order stream, proper teardown
-- [Multi-Exchange Pattern](https://github.com/JKorf/HyperLiquid.Net/blob/main/Examples/ai-friendly/04-multi-exchange.cs): CryptoExchange.Net SharedApis for exchange-agnostic spot/futures ticker and socket code
-- [Error Handling](https://github.com/JKorf/HyperLiquid.Net/blob/main/Examples/ai-friendly/05-error-handling.cs): HttpResult pattern, retry logic, symbol formatting, builder fee checks
+- [Multi-Exchange Pattern](https://github.com/JKorf/HyperLiquid.Net/blob/main/Examples/ai-friendly/04-multi-exchange.cs): CryptoExchange.Net SharedApis for exchange-agnostic spot/futures ticker, socket code, and capability discovery
+- [Error Handling](https://github.com/JKorf/HyperLiquid.Net/blob/main/Examples/ai-friendly/05-error-handling.cs): HttpResult, QueryResult, WebSocketResult, and ExchangeCallResult patterns, retry logic, symbol formatting, builder fee checks
 - [Full Examples Repository](https://github.com/JKorf/HyperLiquid.Net/tree/main/Examples): Console, API, order book, custom order book, and tracker examples
 
 ## Critical Usage Rules
@@ -27,10 +27,12 @@ HyperLiquid.Net is the C# client for HyperLiquid in the CryptoExchange.Net ecosy
 - Use `HyperLiquidCredentials("PUBLIC_ADDRESS", "PRIVATE_KEY")`, not generic `ApiCredentials`.
 - Spot symbols use slash notation such as `HYPE/USDC`; futures symbols use base asset notation such as `ETH`.
 - Check `.Success` before reading `.Data` on every REST or socket result.
+- Use `HttpResult<T>` / `HttpResult` for REST calls, `QueryResult<T>` / `QueryResult` for socket request APIs, and `WebSocketResult<UpdateSubscription>` for socket subscriptions.
 - Market orders still require a `price` argument in `PlaceOrderAsync`.
 - Use `reduceOnly: true` when closing futures exposure.
 - Store `UpdateSubscription` values and unsubscribe on shutdown.
 - Inspect `HyperLiquid.Net/Interfaces/Clients/**` before generating uncertain endpoint names.
+- For multi-exchange code, use `.SharedClient.Discover()` to inspect supported shared features.
 
 ## Reference
 

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Strongly typed .NET client library for the HyperLiquid DEX REST and WebSocket APIs. Supports spot, perpetual futures, staking, vaults, HIP-3 DEX metadata, HIP-4 outcome metadata and streams, REST requests, WebSocket subscriptions, local order books, and CryptoExchange.Net SharedApis.
 
-HyperLiquid.Net is the C# client for HyperLiquid in the CryptoExchange.Net ecosystem. It provides strongly typed models, `WebCallResult<T>` / `CallResult<T>` result handling, automatic WebSocket reconnection, client-side rate limiting, local order book support, user client management, native AOT support, and shared interfaces for multi-exchange applications. Current version in this repository: 4.7.1. Targets netstandard2.0, netstandard2.1, net8.0, net9.0, net10.0.
+HyperLiquid.Net is the C# client for HyperLiquid in the CryptoExchange.Net ecosystem. It provides strongly typed models, `HttpResult<T>` / `WebSocketResult<T>` result handling, automatic WebSocket reconnection, client-side rate limiting, local order book support, user client management, native AOT support, and shared interfaces for multi-exchange applications. Current version in this repository: 4.7.1. Targets netstandard2.0, netstandard2.1, net8.0, net9.0, net10.0.
 
 ## Documentation
 
@@ -18,7 +18,7 @@ HyperLiquid.Net is the C# client for HyperLiquid in the CryptoExchange.Net ecosy
 - [Futures Trading](https://github.com/JKorf/HyperLiquid.Net/blob/main/Examples/ai-friendly/02-futures.cs): Perp metadata, leverage, futures account positions, market/reduce-only order pattern
 - [WebSocket Streams](https://github.com/JKorf/HyperLiquid.Net/blob/main/Examples/ai-friendly/03-websocket.cs): Spot ticker, futures ticker, order book, authenticated order stream, proper teardown
 - [Multi-Exchange Pattern](https://github.com/JKorf/HyperLiquid.Net/blob/main/Examples/ai-friendly/04-multi-exchange.cs): CryptoExchange.Net SharedApis for exchange-agnostic spot/futures ticker and socket code
-- [Error Handling](https://github.com/JKorf/HyperLiquid.Net/blob/main/Examples/ai-friendly/05-error-handling.cs): WebCallResult pattern, retry logic, symbol formatting, builder fee checks
+- [Error Handling](https://github.com/JKorf/HyperLiquid.Net/blob/main/Examples/ai-friendly/05-error-handling.cs): HttpResult pattern, retry logic, symbol formatting, builder fee checks
 - [Full Examples Repository](https://github.com/JKorf/HyperLiquid.Net/tree/main/Examples): Console, API, order book, custom order book, and tracker examples
 
 ## Critical Usage Rules


### PR DESCRIPTION
* Result types:
  * (Web)CallResult types are replaced by HttpResult, WebSocketResult and QueryResult with the same logic
  * WebSocketResult and QueryResult now return additional info for websocket operations
  * Updated result types to record type
  * Removed implicit result type conversion to bool, `if (result)` no longer works, instead use `if (result.Success)`
  * Fixed result object nullability hinting, for example Data might be null if Success isn't checked for true

* Clients:
  * Added ToString overrides on base API types
  * Added Exchange property on BaseApiClient
  * Added ApiCredentials property on Api clients
  * Updated ILogger source from client name to topic specific client name
  * Removed logging from client creation
  * Fixed issue in SocketApiClient.GetSocketConnection causing requests to always wait the full max 10 seconds when there was a reconnecting socket

* Shared APIs:
  * Added missing dedicated option types
  * Added Discover method on ISharedClient interface, returning info on supported capabilities and operations
  * Added ResetStaticExchangeParameters method on ExchangeParameters
  * Added Status property to SharedWithdrawal model
  * Added TradingModes property to SharedBalance model
  * Updated Shared ExchangeParameters parameter names to be case insensitive
  * Updated code comments
  * Replaced ExchangeResult with ExchangeCallResult type
  * Removed TradingMode from the response model, only maintained on models where it makes sense

* Added alwaysPlace parameter to EditOrderAsync endpoints
* Added async streaming on UserDataTracker items with StreamUpdatesAsync
* Added cancellation token support to UserDataTracker starting
* Added SupportedEnvironments property to PlatformInfo
* Added setter to HyperLiquidExchange.RateLimiter to allow custom rate limit settings
* Added Clear() method on UserClientProvider to clear all cached clients
* Various small performance improvements
* Marked SubscribToUserUpdatesAsync as obsolete
* Fixed websocket connection attempts counting towards rate limit even when server could not be reached
* Fixed websocket user data update filtering based on address