### PR TITLE
Add spotHold to HyperLiquidBalance

### DIFF
--- a/HyperLiquid.Net/Objects/Models/HyperLiquidBalance.cs
+++ b/HyperLiquid.Net/Objects/Models/HyperLiquidBalance.cs
@@ -69,6 +69,14 @@ namespace HyperLiquid.Net.Objects.Models
         [JsonPropertyName("hold")]
         public decimal Hold { get; set; }
         /// <summary>
+        /// ["<c>spotHold</c>"] In holding, before portfolio margin borrow capacity is netted off. Null when not
+        /// sent, which has been observed for tokens carrying a zero <see cref="Hold"/>. Subtracting it from
+        /// <see cref="Total"/> leaves the balance actually owned and unencumbered, whereas subtracting
+        /// <see cref="Hold"/> leaves an amount that also includes what could be borrowed
+        /// </summary>
+        [JsonPropertyName("spotHold")]
+        public decimal? SpotHold { get; set; }
+        /// <summary>
         /// ["<c>total</c>"] Total
         /// </summary>
         [JsonPropertyName("total")]


### PR DESCRIPTION
Add spotHold to HyperLiquidBalance

spotClearinghouseState returns a spotHold field on balance entries that isn't currently modelled. Under portfolio margin it's the field that separates "available" from "withdrawable".

hold is reported net of the borrow capacity the account's collateral entitles it to. Subtracting it therefore leaves an amount that includes funds only reachable by borrowing. spotHold is that same reserve before the netting:

total − hold      = available to trade   (includes borrowable capacity)
total − spotHold  = owned and unencumbered (what can actually be withdrawn)

Modelled as decimal? because it isn't sent for every balance entry — tokens carrying a zero hold omit it.

Additive only; no existing behaviour changes.