### PR TITLE
Add Settlement to the Direction enum

### DIFF
--- a/HyperLiquid.Net/Enums/Direction.cs
+++ b/HyperLiquid.Net/Enums/Direction.cs
@@ -59,6 +59,12 @@ namespace HyperLiquid.Net.Enums
         /// ["<c>Auto-Deleveraging</c>"] Auto deleveraging
         /// </summary>
         [Map("Auto-Deleveraging")]
-        AutoDeleveraging
+        AutoDeleveraging,
+        /// <summary>
+        /// ["<c>Settlement</c>"] Delist settlement - the position was settled to the oracle price ahead of a
+        /// validator delisting vote
+        /// </summary>
+        [Map("Settlement")]
+        Settlement
     }
 }


### PR DESCRIPTION
When Hyperliquid delists a perp (validators vote assets off the exchange; open positions settle to the 1-hour TWAP oracle price before the vote), the settlement arrives on `userFills` with a direction not currently in the enum — `"dir": "Settlement"`. The fill otherwise has the usual shape, with no `liquidation` block, `fee` 0, and the entire position closed in a single fill (`sz` equal to `|startPosition|`):

```json
{"coin":"ABC","px":"0.012345","sz":"10000.0","side":"B","time":1234567890123,"startPosition":"-10000.0","dir":"Settlement","closedPnl":"-123.456789","hash":"0xabc123...","oid":123456789,"crossed":true,"fee":"0.0","tid":987654321,"feeToken":"USDC","twapId":null}
```

(shape observed live on a real delisting settlement; values are illustrative)

Without the mapping the value falls back to the enum default, so settlement fills are indistinguishable from ordinary fills. One file changed: the enum member plus its `Map` attribute.
