### PR TITLE
Shared asset types

### DIFF
--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiExchangeData.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiExchangeData.cs
@@ -243,5 +243,20 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         }
 
         #endregion
+
+        #region Get Perp Market Status
+
+        /// <inheritdoc />
+        public async Task<HttpResult<HyperLiquidPerpAnnotation[]>> GetPerpConciseAnnotationsAsync(CancellationToken ct = default)
+        {
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
+            {
+                { "type", "perpConciseAnnotations" },
+            };
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "info", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 20, false);
+            return await _baseClient.SendAsync<HyperLiquidPerpAnnotation[]>(request, parameters, ct).ConfigureAwait(false);
+        }
+
+        #endregion
     }
 }

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiShared.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiShared.cs
@@ -290,9 +290,10 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 {
                     // No annotation and on a dex, could be any type since annotations aren't always assigned
                     var baseAssetName = result.BaseAsset.Split(':')[1];
-                    if (LibraryHelpers.IsCryptoCurrency(baseAssetName))
+                    if (LibraryHelpers.IsEquity(baseAssetName))
                     {
-                        result.BaseAssetType = SharedAssetType.Crypto;
+                        result.BaseAssetType = SharedAssetType.TradFi;
+                        result.BaseAssetSubType = SharedAssetSubType.Equity;
                     }
                     else if (LibraryHelpers.IsCommodity(baseAssetName))
                     {
@@ -303,14 +304,9 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                     {
                         result.BaseAssetType = SharedAssetType.Fiat;
                     }
-                    else if (LibraryHelpers.IsStock(baseAssetName))
-                    {
-                        result.BaseAssetType = SharedAssetType.TradFi;
-                        result.BaseAssetSubType = SharedAssetSubType.Stock;
-                    }
                     else
                     {
-                        result.BaseAssetType = SharedAssetType.Unspecified;
+                        result.BaseAssetType = SharedAssetType.Crypto;
                     }
                 }
                 else
@@ -326,7 +322,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             else if (annotation.Annotations.Category.Equals("indices", StringComparison.OrdinalIgnoreCase))
             {
                 result.BaseAssetType = SharedAssetType.TradFi;
-                result.BaseAssetSubType = SharedAssetSubType.Index;
+                result.BaseAssetSubType = SharedAssetSubType.Equity;
             }
             else if (annotation.Annotations.Category.Equals("fx", StringComparison.OrdinalIgnoreCase))
             {
@@ -335,7 +331,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
             else if (annotation.Annotations.Category.Equals("stocks", StringComparison.OrdinalIgnoreCase))
             {
                 result.BaseAssetType = SharedAssetType.TradFi;
-                result.BaseAssetSubType = SharedAssetSubType.Stock;
+                result.BaseAssetSubType = SharedAssetSubType.Equity;
             }
             else if (annotation.Annotations.Category.Equals("commodities", StringComparison.OrdinalIgnoreCase))
             {

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiShared.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiShared.cs
@@ -23,6 +23,8 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
         public SharedClientInfo Discover() => SharedUtils.GetClientInfo(HyperLiquidExchange.Metadata, this);
 
+        private static readonly HashSet<string> _exchangeKnownFiat = ["EUR", "USD"];
+
 
         #region Balance Client
         GetBalancesOptions IBalanceRestClient.GetBalancesOptions { get; } = new GetBalancesOptions(_exchangeName, AccountTypeFilter.Futures)
@@ -216,6 +218,9 @@ namespace HyperLiquid.Net.Clients.FuturesApi
         #endregion
 
         #region Futures Symbol client
+
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false)
         {
             OptionalExchangeParameters = new List<ParameterDescription>
@@ -231,28 +236,35 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 return HttpResult.Fail<SharedFuturesSymbol[]>(Exchange, validationError);
 
             string? dex = ExchangeParameters.GetValue<string>(request.ExchangeParameters, Exchange, "dex");
-            var result = await ExchangeData.GetExchangeInfoAllDexesAsync(ct: ct).ConfigureAwait(false);
-            if (!result.Success)
-                return HttpResult.Fail<SharedFuturesSymbol[]>(result);
+            var annotationsTask = ExchangeData.GetPerpConciseAnnotationsAsync(ct: ct);
+            var exchangeInfoTask = ExchangeData.GetExchangeInfoAllDexesAsync(ct: ct);
+            await Task.WhenAll(annotationsTask, exchangeInfoTask).ConfigureAwait(false);
+            var annotationsResult = annotationsTask.Result;
+            var exchangeInfoResult = exchangeInfoTask.Result;
+            if (!exchangeInfoResult.Success)
+                return HttpResult.Fail<SharedFuturesSymbol[]>(exchangeInfoResult);
+            if (!annotationsResult.Success)
+                return HttpResult.Fail<SharedFuturesSymbol[]>(annotationsResult);
 
-            var data = result.Data.SelectMany(x => x.Symbols);
+            var data = exchangeInfoResult.Data.SelectMany(x => x.Symbols);
             if (dex != null)
-                data = result.Data.SingleOrDefault(x => x.Name == dex)?.Symbols ?? [];
+                data = exchangeInfoResult.Data.SingleOrDefault(x => x.Name == dex)?.Symbols ?? [];
 
-            var response = data.Where(x => !x.IsDelisted).Select(ParseSymbol).ToArray();
+            var resultData = data
+               .Select(x => ParseSymbol(x, annotationsResult.Data))
+               .ToArray();
 
             // Register both HYPE/USDC and HYPE as symbol names
-            var symbolRegistrations = result.Data.SelectMany(x => x.Symbols.Where(x => !x.IsDelisted).Select(ParseSymbol))
-                .Concat(result.Data.SelectMany(x => x.Symbols.Select(x => new SharedSpotSymbol(x.Name, "USDC", x.Name, true, TradingMode.PerpetualLinear)))).ToArray();
+            var symbolRegistrations = resultData
+                .Concat(resultData.Select(x => new SharedSpotSymbol(x.BaseAsset, "USDC", x.BaseAsset, true, TradingMode.PerpetualLinear))).ToArray();
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, symbolRegistrations);
-            return HttpResult.Ok(result, response);
-                                
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, dex, symbolRegistrations);
+            return HttpResult.Ok(exchangeInfoResult, SharedUtils.ApplySymbolFilter(resultData, request));
         }
 
-        private SharedFuturesSymbol ParseSymbol(HyperLiquidFuturesSymbol symbol)
+        private SharedFuturesSymbol ParseSymbol(HyperLiquidFuturesSymbol symbol, HyperLiquidPerpAnnotation[] annotations)
         {
-            return new SharedFuturesSymbol(
+            var result = new SharedFuturesSymbol(
                 TradingMode.PerpetualLinear,
                 symbol.Name,
                 "USDC",
@@ -265,8 +277,77 @@ namespace HyperLiquid.Net.Clients.FuturesApi
                 PriceSignificantFigures = 5,
                 PriceDecimals = 6 - symbol.QuantityDecimals,
                 MaxLongLeverage = symbol.MaxLeverage,
-                MaxShortLeverage = symbol.MaxLeverage
+                MaxShortLeverage = symbol.MaxLeverage,
+                DisplayName = symbol.Name,
+                QuoteAssetType = SharedAssetType.Crypto,
+                QuoteAssetSubType = SharedAssetSubType.StableCoin
             };
+
+            var annotation = annotations.SingleOrDefault(x => x.Symbol == symbol.Name);
+            if (annotation == null)
+            {
+                if (symbol.Name.Contains(":"))
+                {
+                    // No annotation and on a dex, could be any type since annotations aren't always assigned
+                    var baseAssetName = result.BaseAsset.Split(':')[1];
+                    if (LibraryHelpers.IsCryptoCurrency(baseAssetName))
+                    {
+                        result.BaseAssetType = SharedAssetType.Crypto;
+                    }
+                    else if (LibraryHelpers.IsCommodity(baseAssetName))
+                    {
+                        result.BaseAssetType = SharedAssetType.TradFi;
+                        result.BaseAssetSubType = SharedAssetSubType.Commodity;
+                    }
+                    else if (_exchangeKnownFiat.Contains(baseAssetName))
+                    {
+                        result.BaseAssetType = SharedAssetType.Fiat;
+                    }
+                    else if (LibraryHelpers.IsStock(baseAssetName))
+                    {
+                        result.BaseAssetType = SharedAssetType.TradFi;
+                        result.BaseAssetSubType = SharedAssetSubType.Stock;
+                    }
+                    else
+                    {
+                        result.BaseAssetType = SharedAssetType.Unspecified;
+                    }
+                }
+                else
+                {
+                    // Main exchange only has crypto
+                    result.BaseAssetType = SharedAssetType.Crypto; 
+                }
+            }
+            else if (annotation.Annotations.Category.Equals("crypto", StringComparison.OrdinalIgnoreCase))
+            {
+                result.BaseAssetType = SharedAssetType.Crypto;
+            }
+            else if (annotation.Annotations.Category.Equals("indices", StringComparison.OrdinalIgnoreCase))
+            {
+                result.BaseAssetType = SharedAssetType.TradFi;
+                result.BaseAssetSubType = SharedAssetSubType.Index;
+            }
+            else if (annotation.Annotations.Category.Equals("fx", StringComparison.OrdinalIgnoreCase))
+            {
+                result.BaseAssetType = SharedAssetType.Fiat;
+            }
+            else if (annotation.Annotations.Category.Equals("stocks", StringComparison.OrdinalIgnoreCase))
+            {
+                result.BaseAssetType = SharedAssetType.TradFi;
+                result.BaseAssetSubType = SharedAssetSubType.Stock;
+            }
+            else if (annotation.Annotations.Category.Equals("commodities", StringComparison.OrdinalIgnoreCase))
+            {
+                result.BaseAssetType = SharedAssetType.TradFi;
+                result.BaseAssetSubType = SharedAssetSubType.Commodity;
+            }
+            else if (annotation.Annotations.Category.Equals("preipo", StringComparison.OrdinalIgnoreCase))
+            {
+                result.BaseAssetType = SharedAssetType.TradFi;
+            }
+
+            return result;
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)

--- a/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiShared.cs
+++ b/HyperLiquid.Net/Clients/FuturesApi/HyperLiquidRestClientFuturesApiShared.cs
@@ -219,7 +219,7 @@ namespace HyperLiquid.Net.Clients.FuturesApi
 
         #region Futures Symbol client
 
-        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_exchangeName, _topicId, EnvironmentName, null);
 
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false)
         {

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiShared.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiShared.cs
@@ -248,9 +248,11 @@ namespace HyperLiquid.Net.Clients.SpotApi
                 QuoteAssetSubType = SharedAssetSubType.StableCoin
             };
 
-            if (LibraryHelpers.IsCryptoCurrency(result.BaseAsset))
+            if (LibraryHelpers.IsEquity(result.BaseAsset)
+                || (result.BaseAsset.EndsWith("X") && LibraryHelpers.IsEquity(result.BaseAsset.Substring(0, result.BaseAsset.Length - 1))))
             {
-                result.BaseAssetType = SharedAssetType.Crypto;
+                result.BaseAssetType = SharedAssetType.TradFi;
+                result.BaseAssetSubType = SharedAssetSubType.Equity;
             }
             else if (LibraryHelpers.IsCommodity(result.BaseAsset, "XAUT0"))
             {
@@ -262,14 +264,9 @@ namespace HyperLiquid.Net.Clients.SpotApi
                 result.BaseAssetType = SharedAssetType.Crypto;
                 result.BaseAssetSubType = SharedAssetSubType.StableCoin;
             }
-            else if (LibraryHelpers.IsStock(result.BaseAsset))
-            {
-                result.BaseAssetType = SharedAssetType.TradFi;
-                result.BaseAssetSubType = SharedAssetSubType.Stock;
-            }
             else
             {
-                result.BaseAssetType = SharedAssetType.Unspecified;
+                result.BaseAssetType = SharedAssetType.Crypto;
             }
 
             return result;

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiShared.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiShared.cs
@@ -9,6 +9,7 @@ using CryptoExchange.Net.Objects;
 using HyperLiquid.Net.Enums;
 using CryptoExchange.Net;
 using CryptoExchange.Net.Objects.Errors;
+using HyperLiquid.Net.Objects.Models;
 
 namespace HyperLiquid.Net.Clients.SpotApi
 {
@@ -211,6 +212,8 @@ namespace HyperLiquid.Net.Clients.SpotApi
         #endregion
 
         #region Spot Symbol client
+
+        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false);
 
         async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
@@ -219,22 +222,57 @@ namespace HyperLiquid.Net.Clients.SpotApi
             if (validationError != null)
                 return HttpResult.Fail<SharedSpotSymbol[]>(Exchange, validationError);
 
-                    var result = await ExchangeData.GetExchangeInfoAsync(ct: ct).ConfigureAwait(false);
-                    if (!result.Success)
-                        return HttpResult.Fail<SharedSpotSymbol[]>(result);
+            var result = await ExchangeData.GetExchangeInfoAsync(ct: ct).ConfigureAwait(false);
+            if (!result.Success)
+                return HttpResult.Fail<SharedSpotSymbol[]>(result);
 
-                    var resultData = result.Data.Symbols.Select(s => new SharedSpotSymbol(HyperLiquidExchange.AssetAliases.ExchangeToCommonName(s.BaseAsset.Name), HyperLiquidExchange.AssetAliases.ExchangeToCommonName(s.QuoteAsset.Name), s.Name, true)
-                    {
-                        MinTradeQuantity = 1m / (decimal)(Math.Pow(10, s.BaseAsset.QuantityDecimals)),
-                        MinNotionalValue = 10, // Order API returns error mentioning at least 10$ order value, but value isn't returned by symbol API
-                        QuantityDecimals = s.BaseAsset.QuantityDecimals,
-                        PriceSignificantFigures = 5,
-                        PriceDecimals = 8 - s.BaseAsset.QuantityDecimals
-                    }).ToArray();
+            var resultData = result.Data.Symbols
+               .Select(x => ParseSymbol(x))
+               .ToArray();
 
-                    ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData);
-                    return HttpResult.Ok(result, resultData);
-                
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData);
+            return HttpResult.Ok(result, SharedUtils.ApplySymbolFilter(resultData, request));
+        }
+
+        private SharedSpotSymbol ParseSymbol(HyperLiquidSymbol s)
+        {
+            var result = new SharedSpotSymbol(HyperLiquidExchange.AssetAliases.ExchangeToCommonName(s.BaseAsset.Name), HyperLiquidExchange.AssetAliases.ExchangeToCommonName(s.QuoteAsset.Name), s.Name, true)
+            {
+                MinTradeQuantity = 1m / (decimal)(Math.Pow(10, s.BaseAsset.QuantityDecimals)),
+                MinNotionalValue = 10, // Order API returns error mentioning at least 10$ order value, but value isn't returned by symbol API
+                QuantityDecimals = s.BaseAsset.QuantityDecimals,
+                PriceSignificantFigures = 5,
+                PriceDecimals = 8 - s.BaseAsset.QuantityDecimals,
+                DisplayName = s.Name,
+                QuoteAssetType = SharedAssetType.Crypto,
+                QuoteAssetSubType = SharedAssetSubType.StableCoin
+            };
+
+            if (LibraryHelpers.IsCryptoCurrency(result.BaseAsset))
+            {
+                result.BaseAssetType = SharedAssetType.Crypto;
+            }
+            else if (LibraryHelpers.IsCommodity(result.BaseAsset, "XAUT0"))
+            {
+                result.BaseAssetType = SharedAssetType.TradFi;
+                result.BaseAssetSubType = SharedAssetSubType.Commodity;
+            }
+            else if (LibraryHelpers.IsStableCoin(result.BaseAsset, "USDXL", "FEUSD", "USDHL", "USDUC", "USDT0"))
+            {
+                result.BaseAssetType = SharedAssetType.Crypto;
+                result.BaseAssetSubType = SharedAssetSubType.StableCoin;
+            }
+            else if (LibraryHelpers.IsStock(result.BaseAsset))
+            {
+                result.BaseAssetType = SharedAssetType.TradFi;
+                result.BaseAssetSubType = SharedAssetSubType.Stock;
+            }
+            else
+            {
+                result.BaseAssetType = SharedAssetType.Unspecified;
+            }
+
+            return result;
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiShared.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiShared.cs
@@ -213,7 +213,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
 
         #region Spot Symbol client
 
-        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_exchangeName, _topicId, EnvironmentName, null);
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false);
 
         async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)

--- a/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiShared.cs
+++ b/HyperLiquid.Net/Clients/SpotApi/HyperLiquidRestClientSpotApiShared.cs
@@ -248,8 +248,7 @@ namespace HyperLiquid.Net.Clients.SpotApi
                 QuoteAssetSubType = SharedAssetSubType.StableCoin
             };
 
-            if (LibraryHelpers.IsEquity(result.BaseAsset)
-                || (result.BaseAsset.EndsWith("X") && LibraryHelpers.IsEquity(result.BaseAsset.Substring(0, result.BaseAsset.Length - 1))))
+            if (LibraryHelpers.IsEquity(result.BaseAsset, ["X"], []))
             {
                 result.BaseAssetType = SharedAssetType.TradFi;
                 result.BaseAssetSubType = SharedAssetSubType.Equity;

--- a/HyperLiquid.Net/Converters/HyperLiquidSourceGenerationContext.cs
+++ b/HyperLiquid.Net/Converters/HyperLiquidSourceGenerationContext.cs
@@ -9,6 +9,8 @@ using System.Text.Json.Serialization;
 
 namespace HyperLiquid.Net.Converters
 {
+    [JsonSerializable(typeof(HyperLiquidPerpAnnotation[]))]
+    [JsonSerializable(typeof(HyperLiquidPerpAnnotationDetails))]
     [JsonSerializable(typeof(HyperLiquidSocketMessage2<HyperLiquidSocketEnvelope2<HyperLiquidSocketResponse2<HyperLiquidSocketPayload2<HyperLiquidDefault>>>>))]
 
     [JsonSerializable(typeof(Parameters))]

--- a/HyperLiquid.Net/HyperLiquid.Net.csproj
+++ b/HyperLiquid.Net/HyperLiquid.Net.csproj
@@ -53,13 +53,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="CryptoExchange.Net" Version="12.2.0" />
     <PackageReference Include="Secp256k1.Net" Version="2.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/HyperLiquid.Net/HyperLiquid.Net.csproj
+++ b/HyperLiquid.Net/HyperLiquid.Net.csproj
@@ -53,11 +53,13 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="CryptoExchange.Net" Version="12.1.0" />
     <PackageReference Include="Secp256k1.Net" Version="2.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/HyperLiquid.Net/Interfaces/Clients/FuturesApi/IHyperLiquidRestClientFuturesApiExchangeData.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/FuturesApi/IHyperLiquidRestClientFuturesApiExchangeData.cs
@@ -115,5 +115,7 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// <param name="dex">["<c>dex</c>"] DEX name, for example `xyz`, null for default Perp DEX</param>
         /// <param name="ct">Cancellation token</param>
         Task<HttpResult<HyperLiquidPerpDexStatus>> GetPerpDexMarketStatusAsync(string? dex = null, CancellationToken ct = default);
+
+        Task<HttpResult<HyperLiquidPerpAnnotation[]>> GetPerpConciseAnnotationsAsync(CancellationToken ct = default);
     }
 }

--- a/HyperLiquid.Net/Interfaces/Clients/FuturesApi/IHyperLiquidRestClientFuturesApiExchangeData.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/FuturesApi/IHyperLiquidRestClientFuturesApiExchangeData.cs
@@ -116,6 +116,16 @@ namespace HyperLiquid.Net.Interfaces.Clients.FuturesApi
         /// <param name="ct">Cancellation token</param>
         Task<HttpResult<HyperLiquidPerpDexStatus>> GetPerpDexMarketStatusAsync(string? dex = null, CancellationToken ct = default);
 
+        /// <summary>
+        /// Get annotations for symbols across dexes
+        /// <para>
+        /// Docs:<br />
+        /// <a href="https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint/perpetuals#get-perp-market-status" /><br />
+        /// Endpoint:<br />
+        /// POST /info (type: perpDexStatus)
+        /// </para>
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
         Task<HttpResult<HyperLiquidPerpAnnotation[]>> GetPerpConciseAnnotationsAsync(CancellationToken ct = default);
     }
 }

--- a/HyperLiquid.Net/Objects/Models/HyperLiquidPerpAnnotation.cs
+++ b/HyperLiquid.Net/Objects/Models/HyperLiquidPerpAnnotation.cs
@@ -1,0 +1,53 @@
+﻿using CryptoExchange.Net.Attributes;
+using CryptoExchange.Net.Converters;
+using CryptoExchange.Net.Converters.SystemTextJson;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace HyperLiquid.Net.Objects.Models
+{
+    /// <summary>
+    /// Perp annotations
+    /// </summary>
+    [JsonConverter(typeof(ArrayConverter<HyperLiquidPerpAnnotation>))]
+    public record HyperLiquidPerpAnnotation
+    {
+        /// <summary>
+        /// Symbol name
+        /// </summary>
+        [ArrayProperty(0)]
+        public string Symbol { get; set; } = string.Empty;
+        /// <summary>
+        /// Annotations
+        /// </summary>
+        [ArrayProperty(1)]
+        [JsonConversion]
+        public HyperLiquidPerpAnnotationDetails Annotations { get; set; } = default!;
+    }
+
+    /// <summary>
+    /// Annotations
+    /// </summary>
+    public record HyperLiquidPerpAnnotationDetails
+    {
+        /// <summary>
+        /// ["<c>category</c>"] Category
+        /// </summary>
+        [JsonPropertyName("category")]
+        public string Category { get; set; } = string.Empty;
+        /// <summary>
+        /// ["<c>displayName</c>"] Display name
+        /// </summary>
+        [JsonPropertyName("displayName")]
+        public string? DisplayName { get; set; }
+        /// <summary>
+        /// ["<c>keywords</c>"] Keywords
+        /// </summary>
+        [JsonPropertyName("keywords")]
+        public string[] Keywords { get; set; } = [];
+    }
+}


### PR DESCRIPTION
Updated CryptoExchange.Net to v12.2.0 
Added SpotSymbolCatalog to Shared ISpotSymbolRestClient interface
Added FuturesSymbolCatalog to Shared IFuturesSymbolRestClient interface
Added BaseAssetType, BaseAssetSubType, QuoteAssetType and QuoteAssetSubType to GetSymbolsRequest model
Added DisplayName to SharedSpotSymbol and SharedFuturesSymbol models
Added BaseAssetType, BaseAssetSubType, QuoteAssetType and QuoteAssetSubType to SharedSpotSymbol and SharedFuturesSymbol models
Added DebuggerDisplay attributes to Shared models
Added restClient.FuturesApi.ExchangeData.GetPerpConciseAnnotationsAsync endpoint