### PR TITLE
Add the documented marginMode field to the perp symbol info

### DIFF
--- a/HyperLiquid.Net/Enums/MarginMode.cs
+++ b/HyperLiquid.Net/Enums/MarginMode.cs
@@ -1,0 +1,23 @@
+using System.Text.Json.Serialization;
+using CryptoExchange.Net.Attributes;
+using CryptoExchange.Net.Converters.SystemTextJson;
+namespace HyperLiquid.Net.Enums
+{
+    /// <summary>
+    /// Margin mode restriction on a symbol
+    /// </summary>
+    [JsonConverter(typeof(EnumConverter<MarginMode>))]
+    public enum MarginMode
+    {
+        /// <summary>
+        /// Margin can not be removed
+        /// </summary>
+        [Map("strictIsolated")]
+        StrictIsolated,
+        /// <summary>
+        /// Only isolated margin allowed
+        /// </summary>
+        [Map("noCross")]
+        NoCross
+    }
+}

--- a/HyperLiquid.Net/Enums/MarginRestrictionMode.cs
+++ b/HyperLiquid.Net/Enums/MarginRestrictionMode.cs
@@ -6,8 +6,8 @@ namespace HyperLiquid.Net.Enums
     /// <summary>
     /// Margin mode restriction on a symbol
     /// </summary>
-    [JsonConverter(typeof(EnumConverter<MarginMode>))]
-    public enum MarginMode
+    [JsonConverter(typeof(EnumConverter<MarginRestrictionMode>))]
+    public enum MarginRestrictionMode
     {
         /// <summary>
         /// Margin can not be removed

--- a/HyperLiquid.Net/Objects/Models/HyperLiquidFuturesExchangeInfo.cs
+++ b/HyperLiquid.Net/Objects/Models/HyperLiquidFuturesExchangeInfo.cs
@@ -1,4 +1,5 @@
 using CryptoExchange.Net.Converters.SystemTextJson;
+using HyperLiquid.Net.Enums;
 using System.Text.Json.Serialization;
 
 namespace HyperLiquid.Net.Objects.Models
@@ -62,6 +63,11 @@ namespace HyperLiquid.Net.Objects.Models
         /// </summary>
         [JsonPropertyName("marginTableId")]
         public int MarginTableId { get; set; }
+        /// <summary>
+        /// ["<c>marginMode</c>"] Margin mode restriction, null when the symbol has no restriction
+        /// </summary>
+        [JsonPropertyName("marginMode")]
+        public MarginMode? MarginMode { get; set; }
         /// <summary>
         /// Margin table
         /// </summary>

--- a/HyperLiquid.Net/Objects/Models/HyperLiquidFuturesExchangeInfo.cs
+++ b/HyperLiquid.Net/Objects/Models/HyperLiquidFuturesExchangeInfo.cs
@@ -67,7 +67,7 @@ namespace HyperLiquid.Net.Objects.Models
         /// ["<c>marginMode</c>"] Margin mode restriction, null when the symbol has no restriction
         /// </summary>
         [JsonPropertyName("marginMode")]
-        public MarginMode? MarginMode { get; set; }
+        public MarginRestrictionMode? MarginRestrictionMode { get; set; }
         /// <summary>
         /// Margin table
         /// </summary>


### PR DESCRIPTION
`marginMode` is documented on each `meta` universe entry but isn't mapped. It shows up on symbols such as HPOS and RLB:

```json
{"szDecimals":0,"name":"HPOS","maxLeverage":3,"marginTableId":3,
 "onlyIsolated":true,"isDelisted":true,"marginMode":"strictIsolated"}
```

Mapped as a nullable enum using the two values the docs describe — `strictIsolated`, where margin cannot be removed, and `noCross`, where only isolated margin is allowed — so a symbol with no restriction stays null.

Two files, no test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)