### PR TITLE
Add approveAgent and RemoveAgentAsync to the account API

### DIFF
--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiAccount.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiAccount.cs
@@ -233,6 +233,23 @@ namespace HyperLiquid.Net.Clients.BaseApi
         }
 
         #endregion
+
+        #region Remove Agent
+
+        /// <inheritdoc />
+        public Task<HttpResult> RemoveAgentAsync(
+            string? agentName = null,
+            CancellationToken ct = default)
+        {
+            //an approval pointed at nothing. Hyperliquid publishes no removal action, and this is what its own
+            //interface sends when Remove is pressed - see the remarks on the interface method.
+            return ApproveAgentAsync(ZeroAddress, agentName, ct);
+        }
+
+        /// <summary>The address an approval names when it is removing an agent rather than authorising one.</summary>
+        private const string ZeroAddress = "0x0000000000000000000000000000000000000000";
+
+        #endregion
         #region Transfer Internal
 
         /// <inheritdoc />

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiAccount.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiAccount.cs
@@ -205,6 +205,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         public async Task<HttpResult> ApproveAgentAsync(
             string agentAddress,
             string? agentName = null,
+            DateTime? validUntil = null,
             CancellationToken ct = default)
         {
             await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
@@ -223,8 +224,9 @@ namespace HyperLiquid.Net.Clients.BaseApi
             };
 
             //sent as an empty string rather than omitted when there is no name: the field is part of the signed
-            //type list either way, so leaving it out would sign a three-field struct against a four-field schema
-            actionParameters.Add("agentName", agentName ?? string.Empty);
+            //type list either way, so leaving it out would sign a three-field struct against a four-field schema.
+            //An expiration, when given, is a suffix on this same field - see BuildAgentName.
+            actionParameters.Add("agentName", HyperLiquidUtils.BuildAgentName(agentName, validUntil));
             actionParameters.Add("nonce", DateTime.UtcNow);
             parameters.Add("action", actionParameters);
 
@@ -242,8 +244,9 @@ namespace HyperLiquid.Net.Clients.BaseApi
             CancellationToken ct = default)
         {
             //an approval pointed at nothing. Hyperliquid publishes no removal action, and this is what its own
-            //interface sends when Remove is pressed - see the remarks on the interface method.
-            return ApproveAgentAsync(ZeroAddress, agentName, ct);
+            //interface sends when Remove is pressed - see the remarks on the interface method. No expiration:
+            //the name has to match the agent being removed, and a valid_until suffix would not.
+            return ApproveAgentAsync(ZeroAddress, agentName, validUntil: null, ct: ct);
         }
 
         /// <summary>The address an approval names when it is removing an agent rather than authorising one.</summary>

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiAccount.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidRestClientApiAccount.cs
@@ -198,6 +198,41 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
         #endregion
 
+
+        #region Approve Agent
+
+        /// <inheritdoc />
+        public async Task<HttpResult> ApproveAgentAsync(
+            string agentAddress,
+            string? agentName = null,
+            CancellationToken ct = default)
+        {
+            await HyperLiquidUtils.CheckBuilderFeeAsync(_baseClient.BaseClient).ConfigureAwait(false);
+
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+
+            //the order of these fields is the order of the EIP-712 type list, which is part of the struct hash -
+            //hyperliquidChain, agentAddress, agentName, nonce. Adding them in any other order signs a different
+            //message than the one the exchange verifies.
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
+            {
+                { "type", "approveAgent" },
+                { "hyperliquidChain", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? "Testnet" : "Mainnet" },
+                { "signatureChainId", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? _chainIdTestnet : _chainIdMainnet },
+                { "agentAddress", agentAddress },
+            };
+
+            //sent as an empty string rather than omitted when there is no name: the field is part of the signed
+            //type list either way, so leaving it out would sign a three-field struct against a four-field schema
+            actionParameters.Add("agentName", agentName ?? string.Empty);
+            actionParameters.Add("nonce", DateTime.UtcNow);
+            parameters.Add("action", actionParameters);
+
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "exchange", HyperLiquidExchange.RateLimiter.HyperLiquidRest, 1, true);
+            return await _baseClient.SendAuthAsync<HyperLiquidDefault>(request, parameters, ct).ConfigureAwait(false);
+        }
+
+        #endregion
         #region Transfer Internal
 
         /// <inheritdoc />

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiAccount.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiAccount.cs
@@ -250,6 +250,22 @@ namespace HyperLiquid.Net.Clients.BaseApi
         }
 
         #endregion
+
+        #region Remove Agent
+
+        /// <inheritdoc />
+        public Task<QueryResult> RemoveAgentAsync(
+            string? agentName = null,
+            CancellationToken ct = default)
+        {
+            //an approval pointed at nothing - see the remarks on the interface method
+            return ApproveAgentAsync(ZeroAddress, agentName, ct);
+        }
+
+        /// <summary>The address an approval names when it is removing an agent rather than authorising one.</summary>
+        private const string ZeroAddress = "0x0000000000000000000000000000000000000000";
+
+        #endregion
         #region Transfer Internal
 
         /// <inheritdoc />

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiAccount.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiAccount.cs
@@ -217,6 +217,39 @@ namespace HyperLiquid.Net.Clients.BaseApi
 
         #endregion
 
+
+        #region Approve Agent
+
+        /// <inheritdoc />
+        public async Task<QueryResult> ApproveAgentAsync(
+            string agentAddress,
+            string? agentName = null,
+            CancellationToken ct = default)
+        {
+            var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
+
+            //the order of these fields is the order of the EIP-712 type list, which is part of the struct hash -
+            //hyperliquidChain, agentAddress, agentName, nonce. Adding them in any other order signs a different
+            //message than the one the exchange verifies.
+            var actionParameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings)
+            {
+                { "type", "approveAgent" },
+                { "hyperliquidChain", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? "Testnet" : "Mainnet" },
+                { "signatureChainId", _baseClient.ClientOptions.Environment.Name == TradeEnvironmentNames.Testnet ? _chainIdTestnet : _chainIdMainnet },
+                { "agentAddress", agentAddress },
+            };
+
+            //sent as an empty string rather than omitted when there is no name: the field is part of the signed
+            //type list either way, so leaving it out would sign a three-field struct against a four-field schema
+            actionParameters.Add("agentName", agentName ?? string.Empty);
+            actionParameters.Add("nonce", DateTime.UtcNow);
+            parameters.Add("action", actionParameters);
+
+            return await _baseClient.QueryInternalAsync(
+                new HyperLiquidRequestQuery<HyperLiquidDefault>(_baseClient, "post", "action", parameters, true), ct).ConfigureAwait(false);
+        }
+
+        #endregion
         #region Transfer Internal
 
         /// <inheritdoc />

--- a/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiAccount.cs
+++ b/HyperLiquid.Net/Clients/BaseApi/HyperLiquidSocketClientApiAccount.cs
@@ -224,6 +224,7 @@ namespace HyperLiquid.Net.Clients.BaseApi
         public async Task<QueryResult> ApproveAgentAsync(
             string agentAddress,
             string? agentName = null,
+            DateTime? validUntil = null,
             CancellationToken ct = default)
         {
             var parameters = new Parameters(HyperLiquidExchange._parameterSerializationSettings);
@@ -240,8 +241,9 @@ namespace HyperLiquid.Net.Clients.BaseApi
             };
 
             //sent as an empty string rather than omitted when there is no name: the field is part of the signed
-            //type list either way, so leaving it out would sign a three-field struct against a four-field schema
-            actionParameters.Add("agentName", agentName ?? string.Empty);
+            //type list either way, so leaving it out would sign a three-field struct against a four-field schema.
+            //An expiration, when given, is a suffix on this same field - see BuildAgentName.
+            actionParameters.Add("agentName", HyperLiquidUtils.BuildAgentName(agentName, validUntil));
             actionParameters.Add("nonce", DateTime.UtcNow);
             parameters.Add("action", actionParameters);
 
@@ -258,8 +260,9 @@ namespace HyperLiquid.Net.Clients.BaseApi
             string? agentName = null,
             CancellationToken ct = default)
         {
-            //an approval pointed at nothing - see the remarks on the interface method
-            return ApproveAgentAsync(ZeroAddress, agentName, ct);
+            //an approval pointed at nothing - see the remarks on the interface method. No expiration: the name
+            //has to match the agent being removed, and a valid_until suffix would not.
+            return ApproveAgentAsync(ZeroAddress, agentName, validUntil: null, ct: ct);
         }
 
         /// <summary>The address an approval names when it is removing an agent rather than authorising one.</summary>

--- a/HyperLiquid.Net/HyperLiquidAuthenticationProvider.cs
+++ b/HyperLiquid.Net/HyperLiquidAuthenticationProvider.cs
@@ -160,6 +160,21 @@ namespace HyperLiquid.Net
             return signature;
         }
 
+        /// <summary>
+        /// Fields whose EIP-712 type is address rather than the type inferred from the CLR value.
+        ///
+        /// Hyperliquid is not consistent about this: destination on a withdraw is typed string while agentAddress
+        /// on an approveAgent is typed address, even though both carry an 0x address. The type name is part of the
+        /// struct hash, so getting it wrong produces a perfectly valid signature over the wrong hash - which the
+        /// exchange rejects without saying why.
+        /// </summary>
+        private static readonly HashSet<string> _addressTypedFields = new HashSet<string>
+        {
+            "builder",
+            "user",
+            "agentAddress"
+        };
+
         private List<(string Name, string Type, object Value)> GetMessageFields(Dictionary<string, object> parameters)
         {
             var result = new List<(string, string, object)>();
@@ -168,7 +183,7 @@ namespace HyperLiquid.Net
             {
                 result.Add(
                     (parameter.Key,
-                    ((parameter.Key == "builder" || parameter.Key == "user") ? "address" : _typeMapping[parameter.Value.GetType()]),
+                    _addressTypedFields.Contains(parameter.Key) ? "address" : _typeMapping[parameter.Value.GetType()],
                     parameter.Key == "type" ? ((string)parameter.Value).Substring(0, 1).ToUpper() + ((string)parameter.Value).Substring(1) : parameter.Value));
             }
 

--- a/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidRestClientAccount.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidRestClientAccount.cs
@@ -133,6 +133,25 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
             CancellationToken ct = default);
 
         /// <summary>
+        /// Remove a previously approved API wallet (agent wallet) from this account.
+        /// <para>
+        /// Hyperliquid publishes no removal action - approveAgent is the only agent action in its API - so this
+        /// sends an approveAgent naming the agent with the zero address, which is what the Hyperliquid web
+        /// interface itself sends when Remove is pressed. Being undocumented, it is worth reading the agents back
+        /// with GetExtraAgentsAsync afterwards rather than relying on the reply.
+        /// </para>
+        /// <para>
+        /// Endpoint:<br />
+        /// POST /exchange (type: approveAgent, agentAddress: 0x0000000000000000000000000000000000000000)
+        /// </para>
+        /// </summary>
+        /// <param name="agentName">["<c>agentName</c>"] Name of the API wallet to remove, or null for the unnamed one</param>
+        /// <param name="ct">Cancellation token</param>
+        Task<HttpResult> RemoveAgentAsync(
+            string? agentName = null,
+            CancellationToken ct = default);
+
+        /// <summary>
         /// Transfer USD between Spot and Futures account
         /// <para>
         /// Docs:<br />

--- a/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidRestClientAccount.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidRestClientAccount.cs
@@ -126,10 +126,17 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// </summary>
         /// <param name="agentAddress">["<c>agentAddress</c>"] Address of the API wallet in 42-character hexadecimal format; e.g. 0x0000000000000000000000000000000000000000</param>
         /// <param name="agentName">["<c>agentName</c>"] Optional name for the API wallet</param>
+        /// <param name="validUntil">
+        /// Optional expiration for the API wallet, at most 180 days ahead. Null leaves it out and takes whatever
+        /// default HyperLiquid applies, which is not the maximum. HyperLiquid has no field for this - it is sent
+        /// as a "valid_until {timestamp}" suffix on the name - so it requires <paramref name="agentName"/> and
+        /// does not apply to the unnamed API wallet.
+        /// </param>
         /// <param name="ct">Cancellation token</param>
         Task<HttpResult> ApproveAgentAsync(
             string agentAddress,
             string? agentName = null,
+            DateTime? validUntil = null,
             CancellationToken ct = default);
 
         /// <summary>

--- a/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidRestClientAccount.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidRestClientAccount.cs
@@ -114,6 +114,25 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
             CancellationToken ct = default);
 
         /// <summary>
+        /// Approve an API wallet (also called an agent wallet) to act on this account. The approving signature must
+        /// come from the account's master key. An unnamed agent replaces the previous unnamed one; a named agent is
+        /// kept separately, and the name may carry an expiry as "name valid_until &lt;timestamp&gt;".
+        /// <para>
+        /// Docs:<br />
+        /// <a href="https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint#approve-an-api-wallet" /><br />
+        /// Endpoint:<br />
+        /// POST /exchange (type: approveAgent)
+        /// </para>
+        /// </summary>
+        /// <param name="agentAddress">["<c>agentAddress</c>"] Address of the API wallet in 42-character hexadecimal format; e.g. 0x0000000000000000000000000000000000000000</param>
+        /// <param name="agentName">["<c>agentName</c>"] Optional name for the API wallet</param>
+        /// <param name="ct">Cancellation token</param>
+        Task<HttpResult> ApproveAgentAsync(
+            string agentAddress,
+            string? agentName = null,
+            CancellationToken ct = default);
+
+        /// <summary>
         /// Transfer USD between Spot and Futures account
         /// <para>
         /// Docs:<br />

--- a/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidSocketClientApiAccount.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidSocketClientApiAccount.cs
@@ -115,6 +115,25 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
             CancellationToken ct = default);
 
         /// <summary>
+        /// Approve an API wallet (also called an agent wallet) to act on this account. The approving signature must
+        /// come from the account's master key. An unnamed agent replaces the previous unnamed one; a named agent is
+        /// kept separately, and the name may carry an expiry as "name valid_until &lt;timestamp&gt;".
+        /// <para>
+        /// Docs:<br />
+        /// <a href="https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint#approve-an-api-wallet" /><br />
+        /// Endpoint:<br />
+        /// POST /exchange (type: approveAgent)
+        /// </para>
+        /// </summary>
+        /// <param name="agentAddress">["<c>agentAddress</c>"] Address of the API wallet in 42-character hexadecimal format; e.g. 0x0000000000000000000000000000000000000000</param>
+        /// <param name="agentName">["<c>agentName</c>"] Optional name for the API wallet</param>
+        /// <param name="ct">Cancellation token</param>
+        Task<QueryResult> ApproveAgentAsync(
+            string agentAddress,
+            string? agentName = null,
+            CancellationToken ct = default);
+
+        /// <summary>
         /// Transfer USD between Spot and Futures account
         /// <para>
         /// Docs:<br />

--- a/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidSocketClientApiAccount.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidSocketClientApiAccount.cs
@@ -134,6 +134,25 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
             CancellationToken ct = default);
 
         /// <summary>
+        /// Remove a previously approved API wallet (agent wallet) from this account.
+        /// <para>
+        /// Hyperliquid publishes no removal action - approveAgent is the only agent action in its API - so this
+        /// sends an approveAgent naming the agent with the zero address, which is what the Hyperliquid web
+        /// interface itself sends when Remove is pressed. Being undocumented, it is worth reading the agents back
+        /// with GetExtraAgentsAsync afterwards rather than relying on the reply.
+        /// </para>
+        /// <para>
+        /// Endpoint:<br />
+        /// POST /exchange (type: approveAgent, agentAddress: 0x0000000000000000000000000000000000000000)
+        /// </para>
+        /// </summary>
+        /// <param name="agentName">["<c>agentName</c>"] Name of the API wallet to remove, or null for the unnamed one</param>
+        /// <param name="ct">Cancellation token</param>
+        Task<QueryResult> RemoveAgentAsync(
+            string? agentName = null,
+            CancellationToken ct = default);
+
+        /// <summary>
         /// Transfer USD between Spot and Futures account
         /// <para>
         /// Docs:<br />

--- a/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidSocketClientApiAccount.cs
+++ b/HyperLiquid.Net/Interfaces/Clients/BaseApi/IHyperLiquidSocketClientApiAccount.cs
@@ -127,10 +127,17 @@ namespace HyperLiquid.Net.Interfaces.Clients.BaseApi
         /// </summary>
         /// <param name="agentAddress">["<c>agentAddress</c>"] Address of the API wallet in 42-character hexadecimal format; e.g. 0x0000000000000000000000000000000000000000</param>
         /// <param name="agentName">["<c>agentName</c>"] Optional name for the API wallet</param>
+        /// <param name="validUntil">
+        /// Optional expiration for the API wallet, at most 180 days ahead. Null leaves it out and takes whatever
+        /// default HyperLiquid applies, which is not the maximum. HyperLiquid has no field for this - it is sent
+        /// as a "valid_until {timestamp}" suffix on the name - so it requires <paramref name="agentName"/> and
+        /// does not apply to the unnamed API wallet.
+        /// </param>
         /// <param name="ct">Cancellation token</param>
         Task<QueryResult> ApproveAgentAsync(
             string agentAddress,
             string? agentName = null,
+            DateTime? validUntil = null,
             CancellationToken ct = default);
 
         /// <summary>

--- a/HyperLiquid.Net/Utils/HyperLiquidUtils.cs
+++ b/HyperLiquid.Net/Utils/HyperLiquidUtils.cs
@@ -1,4 +1,5 @@
 ﻿using CryptoExchange.Net;
+using CryptoExchange.Net.Converters.SystemTextJson;
 using CryptoExchange.Net.Objects;
 using CryptoExchange.Net.Objects.Errors;
 using HyperLiquid.Net.Clients;
@@ -35,7 +36,45 @@ namespace HyperLiquid.Net.Utils
         private static readonly SemaphoreSlim _semaphoreSpot = new SemaphoreSlim(1, 1);
         private static readonly SemaphoreSlim _semaphoreFutures = new SemaphoreSlim(1, 1);
         internal static readonly ConcurrentDictionary<string, BuilderFeeStatus> _builderFeeStatus = new ConcurrentDictionary<string, BuilderFeeStatus>();
-        
+
+        /// <summary>
+        /// Builds the agentName field for an approveAgent action, which is where an API wallet's expiration is
+        /// carried: "A custom expiration can be set by appending valid_until {timestamp} after the name."
+        ///
+        /// The expiration is part of the name rather than a field of its own, so it has to be composed before the
+        /// action is signed - the name is in the EIP-712 type list, and appending to it afterwards would sign one
+        /// string and send another.
+        ///
+        /// Shared by the REST and socket clients so the two cannot drift: the same account sees agents approved
+        /// through either, and an expiry that only one of them applied would look like the exchange behaving
+        /// inconsistently.
+        /// </summary>
+        /// <param name="agentName">The name, or null for the unnamed API wallet.</param>
+        /// <param name="validUntil">
+        /// When the wallet stops working, at most 180 days ahead. Null leaves the expiration out entirely, which
+        /// gives whatever default HyperLiquid applies rather than no expiry at all.
+        /// </param>
+        internal static string BuildAgentName(string? agentName, DateTime? validUntil)
+        {
+            if (validUntil == null)
+                return agentName ?? string.Empty;
+
+            if (string.IsNullOrWhiteSpace(agentName))
+            {
+                //an expiration is documented as going AFTER the name, and there is no documented way to give one
+                //for the unnamed wallet. Sending "valid_until 123" on its own would more likely be read as the
+                //name than as an expiry, which is a silent wrong result rather than a rejected request.
+                throw new ArgumentException(
+                    "An expiration can only be set on a named API wallet, because HyperLiquid carries it as a suffix on the name.",
+                    nameof(agentName));
+            }
+
+            var timestamp = DateTimeConverter.ConvertToMilliseconds(validUntil.Value)!.Value;
+
+            return agentName + " valid_until " + timestamp.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+
         internal static async Task<ICallResult> CheckBuilderFeeAsync(HyperLiquidSocketClient client)
         {
             if (!client.SpotApi.Authenticated)


### PR DESCRIPTION
Adds the ability to approve and remove Hyperliquid API wallets (agent wallets), on both the REST and socket account clients.

Three commits, separable:

---

**1. Add approveAgent to the account API**

`ApproveAgentAsync` on both account clients, matching the shape of the other user-signed actions.

This also corrects the EIP-712 type of `agentAddress`. `GetMessageFields` infers the field type from the CLR value and special-cased only `builder` and `user` as `address`. Hyperliquid types `agentAddress` as `address` too, while typing `destination` on a withdraw as `string`, despite both carrying an 0x address. The type name is part of the struct hash, so the inferred `string` type produces a valid signature over the wrong hash and the exchange rejects the action without indicating why. The special cases are now a named set so the inconsistency is visible rather than implied by a boolean.

The field types were taken from the official Python SDK's `sign_agent` rather than the API docs, which do not give the EIP-712 schema for this action.

`agentName` is sent as an empty string rather than omitted when no name is given, because the field is part of the signed type list either way.

No change was needed to the signing path itself: `GenerateSignature` already treats any action carrying `signatureChainId` as a user action and derives `"HyperliquidTransaction:" + PascalCase(type)`.

---

**2. Add RemoveAgentAsync to the account API**

Removing an API wallet is an `approveAgent` naming it with the zero address. Hyperliquid publishes no removal action - `approveAgent` is the only agent action in the API - and this is what the Hyperliquid web interface sends when Remove is pressed, taken from the request it makes rather than inferred.

Kept as its own method because it is not discoverable: nobody reading `ApproveAgentAsync` would guess that pointing it at the zero address removes an agent.

It is separate from the first commit deliberately, as it rests on undocumented behaviour and could be taken or left on its own. If Hyperliquid ever validates `agentAddress`, `RemoveAgentAsync` breaks while `ApproveAgentAsync` keeps working. The remarks say where it came from and suggest reading the agents back with `GetExtraAgentsAsync` rather than trusting the reply.

---

**3. Add an optional expiration to ApproveAgentAsync**

Hyperliquid lets an API wallet be given an expiration, at most 180 days ahead, and applies a default of its own when none is given - observed at 90 days. With the first two commits alone a caller has no way to ask for a particular lifetime.

It is exposed as a `validUntil` parameter rather than left to the caller, because the expiration is documented as `valid_until {timestamp}` appended to the NAME, which is not something anyone would expect from a parameter called `agentName`. The composition has to happen before signing, since the name is part of the EIP-712 type list.

Shared between the REST and socket clients through `HyperLiquidUtils.BuildAgentName` so the two cannot drift - the same account sees agents approved through either, and an expiry only one of them applied would look like the exchange behaving inconsistently.

An expiration requires a name. There is no documented way to give one for the unnamed API wallet, and sending `valid_until {timestamp}` alone would more likely be read as the name than the expiry - a silent wrong result rather than a rejected request. `RemoveAgentAsync` passes none, because the name has to match the agent being removed.

---

**Testing**

Both were exercised against mainnet: an agent was approved, confirmed on the Hyperliquid web interface and via `GetExtraAgentsAsync`, then removed and confirmed gone. The approval signature was produced by an external key custodian through `AsyncTypedDataSignRequestDelegate`, which also exercises that path.

The expiration was exercised the same way: an API wallet approved with a `validUntil` 180 days ahead reported that expiry back, and `GetExtraAgentsAsync` returned the name WITHOUT the suffix - so the exchange consumes it, and the documented name length limit applies to the name alone rather than to the composed string. A second approval then removed the first agent by that bare name.

The existing 33 unit tests pass. No test was added: the test project covers query endpoints against JSON fixtures and no write action currently has one, so a bespoke test here would not match the conventions of the suite.

